### PR TITLE
feat: error handler for all requests MA-578

### DIFF
--- a/api/src/endpoints/neo4j.js
+++ b/api/src/endpoints/neo4j.js
@@ -32,6 +32,10 @@ const fetchWith = async (req, res, queryHandler) => {
     const result = await queryHandler({ id, version, limit, model, full, searchTerm });
     res.json(result);
   } catch (e) {
+    if (e.message === '404') {
+      return res.sendStatus(404);
+    }
+
     res.status(400).send(e.message);
   }
 };

--- a/api/src/neo4j/queryHandlers/single.js
+++ b/api/src/neo4j/queryHandlers/single.js
@@ -8,6 +8,11 @@ const querySingleResult = async (statement) => {
 
   try {
     const response = await session.run(statement);
+
+    if (response.records.length === 0) {
+      throw new Error('404');
+    }
+
     result = response.records[0].get(0);
 
     if (Object.values(result).flat().length === 0) {

--- a/api/src/neo4j/queryHandlers/single.js
+++ b/api/src/neo4j/queryHandlers/single.js
@@ -9,6 +9,10 @@ const querySingleResult = async (statement) => {
   try {
     const response = await session.run(statement);
     result = response.records[0].get(0);
+
+    if (Object.values(result).flat().length === 0) {
+      throw new Error('404');
+    }
   } catch (e) {
     error = e;
   } finally {

--- a/api/src/neo4j/queryHandlers/single.js
+++ b/api/src/neo4j/queryHandlers/single.js
@@ -15,7 +15,8 @@ const querySingleResult = async (statement) => {
 
     result = response.records[0].get(0);
 
-    if (Object.values(result).flat().length === 0) {
+    if (Object.values(result).flat().filter(x => x !== 0).length === 0) {
+      // the result contains only empty lists of 0 values
       throw new Error('404');
     }
   } catch (e) {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -210,7 +210,7 @@ export default {
       axios.interceptors.response.use(
         response => response,
         (error) => {
-          if (error.response.status !== 404) {
+          if (!error.response || error.response.status !== 404) {
             // not found error should be handled in the relevant child components
             this.errorMessage = messages.unknownError;
           }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -71,6 +71,7 @@
       </transition>
     </nav>
     <router-view></router-view>
+    <ErrorPanel :message="errorMessage" @hideErrorPanel="errorMessage=''" />
     <footer id="footer" class="footer has-background-primary-lighter is-size-6 py-4">
       <div class="columns is-gapless">
         <div class="column is-7-desktop is-5-tablet has-text-centered-mobile">
@@ -129,13 +130,17 @@
 
 <script>
 
+import axios from 'axios';
 import { mapState } from 'vuex';
+import ErrorPanel from '@/components/shared/ErrorPanel';
 import GemSearch from '@/components/explorer/gemBrowser/GemSearch';
+import { default as messages } from '@/helpers/messages';
 import { isCookiePolicyAccepted, acceptCookiePolicy } from './helpers/store';
 
 export default {
   name: 'App',
   components: {
+    ErrorPanel,
     GemSearch,
   },
   data() {
@@ -179,6 +184,8 @@ export default {
       viewerLastRoute: {},
       isMobileMenu: false,
       showGemSearch: false,
+      messages,
+      errorMessage: '',
     };
   },
   computed: {
@@ -193,6 +200,20 @@ export default {
           document.querySelector('#search').focus();
         });
       }
+    },
+  },
+  mounted() {
+    this.setupErrorCatcher();
+  },
+  methods: {
+    setupErrorCatcher() {
+      axios.interceptors.response.use(
+        response => response,
+        (error) => {
+          this.errorMessage = messages.unknownError;
+          return Promise.reject(error);
+        }
+      );
     },
   },
 };

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -210,8 +210,9 @@ export default {
       axios.interceptors.response.use(
         response => response,
         (error) => {
-          if (!error.response || error.response.status !== 404) {
-            // not found error should be handled in the relevant child components
+          if (error.response && error.response.status === 404) {
+            this.errorMessage = messages.notFoundError;
+          } else {
             this.errorMessage = messages.unknownError;
           }
           return Promise.reject(error);

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -218,6 +218,12 @@ export default {
           return Promise.reject(error);
         }
       );
+
+      this.$router.afterEach(() => {
+        if (this.errorMessage !== '') {
+          this.errorMessage = '';
+        }
+      });
     },
   },
 };

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -210,7 +210,10 @@ export default {
       axios.interceptors.response.use(
         response => response,
         (error) => {
-          this.errorMessage = messages.unknownError;
+          if (error.response.status !== 404) {
+            // not found error should be handled in the relevant child components
+            this.errorMessage = messages.unknownError;
+          }
           return Promise.reject(error);
         }
       );

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -13,7 +13,7 @@
             Probably there is a typo in the {{ type }} identifier in the URL
             <br>
             Use the
-            <span v-if="type === 'map'">{{ type }} listing</span>
+            <span v-if="type === 'map'">list of {{ type }}s</span>
             <span v-else>search bar above </span>
             to find other {{ type }}s
           </p>

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -1,7 +1,6 @@
 <template>
   <div class="column has-text-centered is-three-fifths-desktop is-three-quarters-tablet is-fullwidth-mobile">
     <div class="box has-background-light content">
-      <template v-if="componentId">
         <template v-if="type">
           <p class="title is-size-5">
             <span class="is-capitalized">{{ type }}&nbsp;</span> "&nbsp;{{ componentId }}&nbsp;" &nbsp;not found
@@ -12,19 +11,14 @@
           <template v-else>
             <p>
               Probably there is a typo in the {{ type }} identifier in the URL
-              <br>Use the search bar above to find other {{ type }}s
+              <br>
+              Use the
+              <span v-if="type === 'map'">{{ type }} listing</span>
+              <span v-else>search bar above </span>
+              to find other {{ type }}s
             </p>
           </template>
         </template>
-        <template v-else>
-          <p class="title is-size-5">
-            <span class="is-capitalized">{{ componentId }}</span>&nbsp;" &nbsp;not found
-          </p>
-          <p>
-            Probably there is a typo in the identifier in the URL
-          </p>
-        </template>
-      </template>
       <template v-else>
         <h1 class="is-size-1 has-text-weight-bold">¯\_(ツ)_/¯<br>404</h1><br>
         <p class="is-size-5">

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -1,17 +1,27 @@
 <template>
   <div class="column has-text-centered is-three-fifths-desktop is-three-quarters-tablet is-fullwidth-mobile">
     <div class="box has-background-light content">
-      <template v-if="type">
-        <p class="title is-size-5">
-          <span class="is-capitalized">{{ type }}&nbsp;</span> "&nbsp;{{ componentId }}&nbsp;" &nbsp;not found
-        </p>
-        <template v-if="type === 'model'">
-          <p>Visit the Explore page to select one of the integrated models</p>
+      <template v-if="componentId">
+        <template v-if="type">
+          <p class="title is-size-5">
+            <span class="is-capitalized">{{ type }}&nbsp;</span> "&nbsp;{{ componentId }}&nbsp;" &nbsp;not found
+          </p>
+          <template v-if="type === 'model'">
+            <p>Visit the Explore page to select one of the integrated models</p>
+          </template>
+          <template v-else>
+            <p>
+              Probably there is a typo in the {{ type }} identifier in the URL
+              <br>Use the search bar above to find other {{ type }}s
+            </p>
+          </template>
         </template>
         <template v-else>
+          <p class="title is-size-5">
+            <span class="is-capitalized">{{ componentId }}</span>&nbsp;" &nbsp;not found
+          </p>
           <p>
-            Probably there is a typo in the {{ type }} identifier in the URL
-            <br>Use the search bar above to find other {{ type }}s
+            Probably there is a typo in the identifier in the URL
           </p>
         </template>
       </template>

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -5,19 +5,15 @@
         <p class="title is-size-5">
           <span class="is-capitalized">{{ type }}</span><code>{{ componentId }}</code>not found
         </p>
-        <template v-if="type === 'model'">
-          <p>Visit the Explore page to select one of the integrated models</p>
-        </template>
-        <template v-else>
-          <p>
-            Probably there is a typo in the {{ type }} identifier in the URL
-            <br>
-            Use the
-            <span v-if="type === 'map'">list of {{ type }}s</span>
-            <span v-else>search bar above </span>
-            to find other {{ type }}s
-          </p>
-        </template>
+        <p v-if="type === 'model'">{{ messages.modelNotFound }}</p>
+        <p v-else>
+          Probably there is a typo in the {{ type }} identifier in the URL
+          <br>
+          Use the
+          <span v-if="type === 'map'">list of {{ type }}s</span>
+          <span v-else>search bar above </span>
+          to find other {{ type }}s
+        </p>
       </template>
       <template v-else>
         <h1 class="is-size-1 has-text-weight-bold">¯\_(ツ)_/¯<br>404</h1><br>
@@ -36,11 +32,18 @@
 </template>
 <script>
 
+import { default as messages } from '@/helpers/messages';
+
 export default {
   name: 'NotFound',
   props: {
     type: String,
     componentId: String,
+  },
+  data() {
+    return {
+      messages,
+    };
   },
 };
 

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -3,7 +3,7 @@
     <div class="box has-background-light content">
       <template v-if="type">
         <p class="title is-size-5">
-          <span class="is-capitalized">{{ type }}&nbsp;</span> "&nbsp;{{ componentId }}&nbsp;" &nbsp;not found
+          <span class="is-capitalized">{{ type }}</span><code>{{ componentId }}</code>not found
         </p>
         <template v-if="type === 'model'">
           <p>Visit the Explore page to select one of the integrated models</p>
@@ -46,5 +46,8 @@ export default {
 
 </script>
 
-<style>
+<style lang="scss" scoped>
+code {
+  font-size: 1em;
+}
 </style>

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -1,24 +1,24 @@
 <template>
   <div class="column has-text-centered is-three-fifths-desktop is-three-quarters-tablet is-fullwidth-mobile">
     <div class="box has-background-light content">
-        <template v-if="type">
-          <p class="title is-size-5">
-            <span class="is-capitalized">{{ type }}&nbsp;</span> "&nbsp;{{ componentId }}&nbsp;" &nbsp;not found
-          </p>
-          <template v-if="type === 'model'">
-            <p>Visit the Explore page to select one of the integrated models</p>
-          </template>
-          <template v-else>
-            <p>
-              Probably there is a typo in the {{ type }} identifier in the URL
-              <br>
-              Use the
-              <span v-if="type === 'map'">{{ type }} listing</span>
-              <span v-else>search bar above </span>
-              to find other {{ type }}s
-            </p>
-          </template>
+      <template v-if="type">
+        <p class="title is-size-5">
+          <span class="is-capitalized">{{ type }}&nbsp;</span> "&nbsp;{{ componentId }}&nbsp;" &nbsp;not found
+        </p>
+        <template v-if="type === 'model'">
+          <p>Visit the Explore page to select one of the integrated models</p>
         </template>
+        <template v-else>
+          <p>
+            Probably there is a typo in the {{ type }} identifier in the URL
+            <br>
+            Use the
+            <span v-if="type === 'map'">{{ type }} listing</span>
+            <span v-else>search bar above </span>
+            to find other {{ type }}s
+          </p>
+        </template>
+      </template>
       <template v-else>
         <h1 class="is-size-1 has-text-weight-bold">¯\_(ツ)_/¯<br>404</h1><br>
         <p class="is-size-5">

--- a/frontend/src/components/explorer/GemBrowser.vue
+++ b/frontend/src/components/explorer/GemBrowser.vue
@@ -117,11 +117,7 @@ export default {
   },
   methods: {
     async getTilesData() {
-      try {
-        await this.$store.dispatch('browserTiles/getBrowserTiles', this.model);
-      } catch {
-        this.errorMessage = messages.unknownError;
-      }
+      await this.$store.dispatch('browserTiles/getBrowserTiles', this.model);
     },
   },
 };

--- a/frontend/src/components/explorer/InteractionPartners.vue
+++ b/frontend/src/components/explorer/InteractionPartners.vue
@@ -525,7 +525,7 @@ export default {
           this.constructGraph(this.rawElms, this.rawRels, this.fitGraph);
         }, 0);
       } catch (error) {
-        switch (error.status) {
+        switch (error.response.status) {
           case 404:
             this.componentNotFound = true;
             break;
@@ -588,7 +588,7 @@ export default {
           this.constructGraph(this.rawElms, this.rawRels);
         }, 0);
       } catch (error) {
-        switch (error.status) {
+        switch (error.response.status) {
           case 404:
             this.errorMessage = messages.notFoundError;
             break;

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -41,7 +41,8 @@
         </div>
         <div v-if="!currentMap"
              class="column is-unselectable om-1 fixed-height-mobile p-0 m-0">
-          <p class="is-size-5 has-text-centered" style="padding: 10%;">
+          <NotFound v-if="mapNotFound" :type="type" :component-id="$route.params.map_id"></NotFound>
+          <p v-else class="is-size-5 has-text-centered" style="padding: 10%;">
             <a @click="showingMapListing = true">Show the map list and choose a compartment or subsystem map</a>
           </p>
         </div>
@@ -89,6 +90,7 @@ import { debounce } from 'vue-debounce';
 import DataOverlay from '@/components/explorer/mapViewer/DataOverlay.vue';
 import ErrorPanel from '@/components/shared/ErrorPanel';
 import MapsListing from '@/components/explorer/mapViewer/MapsListing.vue';
+import NotFound from '@/components/NotFound';
 import SidebarDataPanels from '@/components/explorer/mapViewer/SidebarDataPanels.vue';
 import Svgmap from '@/components/explorer/mapViewer/Svgmap';
 import ThreeDViewer from '@/components/explorer/mapViewer/ThreeDviewer';
@@ -101,6 +103,7 @@ export default {
     DataOverlay,
     ErrorPanel,
     MapsListing,
+    NotFound,
     SidebarDataPanels,
     Svgmap,
     ThreeDViewer,
@@ -116,6 +119,7 @@ export default {
         data: null,
         error: false,
       },
+      mapNotFound: false,
       messages,
     };
   },
@@ -197,14 +201,17 @@ export default {
                   this.currentMap = { ...item };
                   this.currentMap.svgs = [item.svgs[k]];
                   this.currentMap.type = categories[i].slice(0, -1);
+                  this.mapNotFound = false;
                   return;
                 }
               }
             } else if (item.id === id) {
               this.currentMap = item;
               this.currentMap.type = categories[i].slice(0, -1);
+              this.mapNotFound = false;
               return;
             }
+            this.mapNotFound = true;
           }
         }
       }

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -41,7 +41,7 @@
         </div>
         <div v-if="!currentMap"
              class="column is-unselectable om-1 fixed-height-mobile p-0 m-0">
-          <NotFound v-if="mapNotFound" :type="type" :component-id="$route.params.map_id"></NotFound>
+          <NotFound v-if="mapNotFound" type="map" :component-id="$route.params.map_id"></NotFound>
           <p v-else class="is-size-5 has-text-centered" style="padding: 10%;">
             <a @click="showingMapListing = true">Show the map list and choose a compartment or subsystem map</a>
           </p>

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -54,14 +54,7 @@
                         :current-map="currentMap"
                         @unSelect="unSelect"
                         @updatePanelSelectionData="updatePanelSelectionData" />
-          <transition name="slide-fade">
-            <article v-if="loadMapErrorMessage" id="errorPanel" class="message is-danger">
-              <div class="message-header">
-                <b>Oops!..</b>
-              </div>
-              <div class="message-body has-text-centered"><h5 class="title is-6">{{ loadMapErrorMessage }}</h5></div>
-            </article>
-          </transition>
+          <ErrorPanel :message="loadMapErrorMessage" @hideErrorPanel="loadMapErrorMessage=''" />
         </div>
         <div id="dataOverlayBar"
              class="column is-narrow has-text-white is-unselectable is-hidden-mobile fixed-height-desktop p-1"
@@ -94,6 +87,7 @@
 import { mapGetters, mapState } from 'vuex';
 import { debounce } from 'vue-debounce';
 import DataOverlay from '@/components/explorer/mapViewer/DataOverlay.vue';
+import ErrorPanel from '@/components/shared/ErrorPanel';
 import MapsListing from '@/components/explorer/mapViewer/MapsListing.vue';
 import SidebarDataPanels from '@/components/explorer/mapViewer/SidebarDataPanels.vue';
 import Svgmap from '@/components/explorer/mapViewer/Svgmap';
@@ -105,6 +99,7 @@ export default {
   name: 'MapViewer',
   components: {
     DataOverlay,
+    ErrorPanel,
     MapsListing,
     SidebarDataPanels,
     Svgmap,
@@ -323,29 +318,6 @@ export default {
   }
   @media (max-width: $tablet) {
     display: none;
-  }
-}
-
-#errorPanel {
-  z-index: 11;
-  position: absolute;
-  left: 0;
-  right: 0;
-  margin-left: auto;
-  margin-right: auto;
-  width: 350px;
-  bottom: 2rem;
-  border: 1px solid gray;
-
-  .slide-fade-enter-active {
-    transition: all .3s ease;
-  }
-  .slide-fade-leave-active {
-    transition: all .8s cubic-bezier(1.0, 0.5, 0.8, 1.0);
-  }
-  .slide-fade-enter, .slide-fade-leave-active {
-    transform: translateY(200px);
-    opacity: 0;
   }
 }
 </style>

--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="modelErrorMessage" class="columns is-centered">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ errorMessage }}
-        </div>
-      </div>
-      <div v-if="componentNotFound" class="columns is-centered">
-        <notFound :type="type" :component-id="cName"></notFound>
+      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
+        <NotFound
+          :type="modelNotFound ? 'model' : type"
+          :component-id="modelNotFound ? $route.params.model : cName" />
       </div>
       <div v-else>
         <div class="columns">
@@ -74,7 +71,6 @@ import NotFound from '@/components/NotFound';
 import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
 import GemContact from '@/components/shared/GemContact';
 import { buildCustomLink } from '@/helpers/utils';
-import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'Compartment',
@@ -88,12 +84,11 @@ export default {
     return {
       cName: '',
       type: 'compartment',
-      modelErrorMessage: '',
+      modelNotFound: false,
       showFullSubsystem: false,
       limitSubsystem: 30,
       componentNotFound: false,
       showLoaderMessage: '',
-      messages,
     };
   },
   computed: {
@@ -126,7 +121,7 @@ export default {
     if (!this.model || this.model.short_name !== this.$route.params.model) {
       const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
       if (!modelSelectionSuccessful) {
-        this.modelErrorMessage = `Error: ${messages.modelNotFound}`;
+        this.modelNotFound = true;
       }
     }
     this.setup();

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="modelErrorMessage" class="columns is-centered">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ modelErrorMessage }}
-        </div>
-      </div>
-      <div v-if="componentNotFound" class="columns is-centered">
-        <notFound :type="type" :component-id="geneId"></notFound>
+      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
+        <NotFound
+          :type="modelNotFound ? 'model' : type"
+          :component-id="modelNotFound ? $route.params.model : geneId" />
       </div>
       <div v-else>
         <div class="container is-fullhd columns">
@@ -102,7 +99,7 @@ export default {
       limitReaction: 200,
       componentNotFound: false,
       showLoaderMessage: '',
-      modelErrorMessage: '',
+      modelNotFound: false,
       messages,
     };
   },
@@ -122,7 +119,7 @@ export default {
     if (!this.model || this.model.short_name !== this.$route.params.model) {
       const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
       if (!modelSelectionSuccessful) {
-        this.modelErrorMessage = `Error: ${messages.modelNotFound}`;
+        this.modelNotFound = true;
       }
     }
     this.setup();

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="modelErrorMessage" class="columns is-centered">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ modelErrorMessage }}
-        </div>
-      </div>
-      <div v-if="componentNotFound" class="columns is-centered">
-        <notFound :type="type" :component-id="metaboliteId"></notFound>
+      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
+        <NotFound
+          :type="modelNotFound ? 'model' : type"
+          :component-id="modelNotFound ? $route.params.model : metaboliteId" />
       </div>
       <div v-else>
         <div class="columns">
@@ -137,7 +134,7 @@ export default {
       activePanel: 'table',
       componentNotFound: false,
       showLoaderMessage: '',
-      modelErrorMessage: '',
+      modelNotFound: false,
       messages,
     };
   },
