### PR TITLE
fix: make sure that gene ids that are within parenthesis are parsed properly

### DIFF
--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -1,40 +1,6 @@
 import axios from 'axios';
 import { constructCompartmentStr, reformatChemicalReactionHTML } from '@/helpers/utils';
 
-const formatGeneRule = (reaction) => {
-  const { geneRule, genes } = reaction;
-
-  if (!geneRule) {
-    return null;
-  }
-  return geneRule.split(/\s+/).map((w) => {
-    if (w.match(/and|or/)) {
-      return w;
-    }
-
-    let gid = w;
-    let prefix = '';
-    let suffix = '';
-
-    if (gid.slice(0, 2) === '((') {
-      gid = gid.slice(2);
-      prefix = '((';
-    } else if (gid.slice(0, 1) === '(') {
-      gid = gid.slice(1);
-      prefix = '(';
-    } else if (gid.slice(-2) === '))') {
-      gid = gid.slice(0, -2);
-      suffix = '))';
-    } else if (gid.slice(-1) === ')') {
-      gid = gid.slice(0, -1);
-      suffix = ')';
-    }
-
-    const gene = genes.find(g => g.id === gid);
-    return `${prefix}${gene.name}${suffix}`;
-  }).join(' ');
-};
-
 const fetchReactionData = async ({ id, model, version }) => {
   const params = { model, version };
   let { data } = await axios.get(`/reactions/${id}`, { params });
@@ -44,7 +10,6 @@ const fetchReactionData = async ({ id, model, version }) => {
     compartment_str: data.compartments.map(c => c.name).join(', '),
     reactants: data.metabolites.filter(m => m.outgoing),
     products: data.metabolites.filter(m => !m.outgoing),
-    geneRule: formatGeneRule(data),
   };
 
   return {

--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -13,21 +13,25 @@ const formatGeneRule = (reaction) => {
     }
 
     let gid = w;
+    let prefix = '';
+    let suffix = '';
 
-    if (gid[0] === '(') {
+    if (gid.slice(0, 2) === '((') {
+      gid = gid.slice(2);
+      prefix = '((';
+    } else if (gid.slice(0, 1) === '(') {
       gid = gid.slice(1);
-      const gene = genes.find(g => g.id === gid);
-      return `(${gene.name}`;
-    }
-
-    if (gid[gid.length - 1] === ')') {
+      prefix = '(';
+    } else if (gid.slice(-2) === '))') {
+      gid = gid.slice(0, -2);
+      suffix = '))';
+    } else if (gid.slice(-1) === ')') {
       gid = gid.slice(0, -1);
-      const gene = genes.find(g => g.id === gid);
-      return `${gene.name})`;
+      suffix = ')';
     }
 
     const gene = genes.find(g => g.id === gid);
-    return gene.name;
+    return `${prefix}${gene.name}${suffix}`;
   }).join(' ');
 };
 

--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -11,7 +11,22 @@ const formatGeneRule = (reaction) => {
     if (w.match(/and|or/)) {
       return w;
     }
-    const gene = genes.find(g => g.id === w);
+
+    let gid = w;
+
+    if (gid[0] === '(') {
+      gid = gid.slice(1);
+      const gene = genes.find(g => g.id === gid);
+      return `(${gene.name}`;
+    }
+
+    if (gid[gid.length - 1] === ')') {
+      gid = gid.slice(0, -1);
+      const gene = genes.find(g => g.id === gid);
+      return `${gene.name})`;
+    }
+
+    const gene = genes.find(g => g.id === gid);
     return gene.name;
   }).join(' ');
 };

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -173,39 +173,24 @@ export default {
       if (!this.reaction.geneRule) {
         return '-';
       }
-      let newGRnameArr = null;
-      if (this.reaction.geneRule_wname) {
-        newGRnameArr = this.reaction.geneRule_wname.split(/ +/).map(
-          e => e.replace(/^\(+|\)+$/g, '')
-        );
-      }
-      let newGR = this.reaction.geneRule;
-      if (newGR) {
-        let i = -1;
-        const newGRArr = newGR.split(/ +/).map(
-          (e) => {
-            i += 1;
-            if (e === 'or' || e === 'and') {
-              return e;
-            }
-            let prefix = '';
-            let suffix = '';
-            if (e[0] === '(') {
-              prefix = e[1] === '(' ? '((' : '(';
-            }
-            if (e.slice(-1) === ')') {
-              suffix = e.slice(-2) === '))' ? '))' : ')';
-            }
 
-            const newEName = e.replace(/^\(+|\)+$/g, '');
-            const newEId = this.reaction.genes.find(g => g.name === newEName).id;
-            const tag = newGRnameArr ? newGRnameArr[i] : newEName;
-            const customLink = buildCustomLink({ model: this.model.short_name, type: 'gene', id: newEId, title: tag });
-            return `${prefix}<span class="tag">${customLink}</span>${suffix}`;
-          });
-        newGR = newGRArr.join(' ');
-      }
-      return newGR;
+      // capture any sequence that's not a space or parenthesis
+      const regex = /[^\s()]+/g;
+
+      return this.reaction.geneRule.replace(regex, (w) => {
+        if (w.match(/and|or/)) {
+          return w;
+        }
+
+        const gene = this.reaction.genes.find(g => g.id === w);
+        const customLink = buildCustomLink({
+          model: this.model.short_name,
+          type: 'gene',
+          id: gene.id,
+          title: gene.name || gene.id,
+        });
+        return `<span class="tag">${customLink}</span>`;
+      });
     },
     formatQuantFieldName(name) { return `${name}:&nbsp;`; },
     reformatQuant() {

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -188,8 +188,15 @@ export default {
             if (e === 'or' || e === 'and') {
               return e;
             }
-            const prefix = e[0] === '(' ? '(' : '';
-            const suffix = e.slice(-1) === ')' ? ')' : '';
+            let prefix = '';
+            let suffix = '';
+            if (e[0] === '(') {
+              prefix = e[1] === '(' ? '((' : '(';
+            }
+            if (e.slice(-1) === ')') {
+              suffix = e.slice(-2) === '))' ? '))' : ')';
+            }
+
             const newEName = e.replace(/^\(+|\)+$/g, '');
             const newEId = this.reaction.genes.find(g => g.name === newEName).id;
             const tag = newGRnameArr ? newGRnameArr[i] : newEName;


### PR DESCRIPTION
The PR https://github.com/MetabolicAtlas/neo4j-data-generation/pull/18 is required for this to work.

This closes #623 and closes #590.

If successful, when browsing to `/explore/Human-GEM/gem-browser/reaction/HMR_9491` for example, you should see the following section:

<img width="1237" alt="image" src="https://user-images.githubusercontent.com/423498/121947690-a12e9c00-cd56-11eb-9cd1-343207f7d260.png">
