### PR TITLE
feat: flag for force overwriting existing data file at build-stack

### DIFF
--- a/proj.sh
+++ b/proj.sh
@@ -14,7 +14,7 @@ function generate-data {
 }
 
 function build-stack {
-  generate-data $@
+  generate-data
   docker-compose -f docker-compose.yml -f docker-compose-local.yml build $@
 }
 

--- a/proj.sh
+++ b/proj.sh
@@ -5,20 +5,12 @@ function generate-data {
   # enable flag "-q" to force overwritting existing data files
   echo 'Data generation started.'
   source .env && yarn --cwd $DATA_GENERATOR_PATH start $DATA_FILES_PATH "$@"
-  if [ "$(unalias cp 2> /dev/null)" != "" ];then 
-      unalias cp
-  fi
-
-  extra_opt=
-  if [ $1 ==  "-q" ]; then
-      extra_opt="--force"
-  fi
-  cp -r $extra_opt $DATA_GENERATOR_PATH/data/ neo4j/import
-  cp    $extra_opt $DATA_GENERATOR_PATH/data/hpaRna.json api/src/data/
-  cp -r $extra_opt $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
-  cp -r $extra_opt $DATA_FILES_PATH/gemsRepository.json api/src/data/
-  cp -r $extra_opt $DATA_FILES_PATH/svg api/
-  cp -r $extra_opt $DATA_FILES_PATH/ftp-models ftp/
+  /bin/cp -r $DATA_GENERATOR_PATH/data/ neo4j/import
+  /bin/cp    $DATA_GENERATOR_PATH/data/hpaRna.json api/src/data/
+  /bin/cp -r $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
+  /bin/cp -r $DATA_FILES_PATH/gemsRepository.json api/src/data/
+  /bin/cp -r $DATA_FILES_PATH/svg api/
+  /bin/cp -r $DATA_FILES_PATH/ftp-models ftp/
 }
 
 function build-stack {
@@ -57,7 +49,7 @@ function import-db {
 }
 
 echo -e "Available commands:
-\tbuild-stack [-q]
+\tbuild-stack
 \tstart-stack
 \tstop-stack
 \tclean-stack

--- a/proj.sh
+++ b/proj.sh
@@ -2,18 +2,27 @@
 export PATH=$PATH:/usr/local/bin
 
 function generate-data {
+  # enable flag "-q" to force overwritting existing data files
   echo 'Data generation started.'
   source .env && yarn --cwd $DATA_GENERATOR_PATH start $DATA_FILES_PATH "$@"
-  cp -r $DATA_GENERATOR_PATH/data/ neo4j/import
-  cp    $DATA_GENERATOR_PATH/data/hpaRna.json api/src/data/
-  cp -r $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
-  cp -r $DATA_FILES_PATH/gemsRepository.json api/src/data/
-  cp -r $DATA_FILES_PATH/svg api/
-  cp -r $DATA_FILES_PATH/ftp-models ftp/
+  if [ "$(unalias cp 2> /dev/null)" != "" ];then 
+      unalias cp
+  fi
+
+  extra_opt=
+  if [ $1 ==  "-q" ]; then
+      extra_opt="--force"
+  fi
+  cp -r $extra_opt $DATA_GENERATOR_PATH/data/ neo4j/import
+  cp    $extra_opt $DATA_GENERATOR_PATH/data/hpaRna.json api/src/data/
+  cp -r $extra_opt $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
+  cp -r $extra_opt $DATA_FILES_PATH/gemsRepository.json api/src/data/
+  cp -r $extra_opt $DATA_FILES_PATH/svg api/
+  cp -r $extra_opt $DATA_FILES_PATH/ftp-models ftp/
 }
 
 function build-stack {
-  generate-data
+  generate-data $@
   docker-compose -f docker-compose.yml -f docker-compose-local.yml build $@
 }
 
@@ -48,7 +57,7 @@ function import-db {
 }
 
 echo -e "Available commands:
-\tbuild-stack
+\tbuild-stack [-q]
 \tstart-stack
 \tstop-stack
 \tclean-stack


### PR DESCRIPTION
It is a bit annoying to run `build-stack` and type yes-or-no for file overwriting hundred times when there are existing data files in the directory. I added a flag "-q" for `build-stack` function so that when this flag is enabled, existing data files will be overwritten by default. 