### PR TITLE
fix: api url for files in gem repository MA-958

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -15,8 +15,6 @@ services:
     container_name: frontend
     build: frontend
     command: yarn serve
-    environment:
-      - VUE_APP_REPOSITORY_FILES_URL=http://localhost/api/v2/repository
     volumes:
       - ./frontend/src:/project/src
       - ./frontend/public:/project/public

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -5,8 +5,6 @@ services:
     build:
       context: .
       dockerfile: ./nginx/prod.Dockerfile
-      args:
-      - VUE_APP_REPOSITORY_FILES_URL=http://${SERVER_NAME}/api/v2/repository
     ports:
       - "80:80"
       - "443:443"

--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -122,7 +122,9 @@
               <template v-if="selectedModel.files">
                 <h4 class="subtitle is-size-4">Files</h4>
                 <template v-for="file in selectedModel.files">
-                  <a :key="file.path" class="button" :href="`${filesURL}${file.path}`">{{ file.format }}</a>&nbsp;
+                  <a :key="file.path" class="button" :href="`/api/v2/repository/${file.path}`">
+                    {{ file.format }}
+                  </a>&nbsp;
                 </template>
                 <div class="notification mt-4">
                   To download multiple models at once use the
@@ -262,7 +264,6 @@ export default {
         ofLabel: 'of',
       },
       messages,
-      filesURL: `${process.env.VUE_APP_REPOSITORY_FILES_URL}/`,
     };
   },
   computed: {


### PR DESCRIPTION
When trying to download files from the GEM repository, the urls that are computed in the frontend appear to be wrong, and thus not working, potentially due to previous refactoring.