### PR TITLE
fix: show reaction details in sidebar

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -238,6 +238,8 @@ export default {
 #mapViewerContainer {
 
   #mapSidebar {
+    word-wrap: break-word;
+
     .buttons {
 
       button {

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -79,22 +79,11 @@
                 <span class="has-text-weight-bold">{{ capitalize(item.display || item.name) }}:</span>
                 {{ selectionData.data[item.name].name }}
               </template>
-              <template v-else-if="['reactants', 'products'].includes(item.name)">
-                <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
-                <span class="has-text-weight-bold">{{ capitalize(item.display || item.name) }}:</span>
-                <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
-                <p>
-                  <template v-for="s in selectionData.data[item.name]">
-                    <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
-                    &ndash;&nbsp;{{ s.fullName }}<br>
-                  </template>
-                </p>
-              </template>
               <template v-else-if="item.name === 'equation'">
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
                 <p><span class="has-text-weight-bold" v-html="capitalize(item.display || item.name) + ':'"></span><br>
-                  <span v-html="getChemicalReaction(selectionData.data[item.name])">
-                  </span></p>
+                  <span v-html="reformatChemicalReactionHTML(selectionData.data, false, model.short_name)"></span>
+                </p>
               </template>
               <template v-else-if="item.name === 'formula'">
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
@@ -137,7 +126,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import { capitalize, reformatStringToLink } from '@/helpers/utils';
+import { capitalize, reformatStringToLink, reformatChemicalReactionHTML } from '@/helpers/utils';
 import { chemicalFormula } from '@/helpers/chemical-formatters';
 import { default as messages } from '@/helpers/messages';
 
@@ -166,8 +155,6 @@ export default {
         reaction: [
           { name: 'equation' },
           { name: 'subsystems', display: 'Subsystem(s)' },
-          { name: 'reactants', display: 'Reactant(s)' },
-          { name: 'products', display: 'Product(s)' },
         ],
       },
       showMapCardContent: true,
@@ -201,6 +188,7 @@ export default {
     capitalize,
     reformatStringToLink,
     chemicalFormula,
+    reformatChemicalReactionHTML,
   },
 };
 </script>


### PR DESCRIPTION
When loading a 2D map, one is expect to click on all nodes on the map: metabolites, genes and reactions, with the details of each component being shown in the sidebar.
The reaction information was not displayed, just showing as loading forever. Apparently the wrong function was called, throwing some errors in the JS console.
The fix was tested for both 2D and 3D, on several models.