### PR TITLE
fix: improve cypher query for compartments so they don't get timed out

### DIFF
--- a/api/src/neo4j/queries/compartment.js
+++ b/api/src/neo4j/queries/compartment.js
@@ -11,7 +11,7 @@ CALL apoc.cypher.run("
   
   UNION
     
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(cm:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(ss:SubsystemState)
+  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(ss:SubsystemState)
   USING JOIN on r
   RETURN { subsystems: COLLECT(DISTINCT({id: s.id, name: ss.name})) } as data
   

--- a/api/src/neo4j/queries/compartment.js
+++ b/api/src/neo4j/queries/compartment.js
@@ -11,23 +11,19 @@ CALL apoc.cypher.run("
   
   UNION
     
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(ss:SubsystemState)
+  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(cm:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(ss:SubsystemState)
+  USING JOIN on r
   RETURN { subsystems: COLLECT(DISTINCT({id: s.id, name: ss.name})) } as data
   
   UNION
   
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)
-  RETURN { reactionsCount: COUNT(DISTINCT(r)) ${ full ? ', reactions: COLLECT(DISTINCT(r.id))' : ''}} as data
-  
-  UNION
-  
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(cm:CompartmentalizedMetabolite)
-  RETURN { metabolitesCount: COUNT(DISTINCT(cm)) ${ full ? ', metabolites: COLLECT(DISTINCT(cm.id))' : ''}} as data
-  
-  UNION
-  
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(:Reaction)-[${v}]-(g:Gene)
-  RETURN { genesCount: COUNT(DISTINCT(g)) ${ full ? ', genes: COLLECT(DISTINCT(g.id))' : ''}} as data
+  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(cm:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(g:Gene)
+  USING JOIN on r
+  RETURN {
+    reactionsCount: COUNT(DISTINCT(r)) ${ full ? ', reactions: COLLECT(DISTINCT(r))' : ''},
+    metabolitesCount: COUNT(DISTINCT(cm)) ${ full ? ', metabolites: COLLECT(DISTINCT(cm))' : ''},
+    genesCount: COUNT(DISTINCT(g)) ${ full ? ', genes: COLLECT(DISTINCT(g))' : ''}
+  } as data
   
   UNION
   

--- a/api/src/neo4j/queries/compartment.js
+++ b/api/src/neo4j/queries/compartment.js
@@ -11,22 +11,22 @@ CALL apoc.cypher.run("
   
   UNION
     
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(ss:SubsystemState)
-  USING JOIN on r
-  RETURN { subsystems: COLLECT(DISTINCT({id: s.id, name: ss.name})) } as data
-  
-  UNION
-  
-  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(cm:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(g:Gene)
+  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(cm:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(s:Subsystem)-[${v}]-(ss:SubsystemState)
   USING JOIN on r
   RETURN {
+    subsystems: COLLECT(DISTINCT({id: s.id, name: ss.name})) ,
     reactionsCount: COUNT(DISTINCT(r)) ${ full ? ', reactions: COLLECT(DISTINCT(r))' : ''},
-    metabolitesCount: COUNT(DISTINCT(cm)) ${ full ? ', metabolites: COLLECT(DISTINCT(cm))' : ''},
-    genesCount: COUNT(DISTINCT(g)) ${ full ? ', genes: COLLECT(DISTINCT(g))' : ''}
+    metabolitesCount: COUNT(DISTINCT(cm)) ${ full ? ', metabolites: COLLECT(DISTINCT(cm))' : ''}
   } as data
-  
+
   UNION
   
+  MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)-[${v}]-(g:Gene)
+  USING JOIN on r
+  RETURN { genesCount: COUNT(DISTINCT(g)) ${ full ? ', genes: COLLECT(DISTINCT(g))' : ''} } as data
+
+  UNION
+
   MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(e:ExternalDb)
   RETURN { externalDbs: COLLECT(DISTINCT(e {.*})) } as data
   


### PR DESCRIPTION
This closes #599 

For the compartment `extracellular` in Human-GEM, the response time (when testing locally) decreased from ~27s to ~0.5s. The `cytosol` compartment, which is one of the largest, takes just under 1s now.