### PR TITLE
feat: configure Swagger API MA-865

### DIFF
--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -169,3 +169,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /metabolites/{id}/related-metabolites:
+    get:
+      tags:
+      - "metabolite"
+      summary: "List all related metabolites for involving a given metabolite (for example m01587m or citrate[m])."
+      description: "List all related metabolites involving a given metabolite (for example m01587m or citrate[m])."
+      operationId: "metaboliteInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -24,8 +24,12 @@ paths:
     get:
       tags:
       - "Integrated models"
-      summary: "List all Genome-scale metabolic models (GEMs) that are available on the GEM browser."
-      description: "List all Genome-scale metabolic models (GEMs) that are available on the GEM browser."
+      summary: "List all integrated GEMs."
+      description: "Retrieve a list of all GEMs (Genome-Scale
+        Metabolic Models) that Metabolic Atlas integrates. These GEMs are
+        available through tools like GEM Browser, Map Viewer and Interaction
+        Partners. The list is returned in JSON format. No parameters are
+        required."
       operationId: "integratedModels"
       produces:
       - "application/json"
@@ -36,8 +40,11 @@ paths:
     get:
       tags:
       - "Integrated models"
-      summary: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM'."
-      description: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM'."
+      summary: "List a specified GEM"
+      description: "Retrieve information for a specific GEM (Genome-Scale
+        Metabolic Model). The GEMs are available through tools like GEM Browser,
+        Map Viewer and Interaction Partners. The list is returned in JSON format.
+        Required parameter: GEM name, e.g. **Human-GEM**."
       operationId: "modelInfo"
       produces:
       - "application/json"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -245,3 +245,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /subsystems/{id}/related-reactions:
+    get:
+      tags:
+      - "subsystem"
+      summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
+      description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
+      operationId: "subsystemInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -17,6 +17,7 @@ tags:
 - name: "metabolite"
 - name: "reaction"
 - name: "subsystem"
+- name: "interaction-partner"
 - name: "miscellaneous"
 paths:
   /repository/integrated_models:
@@ -253,6 +254,25 @@ paths:
       summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
       description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
       operationId: "subsystemInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"
+  /interaction-partners/{id}/:
+    get:
+      tags:
+      - "interaction-partner"
+      summary: "List all first order interaction partners for a given gene (e.g. ENSG00000196502 or SULT1A1)."
+      description: "List all first order interaction partners for a given gene (e.g. ENSG00000196502 or SULT1A1)."
+      operationId: "geneInfo"
       produces:
       - "application/json"
       parameters:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -207,3 +207,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /reactions/{id}/related-reactions:
+    get:
+      tags:
+      - "reaction"
+      summary: "List all related reactions involving a given reaction (for example HMR_3905)."
+      description: "List all related reactions involving a given reaction (for example HMR_3905)."
+      operationId: "reactionInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -106,7 +106,7 @@ paths:
       - "Genes"
       summary: "Get information of a given gene."
       description: "Retrieve all information for a given gene. The result is
-        returned in JSON format. Required parameter: Gene ID, e.g.
+        returned in JSON format. Required parameter: gene ID, e.g.
         **ENSG00000196502** or **Sult1a1**"
       operationId: "geneInfo"
       produces:
@@ -127,7 +127,7 @@ paths:
       - "Genes"
       summary: "Get related reations for a given gene."
       description: "Retrieve all related reactions for a given gene. The result is
-        returned in JSON format. Required parameter: Gene ID, e.g.
+        returned in JSON format. Required parameter: gene ID, e.g.
         **ENSG00000196502** or **Sult1a1**"
       operationId: "geneReaction"
       produces:
@@ -146,8 +146,10 @@ paths:
     get:
       tags:
       - "Metabolites"
-      summary: "List all information for a given metabolite (for example m01587m or citrate[m])."
-      description: "List all information for a given metabolite (for example m01587m or citrate[m])."
+      summary: "Get information of a given metabolite."
+      description: "Retrieve all information related to a given metabolite. The
+        result is returned in JSON format. Required parameter: metabolite ID,
+        e.g. **m01587m**"
       operationId: "metaboliteInfo"
       produces:
       - "application/json"
@@ -165,9 +167,9 @@ paths:
     get:
       tags:
       - "Metabolites"
-      summary: "List all reactions for a given metabolite (for example m01587m or citrate[m])."
-      description: "List all reactions for a given metabolite (for example m01587m or citrate[m])."
-      operationId: "metaboliteInfo"
+      summary: "Get related reactions for a given metabolite."
+      description: "Retrieve all related reactions for a given metabolite. The returned result is in JSON format. Required parameter: metabolite ID, e.g. **m01587m**"
+      operationId: "metaboliteReaction"
       produces:
       - "application/json"
       parameters:
@@ -184,9 +186,9 @@ paths:
     get:
       tags:
       - "Metabolites"
-      summary: "List all related metabolites for involving a given metabolite (for example m01587m or citrate[m])."
-      description: "List all related metabolites involving a given metabolite (for example m01587m or citrate[m])."
-      operationId: "metaboliteInfo"
+      summary: "Get related metabolites for a given metabolite."
+      description: "Retrieve all related metabolites involving a given metabolite. The returned results is in JSON format. Required parameter: metabolite ID, e.g. **m01587m**"
+      operationId: "metaboliteRelatedMetabolite"
       produces:
       - "application/json"
       parameters:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -131,3 +131,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /metabolites/{id}:
+    get:
+      tags:
+      - "metabolite"
+      summary: "List all information for a given metabolite (for example m01587m or citrate[m])."
+      description: "List all information for a given metabolite (for example m01587m or citrate[m])."
+      operationId: "metaboliteInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -11,7 +11,7 @@ info:
     url: "https://www.gnu.org/licenses/gpl-3.0.html"
 basePath: "/api/v2"
 tags:
-- name: "model"
+- name: "Integrated models"
 - name: "compartment"
 - name: "gene"
 - name: "metabolite"
@@ -23,7 +23,7 @@ paths:
   /repository/integrated_models:
     get:
       tags:
-      - "model"
+      - "Integrated models"
       summary: "List all Genome-scale metabolic models (GEMs) that are available on the GEM browser."
       description: "List all Genome-scale metabolic models (GEMs) that are available on the GEM browser."
       operationId: "integratedModels"
@@ -35,7 +35,7 @@ paths:
   /repository/integrated_models/{name}:
     get:
       tags:
-      - "model"
+      - "Integrated models"
       summary: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM'."
       description: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM'."
       operationId: "modelInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -14,7 +14,7 @@ tags:
 - name: "Integrated models"
 - name: "Compartments"
 - name: "Genes"
-- name: "metabolite"
+- name: "Metabolites"
 - name: "reaction"
 - name: "subsystem"
 - name: "interaction-partner"
@@ -136,7 +136,7 @@ paths:
   /metabolites/{id}:
     get:
       tags:
-      - "metabolite"
+      - "Metabolites"
       summary: "List all information for a given metabolite (for example m01587m or citrate[m])."
       description: "List all information for a given metabolite (for example m01587m or citrate[m])."
       operationId: "metaboliteInfo"
@@ -155,7 +155,7 @@ paths:
   /metabolites/{id}/related-reactions:
     get:
       tags:
-      - "metabolite"
+      - "Metabolites"
       summary: "List all reactions for a given metabolite (for example m01587m or citrate[m])."
       description: "List all reactions for a given metabolite (for example m01587m or citrate[m])."
       operationId: "metaboliteInfo"
@@ -174,7 +174,7 @@ paths:
   /metabolites/{id}/related-metabolites:
     get:
       tags:
-      - "metabolite"
+      - "Metabolites"
       summary: "List all related metabolites for involving a given metabolite (for example m01587m or citrate[m])."
       description: "List all related metabolites involving a given metabolite (for example m01587m or citrate[m])."
       operationId: "metaboliteInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -287,7 +287,7 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /subsystems/{id}:
+  /subsystems/{id}?model={model}:
     get:
       tags:
       - "Subsystems"
@@ -295,8 +295,8 @@ paths:
       description: "Retrieve all information (including metabolites,
         compartments and genes) for a given subsystem. The returned result is in
         JSON format. <br /><br />
-        Required parameters: subsystem ID, e.g.
-        **eicosanoid_metabolism** "
+        Required parameters: subsystem ID (e.g.  **eicosanoid_metabolism**) and
+        model name (e.g. **HumanGem**)"
       operationId: "subsystemInfo"
       produces:
       - "application/json"
@@ -305,25 +305,33 @@ paths:
         in: "path"
         required: true
         type: "string"
+      - name: "model"
+        in: "path"
+        required: true
+        type: "string"
       responses:
         "200":
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /subsystems/{id}/related-reactions:
+  /subsystems/{id}/related-reactions?model={model}:
     get:
       tags:
       - "Subsystems"
       summary: "Get related reactions for a given subsystem."
       description: "Retrieve all related reactions for a given subsystem. The
         returned result is in JSON format. <br /><br />
-        Required parameters: subsystem ID, e.g.
-        **eicosanoid_metabolism** "
+        Required parameters: subsystem ID (e.g.  **eicosanoid_metabolism**) and
+        model name (e.g. **HumanGem**)"
       operationId: "subsystemRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -110,14 +110,15 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /genes/{id}:
+  /genes/{id}?model={model}:
     get:
       tags:
       - "Genes"
       summary: "Get information for a given gene."
       description: "Retrieve all information for a given gene. The result is
         returned in JSON format. <br /><br />
-        Required parameters: gene ID, e.g.  **ENSG00000196502** or **Sult1a1**"
+        Required parameters: gene ID (e.g.  **ENSG00000196502**)
+        and model name (e.g. **HumanGem**)"
       operationId: "geneInfo"
       produces:
       - "application/json"
@@ -126,24 +127,33 @@ paths:
         in: "path"
         required: true
         type: "string"
+      - name: "model"
+        in: "path"
+        required: true
+        type: "string"
       responses:
         "200":
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /genes/{id}/related-reactions:
+  /genes/{id}/related-reactions?model={model}:
     get:
       tags:
       - "Genes"
       summary: "Get related reations for a given gene."
       description: "Retrieve all related reactions for a given gene. The result is
         returned in JSON format. <br /><br />
-        Required parameters: gene ID, e.g.  **ENSG00000196502** or **Sult1a1**"
+        Required parameters: gene ID (e.g.  **ENSG00000196502**)
+        and model name (e.g. **HumanGem**)"
       operationId: "geneRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -84,20 +84,24 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /compartments/{id}/related-reactions:
+  /compartments/{id}/related-reactions?model={model}:
     get:
       tags:
       - "Compartments"
       summary: "Get related reactions for a given compartment."
       description: "Retrieve all related reactions for a given compartment. The
         result is returned in JSON format. <br /><br />
-        Required parameters: compartment ID,
-        e.g. **golgi_apparatus** "
+        Required parameters: compartment ID (e.g. **golgi_apparatus**) and
+        model name (e.g. **HumanGem**) "
       operationId: "compartmentRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -340,20 +340,23 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /interaction-partners/{id}/:
+  /interaction-partners/{id}?model={model}:
     get:
       tags:
       - "Interaction Partners"
       summary: "Get interaction partners for a given gene."
       description: "Retrieve all first order interaction partners for a given
         gene. The returned result is in JSON format. <br /><br />
-        Required parameters: gene ID,
-        e.g.  **ENSG00000196502** or **Sult1a1**"
+        Required parameters: gene ID (e.g.  **ENSG00000196502**) and model name (e.g. **HumanGem**)"
       operationId: "geneInteractionPartners"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -40,11 +40,11 @@ paths:
     get:
       tags:
       - "Integrated models"
-      summary: "List a specified GEM"
-      description: "Retrieve information for a specific GEM (Genome-Scale
+      summary: "Get information for a given GEM."
+      description: "Retrieve information for a given GEM (Genome-Scale
         Metabolic Model). The GEMs are available through tools like GEM Browser,
-        Map Viewer and Interaction Partners. The list is returned in JSON format.
-        Required parameter: GEM name, e.g. **Human-GEM**."
+        Map Viewer and Interaction Partners. The result is returned in JSON format.
+        Required parameter: GEM name, e.g. **Human-GEM** "
       operationId: "modelInfo"
       produces:
       - "application/json"
@@ -62,12 +62,10 @@ paths:
     get:
       tags:
       - "Compartments"
-      summary: "For a given compartment name (e.g., Golgi apparatus or
-        golgi_apparatus), returns all containing metabolites, genes, reactions
-        and subsystems."
-      description: "For a given compartment name (e.g., Golgi apparatus or
-        golgi_apparatus), returns all containing metabolites, genes, reactions
-        and subsystems."
+      summary: "Get information for a given compartment."
+      description: "Retrieve all containing metabolites, genes, reactions
+        and subsystems for a given compartment. The result is returned in JSON format.
+        Required parameter: compartment ID, e.g. **golgi_apparatus** "
       operationId: "compartmentInfo"
       produces:
       - "application/json"
@@ -85,11 +83,11 @@ paths:
     get:
       tags:
       - "Compartments"
-      summary: "For a given compartment name (e.g., Golgi apparatus or
-        golgi_apparatus), return all reactions involving this compartment."
-      description: "For a given compartment name (e.g., Golgi apparatus or
-        golgi_apparatus), return all reactions involving this compartment."
-      operationId: "compartmentInfo"
+      summary: "Get related reactions for a given compartment."
+      description: "Retrieve all related reactions for a given compartment. The
+        result is returned in JSON format. Required parameter: compartment ID,
+        e.g. **golgi_apparatus** "
+      operationId: "compartmentReaction"
       produces:
       - "application/json"
       parameters:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -112,3 +112,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /genes/{id}/related-reactions:
+    get:
+      tags:
+      - "gene"
+      summary: "List all reactions for a given gene (for example ENSG00000196502 or SULT1A1)."
+      description: "List all reactions for a given gene (for example ENSG00000196502 or SULT1A1)."
+      operationId: "geneInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -188,3 +188,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /reactions/{id}:
+    get:
+      tags:
+      - "reaction"
+      summary: "List all the information we have on a reaction (for example HMR_3905)."
+      description: "List all the information we have on a reaction (for example HMR_3905)."
+      operationId: "reactionInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -226,3 +226,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /subsystems/{id}:
+    get:
+      tags:
+      - "subsystem"
+      summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing metabolites and genes/genes."
+      description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing metabolites and genes/genes."
+      operationId: "subsystemInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -72,4 +72,25 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /compartments/{id}/related-reactions:
+    get:
+      tags:
+      - "compartment"
+      summary: "For a given compartment name (e.g., Golgi apparatus or
+        golgi_apparatus), return all reactions involving this compartment"
+      description: "For a given compartment name (e.g., Golgi apparatus or
+        golgi_apparatus), return all reactions involving this compartment"
+      operationId: "compartmentInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"
 

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -49,3 +49,27 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /compartments/{id}:
+    get:
+      tags:
+      - "compartment"
+      summary: "For a given compartment name (e.g., Golgi apparatus or
+        golgi_apparatus), returns all containing metabolites, genes, reactions
+        and subsystems.  "
+      description: "For a given compartment name (e.g., Golgi apparatus or
+        golgi_apparatus), returns all containing metabolites, genes, reactions
+        and subsystems.  "
+      operationId: "compartmentInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"
+

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -150,3 +150,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /metabolites/{id}/related-reactions:
+    get:
+      tags:
+      - "metabolite"
+      summary: "List all reactions for a given metabolite (for example m01587m or citrate[m])."
+      description: "List all reactions for a given metabolite (for example m01587m or citrate[m])."
+      operationId: "metaboliteInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -17,6 +17,7 @@ tags:
 - name: "metabolite"
 - name: "reaction"
 - name: "subsystem"