@@ -155,7 +152,7 @@ export default {
     if (!this.model || this.model.short_name !== this.$route.params.model) {
       const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
       if (!modelSelectionSuccessful) {
-        this.modelErrorMessage = `Error: ${messages.modelNotFound}`;
+        this.modelNotFound = true;
       }
     }
     this.setup();

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="modelErrorMessage" class="columns is-centered">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ modelErrorMessage }}
-        </div>
-      </div>
-      <div v-if="componentNotFound" class="columns is-centered">
-        <notFound :type="type" :component-id="rId"></notFound>
+      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
+        <NotFound
+          :type="modelNotFound ? 'model' : type"
+          :component-id="modelNotFound ? $route.params.model : rId" />
       </div>
       <div v-else>
         <div class="columns">
@@ -98,7 +95,6 @@ import ExtIdTable from '@/components/explorer/gemBrowser/ExtIdTable';
 import GemContact from '@/components/shared/GemContact';
 import References from '@/components/shared/References';
 import { buildCustomLink, reformatTableKey, capitalize, convertCamelCase, addMassUnit, reformatChemicalReactionHTML, equationSign } from '@/helpers/utils';
-import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'Reaction',
@@ -124,11 +120,10 @@ export default {
         { name: 'compartments', display: 'Compartment(s)' },
         { name: 'subsystems', display: 'Subsystem(s)' },
       ],
