### PR TITLE
feat: db performance enhancement MA-931

### DIFF
--- a/api/src/neo4j/queries/randomComponents.js
+++ b/api/src/neo4j/queries/randomComponents.js
@@ -57,7 +57,8 @@ CALL apoc.cypher.run("
   MATCH (:Compartment${m} {id: $cid})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(:Reaction)-[${v}]-(g:Gene)
   RETURN { geneCount: count(distinct g) } as data
   UNION
-  MATCH (:Compartment${m} {id: $cid})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(:Reaction)-[${v}]-(:Subsystem)-[${v}]-(sss:SubsystemState)
+  MATCH (:Compartment${m} {id: $cid})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(sss:SubsystemState)
+  USING JOIN on s
   RETURN { majorSubsystems: COLLECT(DISTINCT(sss.name))[..15] } as data
 ", {cid:cid}) yield value
 RETURN { compartment: apoc.map.mergeList(COLLECT(value.data)) } as xs

--- a/api/src/neo4j/queries/relatedReactions.js
+++ b/api/src/neo4j/queries/relatedReactions.js
@@ -67,6 +67,7 @@ CALL apoc.cypher.run("
   MATCH (:Reaction${m} {id: $rid})-[${v}]-(cm:CompartmentalizedMetabolite)
   WITH DISTINCT cm
   MATCH (cm)-[${v}]-(c:Compartment)-[${v}]-(cs:CompartmentState)
+  USING JOIN on c
   RETURN { id: $rid, compartments: COLLECT(DISTINCT(cs {id: c.id, .*})) } as data
  
   UNION
@@ -87,8 +88,9 @@ CALL apoc.cypher.run("
  
   MATCH (:Reaction${m} {id: $rid})-[cmE${v}]-(cm:CompartmentalizedMetabolite)
   WITH DISTINCT cm, cmE
-  MATCH (cm)-[${v}]-(:Metabolite)-[${v}]-(ms:MetaboliteState)
   MATCH (cm)-[${v}]-(c:Compartment)-[${v}]-(cs:CompartmentState)
+  USING JOIN on c
+  OPTIONAL MATCH (cm)-[${v}]-(:Metabolite)-[${v}]-(ms:MetaboliteState)
   RETURN { id: $rid, metabolites: COLLECT(DISTINCT(ms {id: cm.id, fullName: COALESCE(ms.name, '') + ' [' + COALESCE(cs.letterCode, '') + ']',  compartmentId: c.id, stoichiometry: cmE.stoichiometry, outgoing: startnode(cmE)=cm, .*})) } as data
 ", {rid:rid}) yield value
 RETURN apoc.map.mergeList(apoc.coll.flatten(


### PR DESCRIPTION
This PR covers performance enhancements for the following queries:

- random components: using the `cytosol` compartment as an example, response time improvement: `~40s` -> `~1s`
- related reactions: using the `transport_reactions` subsystem as an example, response time improvement: from `~6300ms` -> `~1200ms`