+- name: "miscellaneous"
 paths:
   /repository/integrated_models:
     get:
@@ -259,6 +260,20 @@ paths:
         in: "path"
         required: true
         type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"
+  /random-components:
+    get:
+      tags:
+      - "miscellaneous"
+      summary: "List all information for random genes, metabolites compartments, reactions and subsystems."
+      description: "List all information for random genes, metabolites compartments, reactions and subsystems."
+      operationId: "randomComponentInfo"
+      produces:
+      - "application/json"
       responses:
         "200":
           description: "Successful operation"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -285,6 +285,20 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
+  /maps/listing:
+    get:
+      tags:
+      - "miscellaneous"
+      summary: "List all compartments and subsystems."
+      description: "List all compartments and subsystems."
+      operationId: "mapListingInfo"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"
   /random-components:
     get:
       tags:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -13,7 +13,7 @@ basePath: "/api/v2"
 tags:
 - name: "Integrated models"
 - name: "Compartments"
-- name: "gene"
+- name: "Genes"
 - name: "metabolite"
 - name: "reaction"
 - name: "subsystem"
@@ -98,7 +98,7 @@ paths:
   /genes/{id}:
     get:
       tags:
-      - "gene"
+      - "Genes"
       summary: "List all information for a given gene (for example ENSG00000196502 or SULT1A1)."
       description: "List all information for a given gene (for example ENSG00000196502 or SULT1A1)."
       operationId: "geneInfo"
@@ -117,7 +117,7 @@ paths:
   /genes/{id}/related-reactions:
     get:
       tags:
-      - "gene"
+      - "Genes"
       summary: "List all reactions for a given gene (for example ENSG00000196502 or SULT1A1)."
       description: "List all reactions for a given gene (for example ENSG00000196502 or SULT1A1)."
       operationId: "geneInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -18,7 +18,7 @@ tags:
 - name: "Reactions"
 - name: "Subsystems"
 - name: "Interaction Partners"
-- name: "miscellaneous"
+- name: "Miscellaneous"
 paths:
   /repository/integrated_models:
     get:
@@ -288,7 +288,7 @@ paths:
   /maps/listing:
     get:
       tags:
-      - "miscellaneous"
+      - "Miscellaneous"
       summary: "List all compartments and subsystems."
       description: "List all compartments and subsystems."
       operationId: "mapListingInfo"
@@ -302,7 +302,7 @@ paths:
   /random-components:
     get:
       tags:
-      - "miscellaneous"
+      - "Miscellaneous"
       summary: "List all information for random genes, metabolites compartments, reactions and subsystems."
       description: "List all information for random genes, metabolites compartments, reactions and subsystems."
       operationId: "randomComponentInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -1,6 +1,6 @@
 swagger: "2.0"
 info:
-  description: "Metabolite Atlas can be accessed programmatically using this web API. Here we provide endpoints to get global information on the list of models integrated in Metabolic Atlas and to retrieve bulk or details information on those models. The API is still under developpment and might change without notice.\n\nUse model.short_name attribute (e.g. \"Yeast-GEM\", \"Human-GEM\") or model.database attribute as model parameter."
+  description: "Metabolic Atlas can be accessed programmatically using this web API. Here we provide endpoints to get global information on the list of models integrated in Metabolic Atlas and to retrieve bulk or details information on those models. The API is still under developpment and might change without notice.\n\nThe results are returned in JSON format."
   version: "2.0"
   title: "Metabolic Atlas API"
   termsOfService: "https://metabolicatlas.org/about"
@@ -25,26 +25,24 @@ paths:
       tags:
       - "Integrated models"
       summary: "List all integrated GEMs."
-      description: "Retrieve a list of all GEMs (Genome-Scale
-        Metabolic Models) that Metabolic Atlas integrates. These GEMs are
+      description: "This query retrieves a list of all GEMs (genome-scale
+        metabolic models) that Metabolic Atlas integrates. These GEMs are
         available through tools like GEM Browser, Map Viewer and Interaction
-        Partners. The list is returned in JSON format. <br /><br />
-        Required parameters: None"
+        Partners. No parameters are required for this query."
       operationId: "integratedModelListing"
       produces:
       - "application/json"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
   /repository/integrated_models/{name}:
     get:
       tags:
       - "Integrated models"
       summary: "Get information for a given GEM."
-      description: "Retrieve information for a given GEM (Genome-Scale
-        Metabolic Model). The GEMs are available through tools like GEM Browser,
-        Map Viewer and Interaction Partners. The result is returned in JSON format.<br /><br />
-        Required parameters: GEM name (e.g. **Human-GEM**) "
+      description: "This query retrieve information for a given GEM (genome-scale
+        metabolic model). The GEMs are available through tools like GEM Browser,
+        Map Viewer and Interaction Partners."
       operationId: "integratedModelInfo"
       produces:
       - "application/json"
@@ -53,9 +51,10 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the original GEM name, e.g. **Human-GEM**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /compartments/{id}?model={model}:
@@ -63,10 +62,8 @@ paths:
       tags:
       - "Compartments"
       summary: "Get information for a given compartment."
-      description: "Retrieve all containing metabolites, genes, reactions
-        and subsystems for a given compartment. The result is returned in JSON format. <br /><br />
-        Required parameters: compartment ID (e.g. **golgi_apparatus**) and
-        model name (e.g. **HumanGem**) "
+      description: "This query retrieves all the metabolites, genes, reactions
+        and subsystems contained by the given compartment."
       operationId: "compartmentInfo"
       produces:
       - "application/json"
@@ -75,13 +72,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the compartment identifier, e.g. **golgi_apparatus**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /compartments/{id}/related-reactions?model={model}:
@@ -89,10 +88,7 @@ paths:
       tags:
       - "Compartments"
       summary: "Get related reactions for a given compartment."
-      description: "Retrieve all related reactions for a given compartment. The
-        result is returned in JSON format. <br /><br />
-        Required parameters: compartment ID (e.g. **golgi_apparatus**) and
-        model name (e.g. **HumanGem**) "
+      description: "This query retrieves all the related reactions for a given compartment. There reactions are associated to compartments via the compartmentalized metabolites."
       operationId: "compartmentRelatedReactionInfo"
       produces:
       - "application/json"
@@ -101,24 +97,23 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the compartment ID, e.g. **golgi_apparatus**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /genes/{id}?model={model}:
     get:
       tags:
       - "Genes"
-      summary: "Get information for a given gene."
-      description: "Retrieve all information for a given gene. The result is
-        returned in JSON format. <br /><br />
-        Required parameters: gene ID (e.g.  **ENSG00000196502**)
-        and model name (e.g. **HumanGem**)"
+      summary: "Get information on a specific gene."
+      description: "This query retrieves all the information for a given gene."
       operationId: "geneInfo"
       produces:
       - "application/json"
@@ -127,13 +122,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the gene ID, e.g. **ENSG00000196502**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /genes/{id}/related-reactions?model={model}:
@@ -141,10 +138,7 @@ paths:
       tags:
       - "Genes"
       summary: "Get related reations for a given gene."
-      description: "Retrieve all related reactions for a given gene. The result is
-        returned in JSON format. <br /><br />
-        Required parameters: gene ID (e.g.  **ENSG00000196502**)
-        and model name (e.g. **HumanGem**)"
+      description: "This query retrieve all the reactions related to the specified gene."
       operationId: "geneRelatedReactionInfo"
       produces:
       - "application/json"
@@ -153,13 +147,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the gene ID, e.g. **ENSG00000196502**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /metabolites/{id}?model={model}:
@@ -167,9 +163,7 @@ paths:
       tags:
       - "Metabolites"
       summary: "Get information for a given metabolite."