-      modelErrorMessage: '',
+      modelNotFound: false,
       showLoaderMessage: '',
       mapsAvailable: {},
       componentNotFound: false,
-      messages,
     };
   },
   computed: {
@@ -146,7 +141,7 @@ export default {
     if (!this.model || this.model.short_name !== this.$route.params.model) {
       const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
       if (!modelSelectionSuccessful) {
-        this.modelErrorMessage = `Error: ${messages.modelNotFound}`;
+        this.modelNotFound = true;
       }
     }
     this.setup();

--- a/frontend/src/components/explorer/gemBrowser/Subsystem.vue
+++ b/frontend/src/components/explorer/gemBrowser/Subsystem.vue
@@ -1,13 +1,10 @@
 <template>
   <div class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="modelErrorMessage" class="columns is-centered">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ modelErrorMessage }}
-        </div>
-      </div>
-      <div v-if="componentNotFound" class="columns is-centered">
-        <notFound :type="type" :component-id="sName"></notFound>
+      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
+        <NotFound
+          :type="modelNotFound ? 'model' : type"
+          :component-id="modelNotFound ? $route.params.model : sName" />
       </div>
       <div v-else>
         <div class="columns">
@@ -101,7 +98,6 @@ import ExtIdTable from '@/components/explorer/gemBrowser/ExtIdTable';
 import ReactionTable from '@/components/explorer/gemBrowser/ReactionTable';
 import GemContact from '@/components/shared/GemContact';
 import { buildCustomLink, reformatTableKey } from '@/helpers/utils';
