### PR TITLE
fix: correct variable name for the external db MA-948

### DIFF
--- a/api/src/neo4j/shared/formatter.js
+++ b/api/src/neo4j/shared/formatter.js
@@ -1,5 +1,5 @@
 const reformatExternalDbs = (externalDbs) => externalDbs.reduce((dbs, db) => {
-  let dbRefs = dbs[db.name] || [];
+  let dbRefs = dbs[db.dbName] || [];
   dbRefs = [...dbRefs, { id: db.externalId, url: db.url }];
   return { ...dbs, [db.dbName]: dbRefs };
 }, {});


### PR DESCRIPTION
This pull request fixes the bug that only one record is shown for the external database table. All records in one external database entry should have separate links as well. The related Jira issue is [MA-948](https://chalmersysbiocsb.atlassian.net/browse/MA-948). 

Examples to check

1. http://localhost/explore/Human-GEM/gem-browser/metabolite/m00016m
The external database `MetaNetX` should have two records 

2. http://localhost/explore/Human-GEM/gem-browser/gene/ENSG00000000419
The external database `Ensembl protein` should have four records (with the new TSV database) 
