### PR TITLE
feat: enable panning using arrow keys for 2D maps MA-598

### DIFF
--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -153,6 +153,37 @@ export default {
       this.$store.dispatch('maps/setLoading', true);
       const payload = { model: this.model.short_name, svgName: this.mapData.svgs[0].filename };
       await this.$store.dispatch('maps/getSvgMap', payload);
+      this.bindKeyboardShortcuts();
+    },
+    bindKeyboardShortcuts() {
+      document.addEventListener('keydown', (event) => {
+        const key = event.key || event.keyCode;
+
+        switch (key) {
+          case 'ArrowLeft':
+          case 37:
+            this.relativePan(-10, 0);
+            break;
+          case 'ArrowUp':
+          case 38:
+            this.relativePan(0, -10);
+            break;
+          case 'ArrowRight':
+          case 39:
+            this.relativePan(10, 0);
+            break;
+          case 'ArrowDown':
+          case 40:
+            this.relativePan(0, 10);
+            break;
+          default:
+            return;
+        }
+        event.preventDefault();
+      });
+    },
+    relativePan(x, y) {
+      this.panzoom.pan(x, y, { relative: true });
     },
     toggleGenes() {
       if ($('.enz, .ee').first().attr('visibility') === 'hidden') {

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -158,23 +158,23 @@ export default {
     bindKeyboardShortcuts() {
       document.addEventListener('keydown', (event) => {
         const key = event.key || event.keyCode;
-
+        const panDistance = 10;
         switch (key) {
           case 'ArrowLeft':
           case 37:
-            this.relativePan(-10, 0);
+            this.relativePan(-panDistance, 0);
             break;
           case 'ArrowUp':
           case 38:
-            this.relativePan(0, -10);
+            this.relativePan(0, -panDistance);
             break;
           case 'ArrowRight':
           case 39:
-            this.relativePan(10, 0);
+            this.relativePan(panDistance, 0);
             break;
           case 'ArrowDown':
           case 40:
-            this.relativePan(0, 10);
+            this.relativePan(0, panDistance);
             break;
           default:
             return;


### PR DESCRIPTION
Jira issue MA-598

This PR introduces the ability to pan 2D maps by using the arrow keys. During testing I found that 10 is a good unit of movement for different maps and zoom levels, but please let me if you feel like it does not work well enough. Note that you can also hold down an arrow key for continuous panning of the map.