### PR TITLE
fix: broken data overlay in 2D map viewer MA-592

### DIFF
--- a/frontend/src/components/explorer/mapViewer/MapSearch.vue
+++ b/frontend/src/components/explorer/mapViewer/MapSearch.vue
@@ -84,7 +84,6 @@ export default {
   },
   created() {
     this.search = debounce(this.search, 300);
-    EventBus.$off('apply2DHPARNAlevels');
     EventBus.$on('apply2DHPARNAlevels', () => {
       this.focusOnInputSearch();
     });


### PR DESCRIPTION
This PR closes the issue #592 

DoD: The color of the gene boxes on the 2D Map Viewer changes when selecting any data source for Human-GEM on the Data Overlay side bar. 

Example to check: http://localhost/explore/Human-GEM/map-viewer/glycolysis_gluconeogenesis?dim=2d&panel=1&sel=&search=&coords=-3118.87,-4443.77,0.21,0,0,500&g1=pancreas&g2=parathyroid%20gland