-      description: "Retrieve all information related to a given metabolite. The
-        result is returned in JSON format. <br /><br />
-        Required parameters: metabolite ID (e.g. **m01587m**) and model name (e.g. **HumanGem**)"
+      description: "This query retrieves all the information about the specified metabolite."
       operationId: "metaboliteInfo"
       produces:
       - "application/json"
@@ -178,13 +172,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the metabolite ID, e.g. **m01587m**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /metabolites/{id}/related-reactions?model={model}:
@@ -192,9 +188,7 @@ paths:
       tags:
       - "Metabolites"
       summary: "Get related reactions for a given metabolite."
-      description: "Retrieve all related reactions for a given metabolite. The
-        returned result is in JSON format.  <br /><br />
-        Required parameters: metabolite ID (e.g. **m01587m**) and model name (e.g. **HumanGem**)"
+      description: "This query retrives all the related reactions that involve the specified metabolite."
       operationId: "metaboliteRelatedReactionInfo"
       produces:
       - "application/json"
@@ -203,13 +197,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the metabolite ID, e.g. **m01587m**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /metabolites/{id}/related-metabolites?model={model}:
@@ -217,9 +213,9 @@ paths:
       tags:
       - "Metabolites"
       summary: "Get related metabolites for a given metabolite."
-      description: "Retrieve all related metabolites involving a given
-        metabolite. The returned result is in JSON format.  <br /><br />
-        Required parameters: metabolite ID (e.g. **m01587m**) and model name (e.g. **HumanGem**)"
+      description: "This query retrieves all related metabolites involving a given
+        metabolite. Metabolites are compartmentalized, which means that the
+        related metabolites are equivalent metabolites in other compartments."
       operationId: "metaboliteRelatedMetaboliteInfo"
       produces:
       - "application/json"
@@ -228,13 +224,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the metabolite ID, e.g. **m01587m**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /reactions/{id}?model={model}:
@@ -242,9 +240,7 @@ paths:
       tags:
       - "Reactions"
       summary: "Get information for a given reaction."
-      description: "Retrieve all information we have on a reaction. The
-        returned result is in JSON format. <br /><br />
-        Required parameters: reaction ID (e.g.  **HMR_3000**) and model name (e.g. **HumanGem**)"
+      description: "This query retrieves all the information we have on a reaction."
       operationId: "reactionInfo"
       produces:
       - "application/json"
@@ -253,13 +249,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the reaction ID, e.g. **HMR_3000**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /reactions/{id}/related-reactions?model={model}:
@@ -267,9 +265,9 @@ paths:
       tags:
       - "Reactions"
       summary: "Get related reactions involving a given reaction."
-      description: "Retrieve all related reactions involving a given reaction.
-        The returned result is in JSON format. <br /><br />
-        Required parameters: reaction ID (e.g.  **HMR_3000**) and model name (e.g. **HumanGem**)"
+      description: "This query retrieves all related reactions involving a given reaction.
+        A limit of 200 related reactions is applied. These related reactions are
+        computed based on the sharing of related (equivalent) metabolites."
       operationId: "reactionRelatedReactionInfo"
       produces:
       - "application/json"
@@ -278,13 +276,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the reaction ID, e.g. **HMR_3000**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /subsystems/{id}?model={model}:
@@ -292,11 +292,8 @@ paths:
       tags:
       - "Subsystems"
       summary: "Get information for a given subsystem."
-      description: "Retrieve all information (including metabolites,
-        compartments and genes) for a given subsystem. The returned result is in
-        JSON format. <br /><br />
-        Required parameters: subsystem ID (e.g.  **eicosanoid_metabolism**) and
-        model name (e.g. **HumanGem**)"
+      description: "This query retrieves all the information for a given subsystem, which
+        includes names and identifiers for metabolites, genes, and compartments."
       operationId: "subsystemInfo"
       produces:
       - "application/json"
@@ -305,13 +302,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the subsystem ID, e.g. **eicosanoid_metabolism**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /subsystems/{id}/related-reactions?model={model}:
@@ -319,10 +318,8 @@ paths:
       tags:
       - "Subsystems"
       summary: "Get related reactions for a given subsystem."
-      description: "Retrieve all related reactions for a given subsystem. The
-        returned result is in JSON format. <br /><br />
-        Required parameters: subsystem ID (e.g.  **eicosanoid_metabolism**) and
-        model name (e.g. **HumanGem**)"
+      description: "This query retrieves all the reactions for the specified subsystem.
+        The query limits the results to 200 reactions."
       operationId: "subsystemRelatedReactionInfo"
       produces:
       - "application/json"
@@ -331,13 +328,15 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the subsystem ID, e.g. **eicosanoid_metabolism**"
       - name: "model"
-        in: "path"
+        in: "query"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
   /interaction-partners/{id}?model={model}:
@@ -345,9 +344,8 @@ paths:
       tags:
       - "Interaction Partners"
       summary: "Get interaction partners for a given gene."
-      description: "Retrieve all first order interaction partners for a given
-        gene. The returned result is in JSON format. <br /><br />
-        Required parameters: gene ID (e.g.  **ENSG00000196502**) and model name (e.g. **HumanGem**)"
+      description: "This query retrieves all first the order interaction partners for
+        a given gene or metabolite."
       operationId: "geneInteractionPartners"
       produces:
       - "application/json"
@@ -356,45 +354,57 @@ paths:
         in: "path"
         required: true
         type: "string"
+        description: "the gene ID, e.g. **ENSG00000196502** or the metabolite ID, e.g. **slfcys_c**"
       - name: "model"
         in: "path"
         required: true
         type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
-  /maps/listing:
+  /maps/listing?model={model}:
     get:
       tags:
       - "Miscellaneous"
-      summary: "List all compartments and subsystems."
-      description: "Retrieve a list of all compartments and subsystems that are
-        available on Metabolic Atlas. The returned result is in JSON format. <br /><br />
-        Required parameters: None"
+      summary: "List all compartments and subsystems for a GEM."
+      description: "This query retrieves a list of all compartments and subsystems that are
+        available on Metabolic Atlas for the specified GEM. This includes identifiers
+        for the SVG maps."
       operationId: "mapListing"
       produces:
       - "application/json"
+      parameters:
+      - name: "model"
+        in: "query"
+        required: true
+        type: "string"
+        description: "the model name, e.g. **HumanGem**"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"
-  /random-components:
+  /random-components?model={model}:
     get:
       tags:
       - "Miscellaneous"
-      summary: "Get information for random components."
-      description: "Retrieve information for a number of random genes,
-        metabolites, compartments, reactions and subsystems. The
-        returned result is in JSON format. <br /><br />
-        Required parameters: None"
+      summary: "Get random components for a GEM."
+      description: "This query retrieves detailed informat for a random sample of
+        genes, metabolites, compartments, reactions and subsystems."
       operationId: "randomComponentInfo"
+      parameters:
+      - name: "model"
+        in: "query"
+        required: true
+        type: "string"
+        description: "the model name, e.g. **HumanGem**"
       produces:
       - "application/json"
       responses:
         "200":
-          description: "Successful operation"
+          description: "Successful query"
         "404":
           description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -16,7 +16,7 @@ tags:
 - name: "Genes"
 - name: "Metabolites"
 - name: "Reactions"
-- name: "subsystem"
+- name: "Subsystems"
 - name: "interaction-partner"
 - name: "miscellaneous"
 paths:
@@ -231,7 +231,7 @@ paths:
   /subsystems/{id}:
     get:
       tags:
-      - "subsystem"
+      - "Subsystems"
       summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing metabolites and genes/genes."
       description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing metabolites and genes/genes."
       operationId: "subsystemInfo"
@@ -250,7 +250,7 @@ paths:
   /subsystems/{id}/related-reactions:
     get:
       tags:
