### PR TITLE
fix: make sure compartment is requested after route change MA-926

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -130,16 +130,14 @@ export default {
     async setup() {
       this.showLoaderMessage = 'Loading compartment data';
       this.cName = this.$route.params.id;
-      if (this.cName !== this.compartment.id) {
-        try {
-          const payload = { model: this.model, id: this.cName };
-          await this.$store.dispatch('compartments/getCompartmentSummary', payload);
-          this.componentNotFound = false;
-          this.showLoaderMessage = '';
-        } catch {
-          this.componentNotFound = true;
-          document.getElementById('search').focus();
-        }
+      try {
+        const payload = { model: this.model, id: this.cName };
+        await this.$store.dispatch('compartments/getCompartmentSummary', payload);
+        this.componentNotFound = false;
+        this.showLoaderMessage = '';
+      } catch {
+        this.componentNotFound = true;
+        document.getElementById('search').focus();
       }
     },
   },


### PR DESCRIPTION
Jira task: MA-926

The compartment component would not load in certain situations, this fixes that.

Steps to reproduce former buggy behavior (written by @nanjiangshu):
1. On the home page, click "Map viewer"
2. Then click "GEM Browser"
3. Then click one of the 2D or 3D Map Viewer
4. Then click "GEM Browser" again, and the server will be in the spinning mode here.