### PR TITLE
fix the name of the component in the left sidebar

### DIFF
--- a/frontend/src/components/ClosestInteractionPartners.vue
+++ b/frontend/src/components/ClosestInteractionPartners.vue
@@ -327,7 +327,8 @@ export default {
 
           [this.rawElms, this.rawRels] = transform(component, component.id, reactions);
           this.selectedElm = this.rawElms[component.id];
-          // this.rawElms = this.loadHPAData(this.rawElms);
+          this.selectedElm.name = this.componentName;
+
           this.expandedIds = [];
           this.expandedIds.push(component.id);
 


### PR DESCRIPTION
the name was not visible if the user do not select a node