### PR TITLE
feat: 2D map coverage MA-784

### DIFF
--- a/api/src/neo4j/queries/map.js
+++ b/api/src/neo4j/queries/map.js
@@ -17,6 +17,11 @@ CALL apoc.cypher.run("
   RETURN { id: $cid, reactionCount: COUNT(DISTINCT(r)) } as data
   
   UNION
+
+  MATCH (:Compartment${m} {id: $cid})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)
+  RETURN { id: $cid, reactionList: COLLECT(DISTINCT(r.id)) } as data
+  
+  UNION
   
   MATCH (csvg:SvgMap)-[${v}]-(:Compartment${m} {id: $cid})
   RETURN { id: $cid, svgs: COLLECT(DISTINCT(csvg {.*})) } as data

--- a/api/src/neo4j/queries/map.js
+++ b/api/src/neo4j/queries/map.js
@@ -41,6 +41,11 @@ CALL apoc.cypher.run("
   
   MATCH (:Subsystem${m} {id: $sid})-[${v}]-(r:Reaction)
   RETURN { id: $sid, reactionCount: COUNT(DISTINCT(r)) } as data
+
+  UNION
+  
+  MATCH (:Subsystem${m} {id: $sid})-[${v}]-(r:Reaction)
+  RETURN { id: $sid, reactionList: COLLECT(DISTINCT(r.id)) } as data
   
   UNION
   

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -56,7 +56,7 @@
             </select>
           </div>
         </div>
-        <p>{{dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data'}}</p>
+        <p>{{ dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data' }}</p>
         <div class="control">
           <div class="select is-fullwidth">
             <select
@@ -85,7 +85,7 @@
             </select>
           </div>
         </div>
-        <div>{{dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data'}}</div>
+        <div>{{ dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data' }}</div>
         <div class="control">
           <div class="select is-fullwidth">
             <select

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -11,7 +11,7 @@
            class="card-content p-4 sidebarCardHover">
         <div class="content mb-0" @click="showModal = true">
           Please note that {{ missingReactionList.length }}
-          of the reactions in the model are not shown on the map
+          of the reactions in the {{ currentMap.type }} are not shown on the map
           <span class="icon"><i class="fa fa-info-circle"></i></span>
         </div>
         <div v-if="showModal" class="modal is-active">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -8,11 +8,11 @@
         </p>
       </header>
       <div v-if="currentMap.reactionList && missingReactionList.length > 0"
-           class="card-content p-4 sidebarCardHover">
-        <div class="content mb-0" @click="showModal = true">
+           class="card-content p-4">
+        <div class="content mb-0">
           Please note that {{ missingReactionList.length }}
-          of the reactions in the {{ currentMap.type }} are not shown on the map
-          <span class="icon"><i class="fa fa-info-circle"></i></span>
+          of the reactions in the {{ currentMap.type }} are not shown on the map.
+          <a @click="showModal = true"> See comparison </a>
         </div>
         <div v-if="showModal" class="modal is-active">
           <div class="modal-background" @click="closeModal"></div>
@@ -303,10 +303,5 @@ export default {
     .loading .button {
       width: 100%;
     }
-  }
-
-  .sidebarCardHover:hover {
-    background: rgba(51,68,109,.03);
-    cursor: pointer;
   }
 </style>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -8,70 +8,70 @@
         </p>
       </header>
       <div v-if="currentMap.reactionList && missingReactionList.length > 0"
-      class="card-content p-4 sidebarCardHover">
+           class="card-content p-4 sidebarCardHover">
         <div class="content mb-0" @click="showModal = true">
           Please note that {{ missingReactionList.length }}
           of the reactions in the model are not shown on the map
           <span class="icon"><i class="fa fa-info-circle"></i></span>
-      </div>
-      <div>
-        <div v-if="showModal" class="modal is-active">
-          <div class="modal-background" @click="closeModal"></div>
-          <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
+        </div>
+        <div>
+          <div v-if="showModal" class="modal is-active">
+            <div class="modal-background" @click="closeModal"></div>
+            <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
             has-background-white">
-            <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
-            <p class="pb-4"> There are {{ missingReactionList.length }}
+              <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
+              <p class="pb-4"> There are {{ missingReactionList.length }}
                 reactions not shown on the map as compared to the model since
                 the map is manually curated and some reactions are not possible
                 to add to the map. The number of reaction shown on the map is
                 {{ mapReactionList.length }}.
-            </p>
-            <table class="table main-table is-fullwidth m-0">
-              <tbody>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis" >Missing reactions on the map</td>
-                  <td>
-                    <div v-html="missingReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionListMissing &&  missingReactionList.length > displayedReaction">
-                      <br>
-                      <button class="is-small button" @click="showFullReactionListMissing=true">
-                        ... and {{ missingReactionList.length - displayedReaction }} more
-                      </button>
-                      <span v-show="missingReactionList.length >= limitReaction"
-                            class="tag is-medium is-warning is-pulled-right">
-                        The number of reactions displayed is limited to {{ limitReaction }}
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
-                  <td>
-                    <div v-html="mapReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionListMap &&  mapReactionList.length > displayedReaction">
-                      <br>
-                      <button class="is-small button" @click="showFullReactionListMap=true">
-                        ... and {{ mapReactionList.length - displayedReaction }} more
-                      </button>
-                      <span v-show="mapReactionList.length >= limitReaction"
-                            class="tag is-medium is-warning is-pulled-right">
-                        The number of reactions displayed is limited to {{ limitReaction }}
-                      </span>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
+              </p>
+              <table class="table main-table is-fullwidth m-0">
+                <tbody>
+                  <tr>
+                    <td class="td-key has-background-primary has-text-white-bis">Missing reactions on the map</td>
+                    <td>
+                      <div v-html="missingReactionIdListHtml"></div>
+                      <div v-if="!showFullReactionListMissing && missingReactionList.length > displayedReaction">
+                        <br>
+                        <button class="is-small button" @click="showFullReactionListMissing=true">
+                          ... and {{ missingReactionList.length - displayedReaction }} more
+                        </button>
+                        <span v-show="missingReactionList.length >= limitReaction"
+                              class="tag is-medium is-warning is-pulled-right">
+                          The number of reactions displayed is limited to {{ limitReaction }}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                  <tr>
+                    <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
+                    <td>
+                      <div v-html="mapReactionIdListHtml"></div>
+                      <div v-if="!showFullReactionListMap && mapReactionList.length > displayedReaction">
+                        <br>
+                        <button class="is-small button" @click="showFullReactionListMap=true">
+                          ... and {{ mapReactionList.length - displayedReaction }} more
+                        </button>
+                        <span v-show="mapReactionList.length >= limitReaction"
+                              class="tag is-medium is-warning is-pulled-right">
+                          The number of reactions displayed is limited to {{ limitReaction }}
+                        </span>
+                      </div>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+            <button class="modal-close is-large" @click="closeModal"></button>
           </div>
-          <button class="modal-close is-large" @click="closeModal"></button>
         </div>
+
+
       </div>
-
-
-    </div>
       <footer v-if="currentMap.type !== 'custom'" class="card-footer sidebarCardHover">
         <router-link class="p-0 is-info is-outlined card-footer-item has-text-centered"
-                    :to="{ name: currentMap.type, params: { model: model.short_name, id: currentMap.id } }">  <!-- eslint-disable-line max-len -->
+                     :to="{ name: currentMap.type, params: { model: model.short_name, id: currentMap.id } }">  <!-- eslint-disable-line max-len -->
           <span class="icon is-large"><i class="fa fa-table fa-lg"></i></span>
           <span>{{ messages.gemBrowserName }}</span>
         </router-link>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -7,18 +7,20 @@
           <i>{{ currentMap.name }}</i>
         </p>
       </header>
+      <div class="card-content p-4">
+        <div class="content">
+          <p v-if="modelNumberOfReactions">
+          <span>Reaction coverage:</span> {{ mapNumberOfReactions }}
+          out of {{ modelNumberOfReactions }} reactions are on the map </p>
+        <p v-else class="has-text-centered"> Reaction coverage not available </p>
+      </div>
+    </div>
       <footer v-if="currentMap.type !== 'custom'" class="card-footer">
         <router-link class="p-0 is-info is-outlined card-footer-item has-text-centered"
                     :to="{ name: currentMap.type, params: { model: model.short_name, id: currentMap.id } }">  <!-- eslint-disable-line max-len -->
           <span class="icon is-large"><i class="fa fa-table fa-lg"></i></span>
           <span>{{ messages.gemBrowserName }}</span>
         </router-link>
-      </footer>
-      <footer class="card-footer">
-        <p v-if="modelNumberOfReactions" class="p-0 pr-3 card-footer-item has-text-centered">
-          <b>Reaction coverage:</b> {{ mapNumberOfReactions }} out of {{ modelNumberOfReactions }}
-          reactions is on the map </p>
-        <p v-else class="p-0 pr-3 card-footer-item has-text-centered"> Reaction coverage not available </p>
       </footer>
     </div>
     <template v-if="loading">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -10,8 +10,8 @@
       <div v-if="currentMap.reactionList && mapReactionList.length !== modelNumberOfReactions"
       class="card-content p-4 sidebarCardHover">
         <div class="content mb-0" @click="showModal = true">
-          Please note that only {{ mapReactionList.length }}
-          out of {{ modelNumberOfReactions }} reactions are shown on the map
+          Please note that {{ missingReactionList.length }}
+          of the reactions in the model are not shown on the map
       </div>
       <div>
         <div v-if="showModal" class="modal is-active">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -36,10 +36,6 @@
                       <button class="is-small button" @click="showFullReactionListMissing=true">
                         ... and {{ missingReactionList.length - displayedReaction }} more
                       </button>
-                      <span v-show="missingReactionList.length >= limitReaction"
-                            class="tag is-medium is-warning is-pulled-right">
-                        The number of reactions displayed is limited to {{ limitReaction }}
-                      </span>
                     </div>
                   </td>
                 </tr>
@@ -52,10 +48,6 @@
                       <button class="is-small button" @click="showFullReactionListMap=true">
                         ... and {{ mapReactionList.length - displayedReaction }} more
                       </button>
-                      <span v-show="mapReactionList.length >= limitReaction"
-                            class="tag is-medium is-warning is-pulled-right">
-                        The number of reactions displayed is limited to {{ limitReaction }}
-                      </span>
                     </div>
                   </td>
                 </tr>
@@ -222,7 +214,6 @@ export default {
       showFullReactionListMissing: false,
       showFullReactionListMap: false,
       displayedReaction: 40,
-      limitReaction: 999999999,
       missingNumberOfReactions: null,
     };
   },
@@ -239,8 +230,7 @@ export default {
       const l = ['<span class="tags">'];
       for (let i = 0; i < this.mapReactionList.length; i += 1) {
         const r = this.mapReactionList[i];
-        if ((!this.showFullReactionListMap && i === this.displayedReaction)
-          || i === this.limitReaction) {
+        if (!this.showFullReactionListMap && i === this.displayedReaction) {
           break;
         }
         const customLink = buildCustomLink({ model: this.model.short_name, type: 'reaction', id: r, title: r, cssClass: 'target="_blank"' });
@@ -262,8 +252,7 @@ export default {
       const l = ['<span class="tags">'];
       for (let i = 0; i < this.missingReactionList.length; i += 1) {
         const r = this.missingReactionList[i];
-        if ((!this.showFullReactionListMissing && i === this.displayedReaction)
-          || i === this.limitReaction) {
+        if (!this.showFullReactionListMissing && i === this.displayedReaction) {
           break;
         }
         const customLink = buildCustomLink({ model: this.model.short_name, type: 'reaction', id: r, title: r, cssClass: 'target="_blank"' });

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -17,11 +17,17 @@
       <div>
         <div v-if="showModal" class="modal is-active">
           <div class="modal-background"></div>
-          <div class="modal-content">
-            <div class="box">
-              <table class="table main-table is-fullwidth m-0">
+          <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
+            has-background-white">
+            <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions </h4>
+            <p class="pb-4"> The map only displays {{ mapReactionList.length }} out of the
+              {{ modelNumberOfReactions }} reactions in the model since the map is manually
+              curated and some reactions are not possible to add to the map
+            </p>
+            <table class="table main-table is-fullwidth m-0">
+              <tbody>
                 <tr>
-                  <td class="td-key has-background-primary has-text-white-bis" >Missing reactionIDs on the map</td>
+                  <td class="td-key has-background-primary has-text-white-bis" >Missing reactions on the map</td>
                   <td>
                     <div v-html="missingReactionIdListHtml"></div>
                     <div v-if="!showFullReactionListMissing &&  modelNumberOfReactions > displayedReaction">
@@ -37,7 +43,7 @@
                   </td>
                 </tr>
                 <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">All reactionIDs in the model</td>
+                  <td class="td-key has-background-primary has-text-white-bis">All reactions in the model</td>
                     <div v-html="totalReactionIdListHtml"></div>
                     <div v-if="!showFullReactionListTotal &&  modelNumberOfReactions > displayedReaction">
                       <br>
@@ -51,8 +57,8 @@
                     </div>
                   <td></td>
                 </tr>
-              </table>
-            </div>
+              </tbody>
+            </table>
           </div>
           <button class="modal-close" @click="closeModal"></button>
         </div>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -19,11 +19,11 @@
           <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
           has-background-white">
             <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
-            <p class="pb-4"> There are {{ missingReactionList.length }}
-              reactions not shown on the map as compared to the model since
-              the map is manually curated and some reactions are not possible
-              to add to the map. The number of reaction shown on the map is
-              {{ mapReactionList.length }}.
+            <p class="pb-4">
+             There are {{ missingReactionList.length }} reactions not shown on the map. Some reactions
+             are missing as the {{ currentMap.type }} is being updated much more often than the maps.
+             Also, as the maps are manually curated, occasionally some reactions are cannot be added.
+             The number of reactions shown are {{ mapReactionList.length }}.
             </p>
             <table class="table main-table is-fullwidth m-0">
               <tbody>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -220,7 +220,7 @@ export default {
       messages,
       showModal: false,
       showFullReactionListMissing: false,
-      showFullReactionListTotal: false,
+      showFullReactionListMap: false,
       displayedReaction: 40,
       limitReaction: 999999999,
       missingNumberOfReactions: null,

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -43,6 +43,7 @@
                 </tr>
                 <tr>
                   <td class="td-key has-background-primary has-text-white-bis">All reactions in the model</td>
+                  <td>
                     <div v-html="totalReactionIdListHtml"></div>
                     <div v-if="!showFullReactionListTotal &&  modelNumberOfReactions > displayedReaction">
                       <br>
@@ -54,7 +55,7 @@
                         The number of reactions displayed is limited to {{ limitReaction }}
                       </span>
                     </div>
-                  <td></td>
+                  </td>
                 </tr>
               </tbody>
             </table>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -16,7 +16,7 @@
       </div>
       <div>
         <div v-if="showModal" class="modal is-active">
-          <div class="modal-background"></div>
+          <div class="modal-background" @click="closeModal"></div>
           <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
             has-background-white">
             <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
@@ -63,7 +63,7 @@
               </tbody>
             </table>
           </div>
-          <button class="modal-close" @click="closeModal"></button>
+          <button class="modal-close is-large" @click="closeModal"></button>
         </div>
       </div>
 

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -9,10 +9,16 @@
       </header>
       <footer v-if="currentMap.type !== 'custom'" class="card-footer">
         <router-link class="p-0 is-info is-outlined card-footer-item has-text-centered"
-                     :to="{ name: currentMap.type, params: { model: model.short_name, id: currentMap.id } }">  <!-- eslint-disable-line max-len -->
+                    :to="{ name: currentMap.type, params: { model: model.short_name, id: currentMap.id } }">  <!-- eslint-disable-line max-len -->
           <span class="icon is-large"><i class="fa fa-table fa-lg"></i></span>
           <span>{{ messages.gemBrowserName }}</span>
         </router-link>
+      </footer>
+      <footer class="card-footer">
+        <p v-if="modelNumberOfReactions" class="p-0 pr-3 card-footer-item has-text-centered">
+          <b>Reaction coverage:</b> {{ mapNumberOfReactions }} out of {{ modelNumberOfReactions }}
+          reactions is on the map </p>
+        <p v-else class="p-0 pr-3 card-footer-item has-text-centered"> Reaction coverage not available </p>
       </footer>
     </div>
     <template v-if="loading">
@@ -166,7 +172,11 @@ export default {
     ...mapState({
       model: state => state.models.model,
       loading: state => state.maps.loadingElement,
+      mapNumberOfReactions: state => state.maps.mapNumberOfReactions,
     }),
+    modelNumberOfReactions() {
+      return this.currentMap.reactionList ? this.currentMap.reactionList.length : null;
+    },
   },
   methods: {
     selectionHasNoData() {

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -24,9 +24,9 @@
                   <td class="td-key has-background-primary has-text-white-bis" >Missing reactionIDs on the map</td>
                   <td>
                     <div v-html="missingReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionList &&  modelNumberOfReactions > displayedReaction">
+                    <div v-if="!showFullReactionListMissing &&  modelNumberOfReactions > displayedReaction">
                       <br>
-                      <button class="is-small button" @click="showFullReactionList=true">
+                      <button class="is-small button" @click="showFullReactionListMissing=true">
                         ... and {{ missingReactionList.length - displayedReaction }} more
                       </button>
                       <span v-show="missingReactionList.length >= limitReaction"
@@ -39,9 +39,9 @@
                 <tr>
                   <td class="td-key has-background-primary has-text-white-bis">All reactionIDs in the model</td>
                     <div v-html="totalReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionList &&  modelNumberOfReactions > displayedReaction">
+                    <div v-if="!showFullReactionListTotal &&  modelNumberOfReactions > displayedReaction">
                       <br>
-                      <button class="is-small button" @click="showFullReactionList=true">
+                      <button class="is-small button" @click="showFullReactionListTotal=true">
                         ... and {{ modelNumberOfReactions - displayedReaction }} more
                       </button>
                       <span v-show="modelNumberOfReactions >= limitReaction"
@@ -54,7 +54,7 @@
               </table>
             </div>
           </div>
-          <button class="modal-close" @click="showModal = false"></button>
+          <button class="modal-close" @click="closeModal"></button>
         </div>
       </div>
 
@@ -214,7 +214,8 @@ export default {
       showSelectionCardContent: true,
       messages,
       showModal: false,
-      showFullReactionList: false,
+      showFullReactionListMissing: false,
+      showFullReactionListTotal: false,
       displayedReaction: 40,
       limitReaction: 999999999,
       missingNumberOfReactions: null,
@@ -233,7 +234,7 @@ export default {
       const l = ['<span class="tags">'];
       for (let i = 0; i < this.modelNumberOfReactions; i += 1) {
         const r = this.currentMap.reactionList[i];
-        if ((!this.showFullReactionList && i === this.displayedReaction)
+        if ((!this.showFullReactionListTotal && i === this.displayedReaction)
           || i === this.limitReaction) {
           break;
         }
@@ -256,7 +257,7 @@ export default {
       const l = ['<span class="tags">'];
       for (let i = 0; i < this.missingReactionList.length; i += 1) {
         const r = this.missingReactionList[i];
-        if ((!this.showFullReactionList && i === this.displayedReaction)
+        if ((!this.showFullReactionListMissing && i === this.displayedReaction)
           || i === this.limitReaction) {
           break;
         }
@@ -290,6 +291,11 @@ export default {
     reformatStringToLink,
     chemicalFormula,
     reformatChemicalReactionHTML,
+    closeModal() {
+      this.showModal = false;
+      this.showFullReactionListMissing = false;
+      this.showFullReactionListTotal = false;
+    },
   },
 };
 </script>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -9,10 +9,9 @@
       </header>
       <div v-if="currentMap.reactionList && mapReactionList.length !== modelNumberOfReactions"
       class="card-content p-4 sidebarCardHover">
-        <div class="content" @click="showModal = true">
-          <modal v-show="showModal" @close="showModal = false"></modal>
-          <p> Please note that only {{ mapReactionList.length }}
-          out of {{ modelNumberOfReactions }} reactions are shown on the map </p>
+        <div class="content mb-0" @click="showModal = true">
+          Please note that only {{ mapReactionList.length }}
+          out of {{ modelNumberOfReactions }} reactions are shown on the map
       </div>
       <div>
         <div v-if="showModal" class="modal is-active">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -7,15 +7,13 @@
           <i>{{ currentMap.name }}</i>
         </p>
       </header>
-      <div class="card-content p-4">
+      <div v-if="currentMap.reactionList && mapReactionList.length !== modelNumberOfReactions"
+      class="card-content p-4 sidebarCardHover">
         <div class="content" @click="showModal = true">
           <modal v-show="showModal" @close="showModal = false"></modal>
-          <p v-if="currentMap.reactionList">
-          <span>Reaction coverage:</span> {{ mapReactionList.length }}
-          out of {{ modelNumberOfReactions }} reactions are on the map </p>
-        <p v-else class="has-text-centered"> Reaction coverage not available </p>
+          <p> Please note that only {{ mapReactionList.length }}
+          out of {{ modelNumberOfReactions }} reactions are shown on the map </p>
       </div>
-
       <div>
         <div v-if="showModal" class="modal is-active">
           <div class="modal-background"></div>
@@ -62,7 +60,7 @@
 
 
     </div>
-      <footer v-if="currentMap.type !== 'custom'" class="card-footer">
+      <footer v-if="currentMap.type !== 'custom'" class="card-footer sidebarCardHover">
         <router-link class="p-0 is-info is-outlined card-footer-item has-text-centered"
                     :to="{ name: currentMap.type, params: { model: model.short_name, id: currentMap.id } }">  <!-- eslint-disable-line max-len -->
           <span class="icon is-large"><i class="fa fa-table fa-lg"></i></span>
@@ -305,5 +303,10 @@ export default {
     .loading .button {
       width: 100%;
     }
+  }
+
+  .sidebarCardHover:hover {
+    background: rgba(51,68,109,.03);
+    cursor: pointer;
   }
 </style>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -18,10 +18,12 @@
           <div class="modal-background"></div>
           <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
             has-background-white">
-            <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions </h4>
-            <p class="pb-4"> The map only displays {{ mapReactionList.length }} out of the
-              {{ modelNumberOfReactions }} reactions in the model since the map is manually
-              curated and some reactions are not possible to add to the map
+            <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
+            <p class="pb-4"> There are {{ missingReactionList.length }}
+                reactions not shown on the map as compared to the model since
+                the map is manually curated and some reactions are not possible
+                to add to the map. The number of reaction shown on the map is
+                {{ mapReactionList.length }}.
             </p>
             <table class="table main-table is-fullwidth m-0">
               <tbody>
@@ -29,7 +31,7 @@
                   <td class="td-key has-background-primary has-text-white-bis" >Missing reactions on the map</td>
                   <td>
                     <div v-html="missingReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionListMissing &&  modelNumberOfReactions > displayedReaction">
+                    <div v-if="!showFullReactionListMissing &&  missingReactionList.length > displayedReaction">
                       <br>
                       <button class="is-small button" @click="showFullReactionListMissing=true">
                         ... and {{ missingReactionList.length - displayedReaction }} more
@@ -42,15 +44,15 @@
                   </td>
                 </tr>
                 <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">All reactions in the model</td>
+                  <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
                   <td>
-                    <div v-html="totalReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionListTotal &&  modelNumberOfReactions > displayedReaction">
+                    <div v-html="mapReactionIdListHtml"></div>
+                    <div v-if="!showFullReactionListMap &&  mapReactionList.length > displayedReaction">
                       <br>
-                      <button class="is-small button" @click="showFullReactionListTotal=true">
-                        ... and {{ modelNumberOfReactions - displayedReaction }} more
+                      <button class="is-small button" @click="showFullReactionListMap=true">
+                        ... and {{ mapReactionList.length - displayedReaction }} more
                       </button>
-                      <span v-show="modelNumberOfReactions >= limitReaction"
+                      <span v-show="mapReactionList.length >= limitReaction"
                             class="tag is-medium is-warning is-pulled-right">
                         The number of reactions displayed is limited to {{ limitReaction }}
                       </span>
@@ -236,11 +238,11 @@ export default {
     modelNumberOfReactions() {
       return this.currentMap.reactionList ? this.currentMap.reactionList.length : null;
     },
-    totalReactionIdListHtml() {
+    mapReactionIdListHtml() {
       const l = ['<span class="tags">'];
-      for (let i = 0; i < this.modelNumberOfReactions; i += 1) {
-        const r = this.currentMap.reactionList[i];
-        if ((!this.showFullReactionListTotal && i === this.displayedReaction)
+      for (let i = 0; i < this.mapReactionList.length; i += 1) {
+        const r = this.mapReactionList[i];
+        if ((!this.showFullReactionListMap && i === this.displayedReaction)
           || i === this.limitReaction) {
           break;
         }
@@ -300,7 +302,7 @@ export default {
     closeModal() {
       this.showModal = false;
       this.showFullReactionListMissing = false;
-      this.showFullReactionListTotal = false;
+      this.showFullReactionListMap = false;
     },
   },
 };

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -12,6 +12,7 @@
         <div class="content mb-0" @click="showModal = true">
           Please note that {{ missingReactionList.length }}
           of the reactions in the model are not shown on the map
+          <span class="icon"><i class="fa fa-info-circle"></i></span>
       </div>
       <div>
         <div v-if="showModal" class="modal is-active">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -22,7 +22,7 @@
             <p class="pb-4">
               There are {{ missingReactionList.length }} reactions not shown on the map. Some reactions
               are missing as the {{ currentMap.type }} is being updated much more often than the maps.
-              Also, as the maps are manually curated, occasionally some reactions are cannot be added.
+              Also, as the maps are manually curated, occasionally some reactions cannot be added.
               The number of reactions shown are {{ mapReactionList.length }}.
             </p>
             <table class="table main-table is-fullwidth m-0">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -7,7 +7,7 @@
           <i>{{ currentMap.name }}</i>
         </p>
       </header>
-      <div v-if="currentMap.reactionList && mapReactionList.length !== modelNumberOfReactions"
+      <div v-if="currentMap.reactionList && missingReactionList.length > 0"
       class="card-content p-4 sidebarCardHover">
         <div class="content mb-0" @click="showModal = true">
           Please note that {{ missingReactionList.length }}

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -20,10 +20,10 @@
           has-background-white">
             <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
             <p class="pb-4">
-             There are {{ missingReactionList.length }} reactions not shown on the map. Some reactions
-             are missing as the {{ currentMap.type }} is being updated much more often than the maps.
-             Also, as the maps are manually curated, occasionally some reactions are cannot be added.
-             The number of reactions shown are {{ mapReactionList.length }}.
+              There are {{ missingReactionList.length }} reactions not shown on the map. Some reactions
+              are missing as the {{ currentMap.type }} is being updated much more often than the maps.
+              Also, as the maps are manually curated, occasionally some reactions are cannot be added.
+              The number of reactions shown are {{ mapReactionList.length }}.
             </p>
             <table class="table main-table is-fullwidth m-0">
               <tbody>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -14,60 +14,56 @@
           of the reactions in the model are not shown on the map
           <span class="icon"><i class="fa fa-info-circle"></i></span>
         </div>
-        <div>
-          <div v-if="showModal" class="modal is-active">
-            <div class="modal-background" @click="closeModal"></div>
-            <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
-            has-background-white">
-              <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
-              <p class="pb-4"> There are {{ missingReactionList.length }}
-                reactions not shown on the map as compared to the model since
-                the map is manually curated and some reactions are not possible
-                to add to the map. The number of reaction shown on the map is
-                {{ mapReactionList.length }}.
-              </p>
-              <table class="table main-table is-fullwidth m-0">
-                <tbody>
-                  <tr>
-                    <td class="td-key has-background-primary has-text-white-bis">Missing reactions on the map</td>
-                    <td>
-                      <div v-html="missingReactionIdListHtml"></div>
-                      <div v-if="!showFullReactionListMissing && missingReactionList.length > displayedReaction">
-                        <br>
-                        <button class="is-small button" @click="showFullReactionListMissing=true">
-                          ... and {{ missingReactionList.length - displayedReaction }} more
-                        </button>
-                        <span v-show="missingReactionList.length >= limitReaction"
-                              class="tag is-medium is-warning is-pulled-right">
-                          The number of reactions displayed is limited to {{ limitReaction }}
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                  <tr>
-                    <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
-                    <td>
-                      <div v-html="mapReactionIdListHtml"></div>
-                      <div v-if="!showFullReactionListMap && mapReactionList.length > displayedReaction">
-                        <br>
-                        <button class="is-small button" @click="showFullReactionListMap=true">
-                          ... and {{ mapReactionList.length - displayedReaction }} more
-                        </button>
-                        <span v-show="mapReactionList.length >= limitReaction"
-                              class="tag is-medium is-warning is-pulled-right">
-                          The number of reactions displayed is limited to {{ limitReaction }}
-                        </span>
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </table>
-            </div>
-            <button class="modal-close is-large" @click="closeModal"></button>
+        <div v-if="showModal" class="modal is-active">
+          <div class="modal-background" @click="closeModal"></div>
+          <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
+          has-background-white">
+            <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
+            <p class="pb-4"> There are {{ missingReactionList.length }}
+              reactions not shown on the map as compared to the model since
+              the map is manually curated and some reactions are not possible
+              to add to the map. The number of reaction shown on the map is
+              {{ mapReactionList.length }}.
+            </p>
+            <table class="table main-table is-fullwidth m-0">
+              <tbody>
+                <tr>
+                  <td class="td-key has-background-primary has-text-white-bis">Missing reactions on the map</td>
+                  <td>
+                    <div v-html="missingReactionIdListHtml"></div>
+                    <div v-if="!showFullReactionListMissing && missingReactionList.length > displayedReaction">
+                      <br>
+                      <button class="is-small button" @click="showFullReactionListMissing=true">
+                        ... and {{ missingReactionList.length - displayedReaction }} more
+                      </button>
+                      <span v-show="missingReactionList.length >= limitReaction"
+                            class="tag is-medium is-warning is-pulled-right">
+                        The number of reactions displayed is limited to {{ limitReaction }}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
+                  <td>
+                    <div v-html="mapReactionIdListHtml"></div>
+                    <div v-if="!showFullReactionListMap && mapReactionList.length > displayedReaction">
+                      <br>
+                      <button class="is-small button" @click="showFullReactionListMap=true">
+                        ... and {{ mapReactionList.length - displayedReaction }} more
+                      </button>
+                      <span v-show="mapReactionList.length >= limitReaction"
+                            class="tag is-medium is-warning is-pulled-right">
+                        The number of reactions displayed is limited to {{ limitReaction }}
+                      </span>
+                    </div>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
+          <button class="modal-close is-large" @click="closeModal"></button>
         </div>
-
-
       </div>
       <footer v-if="currentMap.type !== 'custom'" class="card-footer sidebarCardHover">
         <router-link class="p-0 is-info is-outlined card-footer-item has-text-centered"

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -153,18 +153,9 @@ export default {
       this.$store.dispatch('maps/setLoading', true);
       const payload = { model: this.model.short_name, svgName: this.mapData.svgs[0].filename };
       await this.$store.dispatch('maps/getSvgMap', payload);
-      const svgWrapper = document.querySelector('#svg-wrapper');
-      const svgReactionsIdList = [];
-      Object.entries(svgWrapper.children).forEach((item) => {
-        const nodesChildren = item[1].children.nodes.children;
-        Object.entries(nodesChildren).forEach((child) => {
-          if (child[1].className.animVal === 'rea') {
-            svgReactionsIdList.push(child[1].id);
-          }
-        });
-      });
-      this.bindKeyboardShortcuts();
+      const svgReactionsIdList = this.getSvgReactionIdList();
       this.$store.dispatch('maps/setMapReactionList', svgReactionsIdList);
+      this.bindKeyboardShortcuts();
     },
     bindKeyboardShortcuts() {
       document.addEventListener('keydown', (event) => {
@@ -539,6 +530,19 @@ export default {
       } else {
         this.panzoom.pan(panX, panY);
       }
+    },
+    getSvgReactionIdList() {
+      const svgWrapper = document.querySelector('#svg-wrapper');
+      const svgReactionsIdList = [];
+      Object.entries(svgWrapper.children).forEach((item) => {
+        const nodesChildren = item[1].children.nodes.children;
+        Object.entries(nodesChildren).forEach((child) => {
+          if (child[1].className.animVal === 'rea') {
+            svgReactionsIdList.push(child[1].id);
+          }
+        });
+      });
+      return svgReactionsIdList;
     },
     reformatChemicalReactionHTML,
   },

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -153,6 +153,16 @@ export default {
       this.$store.dispatch('maps/setLoading', true);
       const payload = { model: this.model.short_name, svgName: this.mapData.svgs[0].filename };
       await this.$store.dispatch('maps/getSvgMap', payload);
+      const svgWrapper = document.querySelector('#svg-wrapper');
+      const svgReactionsIdList = [];
+      Object.entries(svgWrapper.children).forEach((item) => {
+        const nodesChildren = item[1].children.nodes.children;
+        Object.entries(nodesChildren).forEach((child) => {
+          if (child[1].className.animVal === 'rea') {
+            svgReactionsIdList.push(child[1].id);
+          }
+        });
+      });
       this.bindKeyboardShortcuts();
     },
     bindKeyboardShortcuts() {

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -164,7 +164,7 @@ export default {
         });
       });
       this.bindKeyboardShortcuts();
-      this.$store.dispatch('maps/setMapNumberOfReactions', svgReactionsIdList.length);
+      this.$store.dispatch('maps/setMapReactionList', svgReactionsIdList);
     },
     bindKeyboardShortcuts() {
       document.addEventListener('keydown', (event) => {

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -164,6 +164,7 @@ export default {
         });
       });
       this.bindKeyboardShortcuts();
+      this.$store.dispatch('maps/setMapNumberOfReactions', svgReactionsIdList.length);
     },
     bindKeyboardShortcuts() {
       document.addEventListener('keydown', (event) => {

--- a/frontend/src/store/modules/maps.js
+++ b/frontend/src/store/modules/maps.js
@@ -38,7 +38,7 @@ const data = {
   backgroundColor: BG_COLORS.light,
   loading: true,
   loadingElement: false,
-  mapNumberOfReactions: null,
+  svgReactionsIdList: null,
 };
 
 const getters = {
@@ -229,8 +229,8 @@ const actions = {
       commit('setTissue2', null);
     }
   },
-  setMapNumberOfReactions({ commit }, numberOfReactions) {
-    commit('setMapNumberOfReactions', numberOfReactions);
+  setMapReactionList({ commit }, svgReactionsIdList) {
+    commit('setMapReactionList', svgReactionsIdList);
   },
 };
 
@@ -298,8 +298,8 @@ const mutations = {
   setLoadingElement: (state, loadingElement) => {
     state.loadingElement = loadingElement;
   },
-  setMapNumberOfReactions: (state, numberOfReactions) => {
-    state.mapNumberOfReactions = numberOfReactions;
+  setMapReactionList: (state, svgReactionsIdList) => {
+    state.svgReactionsIdList = svgReactionsIdList;
   },
 };
 

--- a/frontend/src/store/modules/maps.js
+++ b/frontend/src/store/modules/maps.js
@@ -38,6 +38,7 @@ const data = {
   backgroundColor: BG_COLORS.light,
   loading: true,
   loadingElement: false,
+  mapNumberOfReactions: null,
 };
 
 const getters = {
@@ -228,6 +229,9 @@ const actions = {
       commit('setTissue2', null);
     }
   },
+  setMapNumberOfReactions({ commit }, numberOfReactions) {
+    commit('setMapNumberOfReactions', numberOfReactions);
+  },
 };
 
 const mutations = {
@@ -293,6 +297,9 @@ const mutations = {
 
   setLoadingElement: (state, loadingElement) => {
     state.loadingElement = loadingElement;
+  },
+  setMapNumberOfReactions: (state, numberOfReactions) => {
+    state.mapNumberOfReactions = numberOfReactions;
   },
 };
 

--- a/frontend/src/store/modules/maps.js
+++ b/frontend/src/store/modules/maps.js
@@ -38,7 +38,7 @@ const data = {
   backgroundColor: BG_COLORS.light,
   loading: true,
   loadingElement: false,
-  svgReactionsIdList: null,
+  svgReactionsIdList: [],
 };
 
 const getters = {


### PR DESCRIPTION
This PR closes  #581

This feature informs if there are missing reactions on the map and provides a detailed list of the missing and total reactions in a popup window.

- [x] use a selector to extract the reactions from the svg
- [x] use (a new?) api endpoint to retrieve all the reaction ids for a compartment or a subsystem
- [x] compare the two sets of the reactions
- [x] show the results of the comparison in the frontend
- [x] have a Show more/Expand button for detailed diff
- [x] make sure the Documentation explains the cause of difference (the maps have been manually add using a previous instance of the model) (Info in popup instead of Documentation)
- [x] use an info icon similar to the Data overlay to link to the relevant section in the Documentation (Info in popup instead of Documentation)

This PR was created by @nanjiangshu  and @inghylt