-      - "subsystem"
+      - "Subsystems"
       summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
       description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
       operationId: "subsystemInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -30,7 +30,7 @@ paths:
         available through tools like GEM Browser, Map Viewer and Interaction
         Partners. The list is returned in JSON format. No parameters are
         required."
-      operationId: "integratedModels"
+      operationId: "integratedModelListing"
       produces:
       - "application/json"
       responses:
@@ -44,8 +44,8 @@ paths:
       description: "Retrieve information for a given GEM (Genome-Scale
         Metabolic Model). The GEMs are available through tools like GEM Browser,
         Map Viewer and Interaction Partners. The result is returned in JSON format.
-        Required parameter: GEM name, e.g. **Human-GEM** "
-      operationId: "modelInfo"
+        Required parameters: GEM name, e.g. **Human-GEM** "
+      operationId: "integratedModelInfo"
       produces:
       - "application/json"
       parameters:
@@ -65,7 +65,7 @@ paths:
       summary: "Get information for a given compartment."
       description: "Retrieve all containing metabolites, genes, reactions
         and subsystems for a given compartment. The result is returned in JSON format.
-        Required parameter: compartment ID, e.g. **golgi_apparatus** "
+        Required parameters: compartment ID, e.g. **golgi_apparatus** "
       operationId: "compartmentInfo"
       produces:
       - "application/json"
@@ -85,9 +85,9 @@ paths:
       - "Compartments"
       summary: "Get related reactions for a given compartment."
       description: "Retrieve all related reactions for a given compartment. The
-        result is returned in JSON format. Required parameter: compartment ID,
+        result is returned in JSON format. Required parameters: compartment ID,
         e.g. **golgi_apparatus** "
-      operationId: "compartmentReaction"
+      operationId: "compartmentRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
@@ -106,7 +106,7 @@ paths:
       - "Genes"
       summary: "Get information for a given gene."
       description: "Retrieve all information for a given gene. The result is
-        returned in JSON format. Required parameter: gene ID, e.g.
+        returned in JSON format. Required parameters: gene ID, e.g.
         **ENSG00000196502** or **Sult1a1**"
       operationId: "geneInfo"
       produces:
@@ -127,9 +127,9 @@ paths:
       - "Genes"
       summary: "Get related reations for a given gene."
       description: "Retrieve all related reactions for a given gene. The result is
-        returned in JSON format. Required parameter: gene ID, e.g.
+        returned in JSON format. Required parameters: gene ID, e.g.
         **ENSG00000196502** or **Sult1a1**"
-      operationId: "geneReaction"
+      operationId: "geneRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
@@ -148,7 +148,7 @@ paths:
       - "Metabolites"
       summary: "Get information for a given metabolite."
       description: "Retrieve all information related to a given metabolite. The
-        result is returned in JSON format. Required parameter: metabolite ID,
+        result is returned in JSON format. Required parameters: metabolite ID,
         e.g. **m01587m**"
       operationId: "metaboliteInfo"
       produces:
@@ -169,9 +169,9 @@ paths:
       - "Metabolites"
       summary: "Get related reactions for a given metabolite."
       description: "Retrieve all related reactions for a given metabolite. The
-        returned result is in JSON format. Required parameter: metabolite ID,
+        returned result is in JSON format. Required parameters: metabolite ID,
         e.g. **m01587m**"
-      operationId: "metaboliteReaction"
+      operationId: "metaboliteRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
@@ -190,9 +190,9 @@ paths:
       - "Metabolites"
       summary: "Get related metabolites for a given metabolite."
       description: "Retrieve all related metabolites involving a given
-        metabolite. The returned result is in JSON format. Required parameter:
+        metabolite. The returned result is in JSON format. Required parameters:
         metabolite ID, e.g. **m01587m**"
-      operationId: "metaboliteRelatedMetabolite"
+      operationId: "metaboliteRelatedMetaboliteInfo"
       produces:
       - "application/json"
       parameters:
@@ -211,7 +211,7 @@ paths:
       - "Reactions"
       summary: "Get information for a given reaction."
       description: "Retrieve all information we have on a reaction. The
-        returned result is in JSON format. Required parameter: reaction ID, e.g.
+        returned result is in JSON format. Required parameters: reaction ID, e.g.
         **HMR_3000**"
       operationId: "reactionInfo"
       produces:
@@ -232,9 +232,9 @@ paths:
       - "Reactions"
       summary: "Get related reactions involving a given reaction."
       description: "Retrieve all related reactions involving a given reaction.
-        The returned result is in JSON format. Required parameter: reaction ID,
+        The returned result is in JSON format. Required parameters: reaction ID,
         e.g. **HMR_3000**"
-      operationId: "reactionRelatedReaction"
+      operationId: "reactionRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
@@ -254,7 +254,7 @@ paths:
       summary: "Get information for a given subsystem."
       description: "Retrieve all information (including metabolites,
         compartments and genes) for a given subsystem. The returned result is in
-        JSON format. Required parameter: subsystem ID, e.g.
+        JSON format. Required parameters: subsystem ID, e.g.
         **eicosanoid_metabolism** "
       operationId: "subsystemInfo"
       produces:
@@ -275,9 +275,9 @@ paths:
       - "Subsystems"
       summary: "Get related reactions for a given subsystem."
       description: "Retrieve all related reactions for a given subsystem. The
-        returned result is in JSON format. Required parameter: subsystem ID, e.g.
+        returned result is in JSON format. Required parameters: subsystem ID, e.g.
         **eicosanoid_metabolism** "
-      operationId: "subsystemRelatedReaction"
+      operationId: "subsystemRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
@@ -296,7 +296,7 @@ paths:
       - "Interaction Partners"
       summary: "Get interaction partners for a given gene."
       description: "Retrieve all first order interaction partners for a given
-        gene. The returned result is in JSON format. Required parameter: gene ID,
+        gene. The returned result is in JSON format. Required parameters: gene ID,
         e.g.  **ENSG00000196502** or **Sult1a1**"
       operationId: "geneInteractionPartners"
       produces:
@@ -316,8 +316,10 @@ paths:
       tags:
       - "Miscellaneous"
       summary: "List all compartments and subsystems."
-      description: "List all compartments and subsystems."
-      operationId: "mapListingInfo"
+      description: "Retrieve a list of all compartments and subsystems that are
+        available on Metabolic Atlas. The returned result is in JSON format. No
+        parameters are required."
+      operationId: "mapListing"
       produces:
       - "application/json"
       responses:
@@ -329,8 +331,10 @@ paths:
     get:
       tags:
       - "Miscellaneous"
-      summary: "List all information for random genes, metabolites compartments, reactions and subsystems."
-      description: "List all information for random genes, metabolites compartments, reactions and subsystems."
+      summary: "Get information for random components."
+      description: "Retrieve information for a number of random genes,
+        metabolites, compartments, reactions and subsystems. The
+        returned result is in JSON format. No parameters are required."
       operationId: "randomComponentInfo"
       produces:
       - "application/json"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -15,7 +15,7 @@ tags:
 - name: "Compartments"
 - name: "Genes"
 - name: "Metabolites"
-- name: "reaction"
+- name: "Reactions"
 - name: "subsystem"
 - name: "interaction-partner"
 - name: "miscellaneous"
@@ -193,7 +193,7 @@ paths:
   /reactions/{id}:
     get:
       tags:
-      - "reaction"
+      - "Reactions"
       summary: "List all the information we have on a reaction (for example HMR_3905)."
       description: "List all the information we have on a reaction (for example HMR_3905)."
       operationId: "reactionInfo"
@@ -212,7 +212,7 @@ paths:
   /reactions/{id}/related-reactions:
     get:
       tags:
-      - "reaction"
+      - "Reactions"
       summary: "List all related reactions involving a given reaction (for example HMR_3905)."
       description: "List all related reactions involving a given reaction (for example HMR_3905)."
       operationId: "reactionInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -237,15 +237,14 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /reactions/{id}:
