### PR TITLE
refactor: there is no need to focus on search in GEM Browser

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -138,7 +138,6 @@ export default {
           this.showLoaderMessage = '';
         } catch {
           this.componentNotFound = true;
-          document.getElementById('search').focus();
         }
       }
     },

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -136,7 +136,6 @@ export default {
       } catch {
         this.reactions = [];
         this.componentNotFound = true;
-        document.getElementById('search').focus();
       }
     },
     reformatTableKey(k) { return reformatTableKey(k); },

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -168,7 +168,6 @@ export default {
         await this.getRelatedMetabolites();
       } catch {
         this.componentNotFound = true;
-        document.getElementById('search').focus();
       }
     },
     async getRelatedMetabolites() {

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -158,7 +158,6 @@ export default {
         await this.getRelatedReactions();
       } catch {
         this.componentNotFound = true;
-        document.getElementById('search').focus();
       }
     },
     async getRelatedReactions() {

--- a/frontend/src/components/explorer/gemBrowser/Subsystem.vue
+++ b/frontend/src/components/explorer/gemBrowser/Subsystem.vue
@@ -192,7 +192,6 @@ export default {
         this.showLoaderMessage = '';
       } catch {
         this.componentNotFound = true;
-        document.getElementById('search').focus();
       }
     },
     reformatKey(k) { return reformatTableKey(k); },


### PR DESCRIPTION
Through this PR the pages for the model components are refactored, removing the browser focus on the search, since that functionality is requires a click now. This focus was relevant before, when the search bar was embedded in the page above the model component, always visible.