### PR TITLE
fix: missing 'Generate' graph button

### DIFF
--- a/frontend/src/components/explorer/InteractionPartners.vue
+++ b/frontend/src/components/explorer/InteractionPartners.vue
@@ -598,6 +598,7 @@ export default {
           this.nodeCount = Object.keys(this.rawElms).length;
           if (this.nodeCount > this.warnNodeCount) {
             this.showNetworkGraph = false;
+            this.largeNetworkGraph = true;
             this.errorMessage = '';
             return;
           }


### PR DESCRIPTION
When using the 'load expand' feature, if the new graph had a number of node > node warning, the warning box is supposed to be visible instead of the graph, allowing the user to manually run the generation of the graph and make it visible. This box was not visible, leaving only the side bar (with the reactions table) on the page and forcing the user to reload page to get the graph again.