+  /reactions/{id}?model={model}:
     get:
       tags:
       - "Reactions"
       summary: "Get information for a given reaction."
       description: "Retrieve all information we have on a reaction. The
         returned result is in JSON format. <br /><br />
-        Required parameters: reaction ID, e.g.
-        **HMR_3000**"
+        Required parameters: reaction ID (e.g.  **HMR_3000**) and model name (e.g. **HumanGem**)"
       operationId: "reactionInfo"
       produces:
       - "application/json"
@@ -254,25 +253,32 @@ paths:
         in: "path"
         required: true
         type: "string"
+      - name: "model"
+        in: "path"
+        required: true
+        type: "string"
       responses:
         "200":
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /reactions/{id}/related-reactions:
+  /reactions/{id}/related-reactions?model={model}:
     get:
       tags:
       - "Reactions"
       summary: "Get related reactions involving a given reaction."
       description: "Retrieve all related reactions involving a given reaction.
         The returned result is in JSON format. <br /><br />
-        Required parameters: reaction ID,
-        e.g. **HMR_3000**"
+        Required parameters: reaction ID (e.g.  **HMR_3000**) and model name (e.g. **HumanGem**)"
       operationId: "reactionRelatedReactionInfo"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -210,7 +210,9 @@ paths:
       tags:
       - "Reactions"
       summary: "Get information of a given reaction."
-      description: "Retrieve all information we have on a reaction. The returned result is in JSON format. Required parameter: reaction ID, e.g. **HMR_3000**"
+      description: "Retrieve all information we have on a reaction. The
+        returned result is in JSON format. Required parameter: reaction ID, e.g.
+        **HMR_3000**"
       operationId: "reactionInfo"
       produces:
       - "application/json"
@@ -229,7 +231,9 @@ paths:
       tags:
       - "Reactions"
       summary: "Get related reactions involving a given reaction."
-      description: "Retrieve all related reactions involving a given reaction. The returned result is in JSON format. Required parameter: reaction ID, e.g. **HMR_3000**"
+      description: "Retrieve all related reactions involving a given reaction.
+        The returned result is in JSON format. Required parameter: reaction ID,
+        e.g. **HMR_3000**"
       operationId: "reactionRelatedReaction"
       produces:
       - "application/json"
@@ -247,8 +251,11 @@ paths:
     get:
       tags:
       - "Subsystems"
-      summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing metabolites and genes/genes."
-      description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing metabolites and genes/genes."
+      summary: "Get information for a given subsystem."
+      description: "Retrieve all information (including metabolites,
+        compartments and genes) for a given subsystem. The returned result is in
+        JSON format. Required parameter: subsystem ID, e.g.
+        **eicosanoid_metabolism** "
       operationId: "subsystemInfo"
       produces:
       - "application/json"
@@ -266,9 +273,11 @@ paths:
     get:
       tags:
       - "Subsystems"
-      summary: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
-      description: "For a given subsystem name (e.g. eicosanoid_metabolism), list all the containing reactions."
-      operationId: "subsystemInfo"
+      summary: "Get related reactions for a given subsystem."
+      description: "Retrieve all related reactions for a given subsystem. The
+        returned result is in JSON format. Required parameter: subsystem ID, e.g.
+        **eicosanoid_metabolism** "
+      operationId: "subsystemRelatedReaction"
       produces:
       - "application/json"
       parameters:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -12,7 +12,7 @@ info:
 basePath: "/api/v2"
 tags:
 - name: "Integrated models"
-- name: "compartment"
+- name: "Compartments"
 - name: "gene"
 - name: "metabolite"
 - name: "reaction"
@@ -54,7 +54,7 @@ paths:
   /compartments/{id}:
     get:
       tags:
-      - "compartment"
+      - "Compartments"
       summary: "For a given compartment name (e.g., Golgi apparatus or
         golgi_apparatus), returns all containing metabolites, genes, reactions
         and subsystems."
@@ -77,7 +77,7 @@ paths:
   /compartments/{id}/related-reactions:
     get:
       tags:
-      - "compartment"
+      - "Compartments"
       summary: "For a given compartment name (e.g., Golgi apparatus or
         golgi_apparatus), return all reactions involving this compartment."
       description: "For a given compartment name (e.g., Golgi apparatus or

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -40,7 +40,7 @@ paths:
     get:
       tags:
       - "Integrated models"
-      summary: "Get information for a given GEM."
+      summary: "Get information of a given GEM."
       description: "Retrieve information for a given GEM (Genome-Scale
         Metabolic Model). The GEMs are available through tools like GEM Browser,
         Map Viewer and Interaction Partners. The result is returned in JSON format.
@@ -62,7 +62,7 @@ paths:
     get:
       tags:
       - "Compartments"
-      summary: "Get information for a given compartment."
+      summary: "Get information of a given compartment."
       description: "Retrieve all containing metabolites, genes, reactions
         and subsystems for a given compartment. The result is returned in JSON format.
         Required parameter: compartment ID, e.g. **golgi_apparatus** "
@@ -104,8 +104,10 @@ paths:
     get:
       tags:
       - "Genes"
-      summary: "List all information for a given gene (for example ENSG00000196502 or SULT1A1)."
-      description: "List all information for a given gene (for example ENSG00000196502 or SULT1A1)."
+      summary: "Get information of a given gene."
+      description: "Retrieve all information for a given gene. The result is
+        returned in JSON format. Required parameter: Gene ID, e.g.
+        **ENSG00000196502** or **Sult1a1**"
       operationId: "geneInfo"
       produces:
       - "application/json"
@@ -123,9 +125,11 @@ paths:
     get:
       tags:
       - "Genes"
-      summary: "List all reactions for a given gene (for example ENSG00000196502 or SULT1A1)."
-      description: "List all reactions for a given gene (for example ENSG00000196502 or SULT1A1)."
-      operationId: "geneInfo"
+      summary: "Get related reations for a given gene."
+      description: "Retrieve all related reactions for a given gene. The result is
+        returned in JSON format. Required parameter: Gene ID, e.g.
+        **ENSG00000196502** or **Sult1a1**"
+      operationId: "geneReaction"
       produces:
       - "application/json"
       parameters:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -28,8 +28,8 @@ paths:
       description: "Retrieve a list of all GEMs (Genome-Scale
         Metabolic Models) that Metabolic Atlas integrates. These GEMs are
         available through tools like GEM Browser, Map Viewer and Interaction
-        Partners. The list is returned in JSON format. No parameters are
-        required."
+        Partners. The list is returned in JSON format. <br /><br />
+        Required parameters: None"
       operationId: "integratedModelListing"
       produces:
       - "application/json"
@@ -43,8 +43,8 @@ paths:
       summary: "Get information for a given GEM."
       description: "Retrieve information for a given GEM (Genome-Scale
         Metabolic Model). The GEMs are available through tools like GEM Browser,
-        Map Viewer and Interaction Partners. The result is returned in JSON format.
-        Required parameters: GEM name, e.g. **Human-GEM** "
+        Map Viewer and Interaction Partners. The result is returned in JSON format.<br /><br />
+        Required parameters: GEM name (e.g. **Human-GEM**) "
       operationId: "integratedModelInfo"
       produces:
       - "application/json"
@@ -58,19 +58,24 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /compartments/{id}:
+  /compartments/{id}?model={model}:
     get:
       tags:
       - "Compartments"
       summary: "Get information for a given compartment."
       description: "Retrieve all containing metabolites, genes, reactions
-        and subsystems for a given compartment. The result is returned in JSON format.
-        Required parameters: compartment ID, e.g. **golgi_apparatus** "
+        and subsystems for a given compartment. The result is returned in JSON format. <br /><br />
+        Required parameters: compartment ID (e.g. **golgi_apparatus**) and
+        model name (e.g. **HumanGem**) "
       operationId: "compartmentInfo"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"
