### PR TITLE
fix: create folder api/repository if it does not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,9 +86,9 @@ pids
 *.pid.lock
 
 # GEM repository in FTP
-ftp-models/
+ftp/repository/
 
-# GEM repository in FTP
+# GEM repository in API
 api/repository/
 
 # SVG folder in API

--- a/ftp/Dockerfile
+++ b/ftp/Dockerfile
@@ -1,6 +1,6 @@
 FROM stilliard/pure-ftpd:hardened
 
-COPY ftp-models /var/ftp/models
+COPY repository /var/ftp/models
 RUN useradd -d /var/ftp -s /sbin/nologin ftp
 
 COPY ./prep-cert.sh /project/prep-cert.sh

--- a/proj.sh
+++ b/proj.sh
@@ -11,7 +11,7 @@ function generate-data {
   /bin/cp -r $DATA_FILES_PATH/gemsRepository.json api/src/data/
   /bin/cp -r $DATA_FILES_PATH/svg api/
   /bin/cp -r $DATA_FILES_PATH/ftp-models ftp/
-  /bin/cp -r $DATA_FILES_PATH/ftp-models/* api/repository/
+  /bin/mkdir -p api/repository && /bin/cp -r $DATA_FILES_PATH/ftp-models/* api/repository/
 }
 
 function build-stack {

--- a/proj.sh
+++ b/proj.sh
@@ -10,8 +10,8 @@ function generate-data {
   /bin/cp -r $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
   /bin/cp -r $DATA_FILES_PATH/gemsRepository.json api/src/data/
   /bin/cp -r $DATA_FILES_PATH/svg api/
-  /bin/cp -r $DATA_FILES_PATH/ftp-models ftp/
-  /bin/mkdir -p api/repository && /bin/cp -r $DATA_FILES_PATH/ftp-models/* api/repository/
+  /bin/cp -r $DATA_FILES_PATH/repository ftp/
+  /bin/cp -r $DATA_FILES_PATH/repository api/
 }
 
 function build-stack {


### PR DESCRIPTION
Create the folder `api/repository` if it does not exist (which is the case after a fresh clone), otherwise, the command ```/bin/cp -r $DATA_FILES_PATH/ftp-models/* api/repository/``` will end up in an error. 