### PR TITLE
fix: make sure the linked integrated model is selected MA-940

### DIFF
--- a/frontend/src/components/Explorer.vue
+++ b/frontend/src/components/Explorer.vue
@@ -110,10 +110,18 @@ export default {
       model: state => state.models.model,
     }),
   },
+  mounted() {
+    const modelShortName = this.$route.params.model;
+    if (modelShortName && this.model && modelShortName !== this.model.short_name) {
+      this.selectModel(modelShortName);
+    }
+  },
   methods: {
     async selectModel(modelShortName) {
-      if (modelShortName !== this.model.short_name) {
+      if (modelShortName !== this.$route.params.model) {
         this.$router.replace({ params: { model: modelShortName } });
+      }
+      if (modelShortName !== this.model.short_name) {
         this.$store.dispatch('models/selectModel', modelShortName);
       }
     },

--- a/frontend/src/components/Explorer.vue
+++ b/frontend/src/components/Explorer.vue
@@ -117,7 +117,7 @@ export default {
     }
   },
   methods: {
-    async selectModel(modelShortName) {
+    selectModel(modelShortName) {
       if (modelShortName !== this.$route.params.model) {
         this.$router.replace({ params: { model: modelShortName } });
       }


### PR DESCRIPTION
Jira issue MA-940

### Steps to reproduce buggy behavior:

1. Visit the `/about` page.
2. Click `Human-GEM` link in the second paragraph of the page.
3. The user is now taken to the explore page with the correct URL `/explore/Human-GEM` but the wrong model is selected. (At the time of writing, the selected one is `Fruitfly-GEM`, which is the first one listed.)

### Acceptance test scenario:

1. Visit the `/about` page.
2. Click `Human-GEM` link in the second paragraph of the page.
3. The user should now be taken to the explore page with the correct URL `/explore/Human-GEM` and the `Human-GEM` model selected.
4. Repeat steps 1-3 for `Yeast-GEM`.