### PR TITLE
fix: on-click gene expression info icon to documentation MA-704

### DIFF
--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -6,8 +6,13 @@
     <div class="has-text-centered"
          title="Load a TSV file with gene IDs and TPM values.
          More information can be found in the documentation.">
-      Load custom gene expression data<router-link :to="{ name: 'documentation', hash: '#Data-overlay'}">
-        <span class="icon"><i class="fa fa-info-circle"></i></span> </router-link>
+      Load custom gene expression
+      <span style="white-space: nowrap;">
+        data
+        <router-link :to="{ name: 'documentation', hash: '#Data-overlay'}">
+          <span class="icon"><i class="fa fa-info-circle"></i></span>
+        </router-link>
+      </span>
     </div>
     <div class="file is-centered mb-2">
       <label class="file-label">

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -7,8 +7,7 @@
          title="Load a TSV file with gene IDs and TPM values.
          More information can be found in the documentation.">
       Load custom gene expression data<router-link :to="{ name: 'documentation', hash: '#Data-overlay'}">
-      <span class="icon"><i class="fa fa-info-circle"></i></span>
-      </router-link>
+        <span class="icon"><i class="fa fa-info-circle"></i></span> </router-link>
     </div>
     <div class="file is-centered mb-2">
       <label class="file-label">

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -6,7 +6,9 @@
     <div class="has-text-centered"
          title="Load a TSV file with gene IDs and TPM values.
          More information can be found in the documentation.">
-      Load custom gene expression data<span class="icon"><i class="fa fa-info-circle"></i></span>
+      Load custom gene expression data<router-link :to="{ name: 'documentation', hash: '#Data-overlay'}">
+      <span class="icon"><i class="fa fa-info-circle"></i></span>
+      </router-link>
     </div>
     <div class="file is-centered mb-2">
       <label class="file-label">


### PR DESCRIPTION
- [x] direct to documentation by clicking the gene expression info icon 