@@ -85,7 +90,8 @@ paths:
       - "Compartments"
       summary: "Get related reactions for a given compartment."
       description: "Retrieve all related reactions for a given compartment. The
-        result is returned in JSON format. Required parameters: compartment ID,
+        result is returned in JSON format. <br /><br />
+        Required parameters: compartment ID,
         e.g. **golgi_apparatus** "
       operationId: "compartmentRelatedReactionInfo"
       produces:
@@ -106,8 +112,8 @@ paths:
       - "Genes"
       summary: "Get information for a given gene."
       description: "Retrieve all information for a given gene. The result is
-        returned in JSON format. Required parameters: gene ID, e.g.
-        **ENSG00000196502** or **Sult1a1**"
+        returned in JSON format. <br /><br />
+        Required parameters: gene ID, e.g.  **ENSG00000196502** or **Sult1a1**"
       operationId: "geneInfo"
       produces:
       - "application/json"
@@ -127,8 +133,8 @@ paths:
       - "Genes"
       summary: "Get related reations for a given gene."
       description: "Retrieve all related reactions for a given gene. The result is
-        returned in JSON format. Required parameters: gene ID, e.g.
-        **ENSG00000196502** or **Sult1a1**"
+        returned in JSON format. <br /><br />
+        Required parameters: gene ID, e.g.  **ENSG00000196502** or **Sult1a1**"
       operationId: "geneRelatedReactionInfo"
       produces:
       - "application/json"
@@ -148,8 +154,8 @@ paths:
       - "Metabolites"
       summary: "Get information for a given metabolite."
       description: "Retrieve all information related to a given metabolite. The
-        result is returned in JSON format. Required parameters: metabolite ID,
-        e.g. **m01587m**"
+        result is returned in JSON format. <br /><br />
+        Required parameters: metabolite ID, e.g. **m01587m**"
       operationId: "metaboliteInfo"
       produces:
       - "application/json"
@@ -169,8 +175,8 @@ paths:
       - "Metabolites"
       summary: "Get related reactions for a given metabolite."
       description: "Retrieve all related reactions for a given metabolite. The
-        returned result is in JSON format. Required parameters: metabolite ID,
-        e.g. **m01587m**"
+        returned result is in JSON format.  <br /><br />
+        Required parameters: metabolite ID, e.g. **m01587m**"
       operationId: "metaboliteRelatedReactionInfo"
       produces:
       - "application/json"
@@ -190,7 +196,8 @@ paths:
       - "Metabolites"
       summary: "Get related metabolites for a given metabolite."
       description: "Retrieve all related metabolites involving a given
-        metabolite. The returned result is in JSON format. Required parameters:
+        metabolite. The returned result is in JSON format.  <br /><br />
+        Required parameters:
         metabolite ID, e.g. **m01587m**"
       operationId: "metaboliteRelatedMetaboliteInfo"
       produces:
@@ -211,7 +218,8 @@ paths:
       - "Reactions"
       summary: "Get information for a given reaction."
       description: "Retrieve all information we have on a reaction. The
-        returned result is in JSON format. Required parameters: reaction ID, e.g.
+        returned result is in JSON format. <br /><br />
+        Required parameters: reaction ID, e.g.
         **HMR_3000**"
       operationId: "reactionInfo"
       produces:
@@ -232,7 +240,8 @@ paths:
       - "Reactions"
       summary: "Get related reactions involving a given reaction."
       description: "Retrieve all related reactions involving a given reaction.
-        The returned result is in JSON format. Required parameters: reaction ID,
+        The returned result is in JSON format. <br /><br />
+        Required parameters: reaction ID,
         e.g. **HMR_3000**"
       operationId: "reactionRelatedReactionInfo"
       produces:
@@ -254,7 +263,8 @@ paths:
       summary: "Get information for a given subsystem."
       description: "Retrieve all information (including metabolites,
         compartments and genes) for a given subsystem. The returned result is in
-        JSON format. Required parameters: subsystem ID, e.g.
+        JSON format. <br /><br />
+        Required parameters: subsystem ID, e.g.
         **eicosanoid_metabolism** "
       operationId: "subsystemInfo"
       produces:
@@ -275,7 +285,8 @@ paths:
       - "Subsystems"
       summary: "Get related reactions for a given subsystem."
       description: "Retrieve all related reactions for a given subsystem. The
-        returned result is in JSON format. Required parameters: subsystem ID, e.g.
+        returned result is in JSON format. <br /><br />
+        Required parameters: subsystem ID, e.g.
         **eicosanoid_metabolism** "
       operationId: "subsystemRelatedReactionInfo"
       produces:
@@ -296,7 +307,8 @@ paths:
       - "Interaction Partners"
       summary: "Get interaction partners for a given gene."
       description: "Retrieve all first order interaction partners for a given
-        gene. The returned result is in JSON format. Required parameters: gene ID,
+        gene. The returned result is in JSON format. <br /><br />
+        Required parameters: gene ID,
         e.g.  **ENSG00000196502** or **Sult1a1**"
       operationId: "geneInteractionPartners"
       produces:
@@ -317,8 +329,8 @@ paths:
       - "Miscellaneous"
       summary: "List all compartments and subsystems."
       description: "Retrieve a list of all compartments and subsystems that are
-        available on Metabolic Atlas. The returned result is in JSON format. No
-        parameters are required."
+        available on Metabolic Atlas. The returned result is in JSON format. <br /><br />
+        Required parameters: None"
       operationId: "mapListing"
       produces:
       - "application/json"
@@ -334,7 +346,8 @@ paths:
       summary: "Get information for random components."
       description: "Retrieve information for a number of random genes,
         metabolites, compartments, reactions and subsystems. The
-        returned result is in JSON format. No parameters are required."
+        returned result is in JSON format. <br /><br />
+        Required parameters: None"
       operationId: "randomComponentInfo"
       produces:
       - "application/json"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -34,8 +34,8 @@ paths:
     get:
       tags:
       - "model"
-      summary: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM’."
-      description: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM’."
+      summary: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM'."
+      description: "List all information for a given model available on the GEM browser, supply its name e.g., 'Human-GEM'."
       operationId: "modelInfo"
       produces:
       - "application/json"
@@ -55,10 +55,10 @@ paths:
       - "compartment"
       summary: "For a given compartment name (e.g., Golgi apparatus or
         golgi_apparatus), returns all containing metabolites, genes, reactions
-        and subsystems.  "
+        and subsystems."
       description: "For a given compartment name (e.g., Golgi apparatus or
         golgi_apparatus), returns all containing metabolites, genes, reactions
-        and subsystems.  "
+        and subsystems."
       operationId: "compartmentInfo"
       produces:
       - "application/json"
@@ -77,9 +77,9 @@ paths:
       tags:
       - "compartment"
       summary: "For a given compartment name (e.g., Golgi apparatus or
-        golgi_apparatus), return all reactions involving this compartment"
+        golgi_apparatus), return all reactions involving this compartment."
       description: "For a given compartment name (e.g., Golgi apparatus or
-        golgi_apparatus), return all reactions involving this compartment"
+        golgi_apparatus), return all reactions involving this compartment."
       operationId: "compartmentInfo"
       produces:
       - "application/json"
@@ -93,4 +93,22 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-
+  /genes/{id}:
+    get:
+      tags:
+      - "gene"
+      summary: "List all information for a given gene (for example ENSG00000196502 or SULT1A1)."
+      description: "List all information for a given gene (for example ENSG00000196502 or SULT1A1)."
+      operationId: "geneInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -40,7 +40,7 @@ paths:
     get:
       tags:
       - "Integrated models"
-      summary: "Get information of a given GEM."
+      summary: "Get information for a given GEM."
       description: "Retrieve information for a given GEM (Genome-Scale
         Metabolic Model). The GEMs are available through tools like GEM Browser,
         Map Viewer and Interaction Partners. The result is returned in JSON format.
