### PR TITLE
fix: source url for matomo

### DIFF
--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -19,7 +19,7 @@ Vue.use(vueDebounce);
 
 if (navigator.doNotTrack !== '1') {
   Vue.use(VueMatomo, {
-    host: 'https://csbi.chalmers.se/',
+    host: 'https://csbi.chalmers.se/matomo',
     siteId: process.env.VUE_APP_MATOMOID,
     router,
   });


### PR DESCRIPTION
The url needs to contain the full path up until the `/piwik.js` suffix.