-import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'Subsystem',
@@ -117,7 +113,7 @@ export default {
     return {
       sName: this.$route.params.id,
       type: 'subsystem',
-      modelErrorMessage: '',
+      modelNotFound: false,
       mainTableKey: [
         { name: 'name', display: 'Name' },
       ],
@@ -127,7 +123,6 @@ export default {
       displayedGene: 40,
       componentNotFound: false,
       showLoaderMessage: '',
-      messages,
     };
   },
   computed: {
@@ -181,7 +176,7 @@ export default {
     if (!this.model || this.model.short_name !== this.$route.params.model) {
       const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
       if (!modelSelectionSuccessful) {
-        this.modelErrorMessage = `Error: ${messages.modelNotFound}`;
+        this.modelNotFound = true;
       }
     }
     this.setup();

--- a/frontend/src/components/explorer/mapViewer/RNAexpression.vue
+++ b/frontend/src/components/explorer/mapViewer/RNAexpression.vue
@@ -16,7 +16,6 @@ import { mapGetters, mapState } from 'vuex';
 import { default as EventBus } from '@/event-bus';
 import RNALegend from '@/components/explorer/mapViewer/RNALegend.vue';
 import { getSingleRNAExpressionColor, getComparisonRNAExpressionColor, multipleColors } from '@/expression-sources/hpa';
-import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'RNAexpression',
@@ -143,11 +142,7 @@ export default {
       this.$emit('secondTissueSelected', tissue);
     },
     async getRnaLevels() {
-      try {
-        await this.$store.dispatch('humanProteinAtlas/getLevels');
-      } catch {
-        this.loadErrorMesssage = messages.unknownError;
-      }
+      await this.$store.dispatch('humanProteinAtlas/getLevels');
     },
     parseHPARNAlevels(tissue, index, callback) {
       const RNAlevels = {};

--- a/frontend/src/components/shared/ErrorPanel.vue
+++ b/frontend/src/components/shared/ErrorPanel.vue
@@ -1,0 +1,72 @@
+<template>
+  <transition name="slide-fade">
+    <article v-if="message" id="errorPanel" class="message is-danger">
+      <div class="message-header">
+        <b>{{ title }}</b>
+        <button v-if="hasHideListener" class="delete" aria-label="delete" @click="$emit('hideErrorPanel')" />
+      </div>
+      <div class="message-body has-text-centered">
+        <h5 class="title is-6">{{ message }}</h5>
+      </div>
+    </article>
+  </transition>
+</template>
+
+<script>
+
+/**
+ * The ErrorPanel component is controlled by providing a `message`, and
+ * an optional `title`.
+ *
+ * The `@hideErrorPanel` event could be used to reset
+ * the `message` by clicking the "x" button.
+ *
+ * Example usage for the ErrorPanel component:
+ * <ErrorPanel :message="mess" @hideErrorPanel="mess=''" />
+ */
+export default {
+  name: 'ErrorPanel',
+  props: {
+    title: {
+      type: String,
+      default: 'Oops!..',
+    },
+    message: {
+      type: String,
+    },
+  },
+  computed: {
+    hasHideListener() {
+      return Object.keys(this.$listeners).includes('hideErrorPanel');
+    },
+  },
+};
+
+</script>
+
+<style>
+
+#errorPanel {
+  z-index: 11;
+  position: absolute;
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  width: 350px;
+  bottom: 2rem;
+  border: 1px solid gray;
+}
+
+.slide-fade-enter-active {
+  transition: all .3s ease;
+}
+.slide-fade-leave-active {
+  transition: all .3s cubic-bezier(1.0, 0.5, 0.8, 1.0);
+}
+.slide-fade-enter, .slide-fade-leave-to {
+  transform: translateY(200px);
+  opacity: 0;
+}
+
+</style>

--- a/frontend/src/components/shared/ErrorPanel.vue
+++ b/frontend/src/components/shared/ErrorPanel.vue
@@ -6,7 +6,7 @@
         <button v-if="hasHideListener" class="delete" aria-label="delete" @click="$emit('hideErrorPanel')" />
       </div>
       <div class="message-body has-text-centered">
-        <h5 class="title is-6" v-html="message" />
+        <p class="title is-6" v-html="message" />
       </div>
     </article>
   </transition>

--- a/frontend/src/components/shared/ErrorPanel.vue
+++ b/frontend/src/components/shared/ErrorPanel.vue
@@ -48,13 +48,10 @@ export default {
 
 #errorPanel {
   z-index: 11;
-  position: absolute;
-  left: 0;
-  right: 0;
-  margin-left: auto;
-  margin-right: auto;
+  position: fixed;
   width: 350px;
-  bottom: 2rem;
+  right: 20px;
+  bottom: 80px;
   border: 1px solid gray;
 }
 

--- a/frontend/src/components/shared/ErrorPanel.vue
+++ b/frontend/src/components/shared/ErrorPanel.vue
@@ -50,7 +50,7 @@ export default {
   z-index: 11;
   position: fixed;
   width: 350px;
-  right: 20px;
+  left: calc(50% - 175px);
   bottom: 80px;
   border: 1px solid gray;
 }

--- a/frontend/src/components/shared/ErrorPanel.vue
+++ b/frontend/src/components/shared/ErrorPanel.vue
@@ -6,7 +6,7 @@
         <button v-if="hasHideListener" class="delete" aria-label="delete" @click="$emit('hideErrorPanel')" />
       </div>
       <div class="message-body has-text-centered">
-        <h5 class="title is-6">{{ message }}</h5>
+        <h5 class="title is-6" v-html="message" />
       </div>
     </article>
   </transition>

--- a/frontend/src/components/shared/ExportTSV.vue
+++ b/frontend/src/components/shared/ExportTSV.vue
@@ -1,20 +1,34 @@
 <template>
-  <a class="button is-primary is-outlined" @click="exportToTSV">
-    <span class="icon is-large"><i class="fa fa-download"></i></span>
-    <span>Export to TSV</span>
-  </a>
+  <span>
+    <a class="button is-primary is-outlined" @click="exportToTSV">
+      <span class="icon is-large"><i class="fa fa-download"></i></span>
+      <span>Export to TSV</span>
+    </a>
+    <ErrorPanel :message="errorMessage" @hideErrorPanel="errorMessage=''" />
+  </span>
 </template>
 
 <script>
 
 import { default as FileSaver } from 'file-saver';
+import ErrorPanel from '@/components/shared/ErrorPanel';
+import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'ExportTSV',
+  components: {
+    ErrorPanel,
+  },
   props: {
     arg: [Number, String, Object, Array],
     filename: String,
     formatFunction: Function,
+  },
+  data() {
+    return {
+      messages,
+      errorMessage: '',
+    };
   },
   methods: {
     exportToTSV() {
@@ -31,7 +45,7 @@ export default {
         });
         FileSaver.saveAs(blob, this.filename);
       } catch (error) {
-        this.props.filename = 'error';
+        this.errorMessage = messages.fileSaveError;
       }
     },
   },

--- a/frontend/src/helpers/messages.js
+++ b/frontend/src/helpers/messages.js
@@ -9,4 +9,5 @@ export default {
   mapViewerName: 'Map Viewer',
   gemBrowserName: 'GEM Browser',
   interPartName: 'Interaction Partners',
+  fileSaveError: 'There was a problem saving the file. Please try using a different browser or contact us.',
 };

--- a/frontend/src/helpers/messages.js
+++ b/frontend/src/helpers/messages.js
@@ -4,10 +4,10 @@ export default {
   modelNotFound: 'The url contains a model identifier that does not exist in the database. Browse the available models on the Explore page.',
   mapNotFound: 'Sorry, it seems that the selected 2D map is not available because the SVG is missing.<br>If you think this is an accident, drop us a line at <a href="mailto:contact@metabolicatlas.org?subject=SVG error&body=There was an error when choosing to see the 2D map for ..">contact@metabolicatlas.org</a>.',
   notFoundError: 'No matching record(s) found, please check the parameters and try again.',
-  unknownError: 'Something went wrong, please try again later or contact us.',
+  unknownError: 'Something went wrong, please try again later or contact us at <a href="mailto:contact@metabolicatlas.org">contact@metabolicatlas.org</a>.',
   noInfoAvailable: 'No information available',
   mapViewerName: 'Map Viewer',
   gemBrowserName: 'GEM Browser',
   interPartName: 'Interaction Partners',
-  fileSaveError: 'There was a problem saving the file. Please try using a different browser or contact us.',
+  fileSaveError: 'There was a problem saving the file. Please try using a different browser or contact us at <a href="mailto:contact@metabolicatlas.org">contact@metabolicatlas.org</a>.',
 };


### PR DESCRIPTION
Non-existent ids in gem browser, map viewer, and interaction partners now display an error message using the `NotFound` component.

An `ErrorPanel` component is added and used in:
- specific scenarios such as failing to apply RNA levels or exporting TSV file
- general, non 404, scenarios where a web request fails