@@ -62,7 +62,7 @@ paths:
     get:
       tags:
       - "Compartments"
-      summary: "Get information of a given compartment."
+      summary: "Get information for a given compartment."
       description: "Retrieve all containing metabolites, genes, reactions
         and subsystems for a given compartment. The result is returned in JSON format.
         Required parameter: compartment ID, e.g. **golgi_apparatus** "
@@ -104,7 +104,7 @@ paths:
     get:
       tags:
       - "Genes"
-      summary: "Get information of a given gene."
+      summary: "Get information for a given gene."
       description: "Retrieve all information for a given gene. The result is
         returned in JSON format. Required parameter: gene ID, e.g.
         **ENSG00000196502** or **Sult1a1**"
@@ -146,7 +146,7 @@ paths:
     get:
       tags:
       - "Metabolites"
-      summary: "Get information of a given metabolite."
+      summary: "Get information for a given metabolite."
       description: "Retrieve all information related to a given metabolite. The
         result is returned in JSON format. Required parameter: metabolite ID,
         e.g. **m01587m**"
@@ -209,7 +209,7 @@ paths:
     get:
       tags:
       - "Reactions"
-      summary: "Get information of a given reaction."
+      summary: "Get information for a given reaction."
       description: "Retrieve all information we have on a reaction. The
         returned result is in JSON format. Required parameter: reaction ID, e.g.
         **HMR_3000**"
@@ -294,9 +294,11 @@ paths:
     get:
       tags:
       - "Interaction Partners"
-      summary: "List all first order interaction partners for a given gene (e.g. ENSG00000196502 or SULT1A1)."
-      description: "List all first order interaction partners for a given gene (e.g. ENSG00000196502 or SULT1A1)."
-      operationId: "geneInfo"
+      summary: "Get interaction partners for a given gene."
+      description: "Retrieve all first order interaction partners for a given
+        gene. The returned result is in JSON format. Required parameter: gene ID,
+        e.g.  **ENSG00000196502** or **Sult1a1**"
+      operationId: "geneInteractionPartners"
       produces:
       - "application/json"
       parameters:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -17,7 +17,7 @@ tags:
 - name: "Metabolites"
 - name: "Reactions"
 - name: "Subsystems"
-- name: "interaction-partner"
+- name: "Interaction Partners"
 - name: "miscellaneous"
 paths:
   /repository/integrated_models:
@@ -269,7 +269,7 @@ paths:
   /interaction-partners/{id}/:
     get:
       tags:
-      - "interaction-partner"
+      - "Interaction Partners"
       summary: "List all first order interaction partners for a given gene (e.g. ENSG00000196502 or SULT1A1)."
       description: "List all first order interaction partners for a given gene (e.g. ENSG00000196502 or SULT1A1)."
       operationId: "geneInfo"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -162,14 +162,14 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /metabolites/{id}:
+  /metabolites/{id}?model={model}:
     get:
       tags:
       - "Metabolites"
       summary: "Get information for a given metabolite."
       description: "Retrieve all information related to a given metabolite. The
         result is returned in JSON format. <br /><br />
-        Required parameters: metabolite ID, e.g. **m01587m**"
+        Required parameters: metabolite ID (e.g. **m01587m**) and model name (e.g. **HumanGem**)"
       operationId: "metaboliteInfo"
       produces:
       - "application/json"
@@ -178,24 +178,7 @@ paths:
         in: "path"
         required: true
         type: "string"
-      responses:
-        "200":
-          description: "Successful operation"
-        "404":
-          description: "Invalid input"
-  /metabolites/{id}/related-reactions:
-    get:
-      tags:
-      - "Metabolites"
-      summary: "Get related reactions for a given metabolite."
-      description: "Retrieve all related reactions for a given metabolite. The
-        returned result is in JSON format.  <br /><br />
-        Required parameters: metabolite ID, e.g. **m01587m**"
-      operationId: "metaboliteRelatedReactionInfo"
-      produces:
-      - "application/json"
-      parameters:
-      - name: "id"
+      - name: "model"
         in: "path"
         required: true
         type: "string"
@@ -204,20 +187,48 @@ paths:
           description: "Successful operation"
         "404":
           description: "Invalid input"
-  /metabolites/{id}/related-metabolites:
+  /metabolites/{id}/related-reactions?model={model}:
+    get:
+      tags:
+      - "Metabolites"
+      summary: "Get related reactions for a given metabolite."
+      description: "Retrieve all related reactions for a given metabolite. The
+        returned result is in JSON format.  <br /><br />
+        Required parameters: metabolite ID (e.g. **m01587m**) and model name (e.g. **HumanGem**)"
+      operationId: "metaboliteRelatedReactionInfo"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
+        in: "path"
+        required: true
+        type: "string"
+      responses:
+        "200":
+          description: "Successful operation"
+        "404":
+          description: "Invalid input"
+  /metabolites/{id}/related-metabolites?model={model}:
     get:
       tags:
       - "Metabolites"
       summary: "Get related metabolites for a given metabolite."
       description: "Retrieve all related metabolites involving a given
         metabolite. The returned result is in JSON format.  <br /><br />
-        Required parameters:
-        metabolite ID, e.g. **m01587m**"
+        Required parameters: metabolite ID (e.g. **m01587m**) and model name (e.g. **HumanGem**)"
       operationId: "metaboliteRelatedMetaboliteInfo"
       produces:
       - "application/json"
       parameters:
       - name: "id"
+        in: "path"
+        required: true
+        type: "string"
+      - name: "model"
         in: "path"
         required: true
         type: "string"

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -168,7 +168,9 @@ paths:
       tags:
       - "Metabolites"
       summary: "Get related reactions for a given metabolite."
-      description: "Retrieve all related reactions for a given metabolite. The returned result is in JSON format. Required parameter: metabolite ID, e.g. **m01587m**"
+      description: "Retrieve all related reactions for a given metabolite. The
+        returned result is in JSON format. Required parameter: metabolite ID,
+        e.g. **m01587m**"
       operationId: "metaboliteReaction"
       produces:
       - "application/json"
@@ -187,7 +189,9 @@ paths:
       tags:
       - "Metabolites"
       summary: "Get related metabolites for a given metabolite."
-      description: "Retrieve all related metabolites involving a given metabolite. The returned results is in JSON format. Required parameter: metabolite ID, e.g. **m01587m**"
+      description: "Retrieve all related metabolites involving a given
+        metabolite. The returned result is in JSON format. Required parameter:
+        metabolite ID, e.g. **m01587m**"
       operationId: "metaboliteRelatedMetabolite"
       produces:
       - "application/json"
@@ -205,8 +209,8 @@ paths:
     get:
       tags:
       - "Reactions"
-      summary: "List all the information we have on a reaction (for example HMR_3905)."
-      description: "List all the information we have on a reaction (for example HMR_3905)."
+      summary: "Get information of a given reaction."
+      description: "Retrieve all information we have on a reaction. The returned result is in JSON format. Required parameter: reaction ID, e.g. **HMR_3000**"
       operationId: "reactionInfo"
       produces:
       - "application/json"
@@ -224,9 +228,9 @@ paths:
     get:
       tags:
       - "Reactions"
-      summary: "List all related reactions involving a given reaction (for example HMR_3905)."
-      description: "List all related reactions involving a given reaction (for example HMR_3905)."
-      operationId: "reactionInfo"
+      summary: "Get related reactions involving a given reaction."
+      description: "Retrieve all related reactions involving a given reaction. The returned result is in JSON format. Required parameter: reaction ID, e.g. **HMR_3000**"
+      operationId: "reactionRelatedReaction"
       produces:
       - "application/json"
       parameters:


### PR DESCRIPTION
Add Swagger API Docs so that users can browser the API interface, and play around with an example query.
Example entry names or IDs are added in the description.