### PR TITLE
fix: messy sizing of the IP button MA-942

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -18,7 +18,7 @@
         <div v-else class="columns">
           <div class="column">
             <div class="columns is-multiline is-variable is-8">
-              <div id="gene-details" class="reaction-table column is-10-widescreen is-9-desktop is-full-tablet">
+              <div id="gene-details" class="reaction-table column is-9-widescreen is-9-desktop is-full-tablet">
                 <div class="table-contaner">
                   <table v-if="gene && Object.keys(gene).length !== 0" class="table main-table is-fullwidth">
                     <tr v-for="el in mainTableKey" :key="el.name">
@@ -44,7 +44,7 @@
                 </div>
                 <ExtIdTable :type="type" :external-dbs="gene.externalDbs"></ExtIdTable>
               </div>
-              <div class="column is-2-widescreen is-3-desktop is-full-tablet has-text-centered">
+              <div class="column is-3-widescreen is-3-desktop is-full-tablet has-text-centered">
                 <router-link v-if="model && gene.id" class="button is-info is-fullwidth is-outlined"
                              :to="{ name: 'interaction', params: { model: model.short_name, id: gene.id } }">
                   <span class="icon"><i class="fa fa-connectdevelop fa-lg"></i></span>&nbsp;

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -75,7 +75,7 @@
                   {{ metabolite.name }} via ChEBI</a>
               </a>
             </div>
-            <div class="column is-2-widescreen is-3-desktop is-full-tablet has-text-centered">
+            <div class="column is-3-widescreen is-3-desktop is-full-tablet has-text-centered">
               <router-link v-if="model" class="button is-info is-fullwidth is-outlined"
                            :to="{ name: 'interaction',
                                   params: { model: model.short_name, id: metaboliteId } }">


### PR DESCRIPTION
This PR closes the issue #582 

DoD: the text of the button Interaction Partners should be within the frame when resizing the window size for the Genes page and Metabolites page.

Examples for testing: 
http://localhost:9080/explore/Human-GEM/gem-browser/gene/ENSG00000140905  (Genes page)
http://localhost:9080/explore/Human-GEM/gem-browser/metabolite/m02899m         (Metabolites page with ChEBI image) 
http://localhost:9080/explore/Human-GEM/gem-browser/metabolite/m02576c          (Metabolites page without ChEBI image)

Tested web-browser: Firefox, Safari and Chrome.
