### PR TITLE
fix: code ql warnings

### DIFF
--- a/api/src/endpoints/hpaRna.js
+++ b/api/src/endpoints/hpaRna.js
@@ -11,7 +11,7 @@ routes.get('/all', async (req, res) => {
 
     res.json(HPA_JSON);
   } catch (e) {
-    res.status(400).send(e);
+    res.status(400).send(e.message);
   }
 });
 

--- a/api/src/endpoints/neo4j.js
+++ b/api/src/endpoints/neo4j.js
@@ -25,7 +25,6 @@ import {
 } from 'neo4j/index';
 
 const neo4jRoutes = express.Router();
-const CACHED_3D_NETWORKS = {};
 
 const fetchWith = async (req, res, queryHandler) => {
   const { id } = req.params;
@@ -78,32 +77,13 @@ neo4jRoutes.get('/3d-network', async (req, res) => {
   const { model, version, type, id } = req.query;
 
   try {
-    if (!CACHED_3D_NETWORKS[model]) {
-      CACHED_3D_NETWORKS[model] = {};
-    }
-
-    let network;
-
-    if (!CACHED_3D_NETWORKS[model][version]) {
-      CACHED_3D_NETWORKS[model][version] = {};
-    }
+    let payload = { model, version };
 
     if (type && id) {
-      if (!CACHED_3D_NETWORKS[model][version][id]) {
-        const n = await get3dNetwork({ model, version, type, id });
-        CACHED_3D_NETWORKS[model][version][id] = n;
-      }
-
-      network = CACHED_3D_NETWORKS[model][version][id];
-    } else {
-      if (!CACHED_3D_NETWORKS[model][version].whole) {
-        const n = await get3dNetwork({ model, version });
-        CACHED_3D_NETWORKS[model][version].whole = n;
-      }
-
-      network = CACHED_3D_NETWORKS[model][version].whole;
+      payload = { ...payload, type, id };
     }
 
+    const network = await get3dNetwork(payload);
     res.json(network);
   } catch (e) {
     res.status(400).send(e.message);

--- a/api/src/endpoints/repository.js
+++ b/api/src/endpoints/repository.js
@@ -14,7 +14,7 @@ routes.get('/integrated_models', async (req, res) => {
 
     res.json(models);
   } catch (e) {
-    res.status(400).send(e);
+    res.status(400).send(e.message);
   }
 });
 
@@ -29,7 +29,7 @@ routes.get('/integrated_models/:name', async (req, res) => {
       res.sendStatus(404);
     }
   } catch (e) {
-    res.status(400).send(e);
+    res.status(400).send(e.message);
   }
 });
 
@@ -37,7 +37,7 @@ routes.get('/models', async (req, res) => {
   try {
     res.json(gemsRepoJson);
   } catch (e) {
-    res.status(400).send(e);
+    res.status(400).send(e.message);
   }
 });
 

--- a/api/src/endpoints/swagger.js
+++ b/api/src/endpoints/swagger.js
@@ -12,9 +12,9 @@ const options = {
   customCssUrl: 'https://cdn.jsdelivr.net/npm/bulma@0.9.1/css/bulma.min.css',
 };
 
-routes.get('/favicon*', function (req, res) {
-  res.redirect('public' + req.url);
-});
+routes.use('/favicon*', (req, res, next) =>
+  express.static(`public/favicon${req.params[0]}`)(req, res, next)
+);
 routes.use('', swaggerUi.serve);
 routes.get('', swaggerUi.setup(config, options));
 

--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -1,5 +1,4 @@
 import Vue from 'vue';
-import $ from 'jquery';
 import VueRouter from 'vue-router';
 import NProgress from 'nprogress';
 import Home from '@/components/Home';
@@ -48,9 +47,7 @@ const router = new VueRouter({
   mode: 'history',
   routes,
   scrollBehavior(to) {
-    if (to.hash) {
-      $(window).scrollTop($(to.hash).offset().top);
-    }
+    return to.hash ? { selector: to.hash } : {};
   },
 });
 

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -30,6 +30,9 @@ http {
       proxy_set_header    Connection 'upgrade';
       proxy_set_header    Host $host;
       proxy_cache_bypass  $http_upgrade;
+      proxy_read_timeout 300;
+      proxy_connect_timeout 300;
+      proxy_send_timeout 300;
     }
 
     location /api {

--- a/proj.sh
+++ b/proj.sh
@@ -20,7 +20,7 @@ function build-stack {
 }
 
 function start-stack {
-  docker compose -f docker-compose.yml -f docker-compose-local.yml up -d
+  docker-compose -f docker-compose.yml -f docker-compose-local.yml up -d
   docker cp frontend:/project/yarn.lock frontend/yarn.lock
   docker cp api:/project/yarn.lock api/yarn.lock
 }

--- a/proj.sh
+++ b/proj.sh
@@ -20,7 +20,7 @@ function build-stack {
 }
 
 function start-stack {
-  docker-compose -f docker-compose.yml -f docker-compose-local.yml up -d
+  docker compose -f docker-compose.yml -f docker-compose-local.yml up -d
   docker cp frontend:/project/yarn.lock frontend/yarn.lock
   docker cp api:/project/yarn.lock api/yarn.lock
 }


### PR DESCRIPTION
This PR closes #606. Looks like this clears all the alert (see screenshot below).

<img width="712" alt="image" src="https://user-images.githubusercontent.com/423498/121233914-70042680-c893-11eb-9141-b15bdd199998.png">

For the "Prototype-polluting assignment" warnings (`CACHED_3D_NETWORKS[model][version].whole = n;`), I simply removed the custom cache for 3D maps. For servers these should already being cached by nginx now. The potential downside is that when working locally, one might need to wait longer for working with larger 3D maps. Or maybe it is good if the developer can always see the actual load time for a 3D map. If we want to make sure that 3D networks are cached when working locally I suggest we create a new issue for caching them using nginx.