### PR TITLE
fix: ftp server access

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,6 +9,9 @@ NEO4J_PASSWORD=password-unhackable
 FTP_MIN_PORT=30000
 FTP_MAX_PORT=31000
 
+# change this to the IP of the FTP server
+FTP_IP=127.0.0.1
+
 PORT_NGINX=80
 PORT_FRONTEND=81
 PORT_NEO4J_1=7474

--- a/.env.sample
+++ b/.env.sample
@@ -1,20 +1,36 @@
-CERTBOT_EMAIL=
-SERVER_NAME=localhost
+## The variables below are required for the production enviroment.
+## Some might be also required for the local environment.
+
+# These paths are needed to use code and files from other
+# repositories (dependencies).
 DATA_FILES_PATH=../data-files
 DATA_GENERATOR_PATH=../neo4j-data-generation
 
+# These variables are needed to obtain the SSL certificate from Let's Encrypt.
+CERTBOT_EMAIL=
+SERVER_NAME=localhost
+
+# These variables are used by Neo4j.
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password-unhackable
 
+# The variables below control the port range for the FTP connections.
 FTP_MIN_PORT=30000
 FTP_MAX_PORT=31000
 
-# change this to the IP of the FTP server
+# Change this to the IP of the FTP server. For the local setup, the
+# IP 127.0.0.1 is hard-coded in docker-compose-local.yml.
 FTP_IP=127.0.0.1
+
+# This variable holds the Nginx IP filter
+IP_FILTER="allow 129.16.0.0/16; allow 130.238.0.0/16; deny all;"
+
+
+## All the variables below concern only the local environment
+## and do not need to be configured, as default values are provided
+## in docker-compose-local.yml
 
 PORT_NGINX=80
 PORT_FRONTEND=81
 PORT_NEO4J_1=7474
 PORT_NEO4J_2=7687
-
-IP_FILTER="allow 129.16.0.0/16; allow 130.238.0.0/16; deny all;"

--- a/.gitignore
+++ b/.gitignore
@@ -35,9 +35,6 @@ Temporary Items
 *.sublime-workspace
 *.sublime-project
 
-# sftp configuration file
-sftp-config.json
-
 # Package control specific files
 Package Control.last-run
 Package Control.ca-list

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -47,4 +47,5 @@ services:
 
   ftp:
     environment:
+      - FTP_IP=127.0.0.1
       - FLAGS=-Y 0 -d -d

--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -57,6 +57,7 @@ services:
 
   ftp:
     environment:
+      - FTP_IP=${FTP_IP}
       - FLAGS=-Y 1
     volumes:
       - letsencrypt:/etc/letsencrypt:ro

--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -255,7 +255,7 @@ export default {
   data() {
     return {
       multipleColors,
-      ftpUrl: 'metabolicatlas.org',
+      ftpUrl: 'ftp.metabolicatlas.org',
     };
   },
 };

--- a/ftp/Dockerfile
+++ b/ftp/Dockerfile
@@ -6,4 +6,4 @@ RUN useradd -d /var/ftp -s /sbin/nologin ftp
 COPY ./prep-cert.sh /project/prep-cert.sh
 RUN chmod +x /project/prep-cert.sh
 
-CMD /project/prep-cert.sh && /run.sh pure-ftpd -4 -A -c 50 -C 5 -e -G -H -i -p $FTP_MIN_PORT:$FTP_MAX_PORT -P $PUBLICHOST -r -R -s -X -x -Z $FLAGS
+CMD /project/prep-cert.sh && /run.sh pure-ftpd -4 -A -c 50 -C 5 -e -G -H -i -p $FTP_MIN_PORT:$FTP_MAX_PORT -P 129.16.69.158 -r -R -s -X -x -Z $FLAGS

--- a/ftp/Dockerfile
+++ b/ftp/Dockerfile
@@ -6,4 +6,4 @@ RUN useradd -d /var/ftp -s /sbin/nologin ftp
 COPY ./prep-cert.sh /project/prep-cert.sh
 RUN chmod +x /project/prep-cert.sh
 
-CMD /project/prep-cert.sh && /run.sh pure-ftpd -4 -A -c 50 -C 5 -e -G -H -i -p $FTP_MIN_PORT:$FTP_MAX_PORT $FTP_IP -P 129.16.69.158 -r -R -s -X -x -Z $FLAGS
+CMD /project/prep-cert.sh && /run.sh pure-ftpd -4 -A -c 50 -C 5 -e -G -H -i -p $FTP_MIN_PORT:$FTP_MAX_PORT -P $FTP_IP -r -R -s -X -x -Z $FLAGS

--- a/ftp/Dockerfile
+++ b/ftp/Dockerfile
@@ -6,4 +6,4 @@ RUN useradd -d /var/ftp -s /sbin/nologin ftp
 COPY ./prep-cert.sh /project/prep-cert.sh
 RUN chmod +x /project/prep-cert.sh
 
-CMD /project/prep-cert.sh && /run.sh pure-ftpd -4 -A -c 50 -C 5 -e -G -H -i -p $FTP_MIN_PORT:$FTP_MAX_PORT -P 129.16.69.158 -r -R -s -X -x -Z $FLAGS
+CMD /project/prep-cert.sh && /run.sh pure-ftpd -4 -A -c 50 -C 5 -e -G -H -i -p $FTP_MIN_PORT:$FTP_MAX_PORT $FTP_IP -P 129.16.69.158 -r -R -s -X -x -Z $FLAGS


### PR DESCRIPTION
This PR closes #595 by using a dedicated subdomain for the ftp server, in order to set it as unproxied in the DNS settings. Moreover, since this changes the FTP host name, it was replaced by the IP of the VM. The fix was deployed and has been verified.
Potentially one could use a variable for this, but then this variable would have to be used both in Vue and in the Dockerfile.