### PR TITLE
fix: only show ChEBI image div if ChEBI image exist MA-943

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -67,7 +67,7 @@
               </div>
               <ExtIdTable :type="type" :external-dbs="metabolite.externalDbs"></ExtIdTable>
             </div>
-            <div v-if="metabolite && metabolite.externalDbs && metabolite.externalDbs.ChEBI"
+            <div v-if="chebiImagePresent"
                  class="column is-3-widescreen is-2-desktop is-full-tablet has-text-centered px-2">
               <a :href="metabolite.externalDbs.ChEBI[0].url" target="_blank">
                 <img id="chebi-img" :src="`https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${metabolite.externalDbs.ChEBI[0].id.slice(6)}&dimensions=400`" class="hoverable" />
@@ -97,6 +97,7 @@
 </template>
 
 <script>
+import axios from 'axios';
 import { mapState } from 'vuex';
 import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
 import ReactionTable from '@/components/explorer/gemBrowser/ReactionTable';
@@ -138,6 +139,7 @@ export default {
       showLoaderMessage: '',
       modelNotFound: false,
       messages,
+      chebiImagePresent: false,
     };
   },
   computed: {
@@ -166,6 +168,10 @@ export default {
         const payload = { model: this.model, id: this.metaboliteId };
         await this.$store.dispatch('metabolites/getMetaboliteData', payload);
         this.componentNotFound = false;
+        if (this.metabolite.externalDbs.ChEBI) {
+          const { data } = await axios.get(`https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${this.metabolite.externalDbs.ChEBI[0].id.slice(6)}`);
+          this.chebiImagePresent = data !== '';
+        }
         this.showLoaderMessage = '';
         await this.getRelatedMetabolites();
       } catch {

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -67,10 +67,10 @@
               </div>
               <ExtIdTable :type="type" :external-dbs="metabolite.externalDbs"></ExtIdTable>
             </div>
-            <div v-if="chebiImagePresent"
+            <div v-if="chebiImageLink"
                  class="column is-3-widescreen is-2-desktop is-full-tablet has-text-centered px-2">
               <a :href="metabolite.externalDbs.ChEBI[0].url" target="_blank">
-                <img id="chebi-img" :src="`https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${metabolite.externalDbs.ChEBI[0].id.slice(6)}&dimensions=400`" class="hoverable" />
+                <img id="chebi-img" :src="chebiImageLink" class="hoverable" />
                 <a :href="metabolite.externalDbs.ChEBI[0].url" target="_blank" style="display: block;">
                   {{ metabolite.name }} via ChEBI</a>
               </a>
@@ -139,7 +139,7 @@ export default {
       showLoaderMessage: '',
       modelNotFound: false,
       messages,
-      chebiImagePresent: false,
+      chebiImageLink: null,
     };
   },
   computed: {
@@ -169,8 +169,11 @@ export default {
         await this.$store.dispatch('metabolites/getMetaboliteData', payload);
         this.componentNotFound = false;
         if (this.metabolite.externalDbs.ChEBI) {
-          const { data } = await axios.get(`https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${this.metabolite.externalDbs.ChEBI[0].id.slice(6)}`);
-          this.chebiImagePresent = data !== '';
+          const link = `https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${this.metabolite.externalDbs.ChEBI[0].id.slice(6)}`;
+          const { data } = await axios.get(link);
+          if (data !== '') {
+            this.chebiImageLink = `${link}&dimensions=400`;
+          }
         }
         this.showLoaderMessage = '';
         await this.getRelatedMetabolites();


### PR DESCRIPTION
Issue #583

Fix so no broken ChEBI images are shown

Examples:
With image
http://localhost/explore/Human-GEM/gem-browser/metabolite/CE5122_p

With broken image
http://localhost/explore/Human-GEM/gem-browser/metabolite/m02576c

With no ChEBI entry at all
http://localhost/explore/Human-GEM/gem-browser/metabolite/m02865c

Please see if the ChEBI image check is placed suitably in method setup() (line165), and that there are no undesired side effects such as slow response time