### PR TITLE
fix: use id as fallback if name is not available for title in interaction partners page

### DIFF
--- a/frontend/src/store/modules/interactionPartners.js
+++ b/frontend/src/store/modules/interactionPartners.js
@@ -15,7 +15,10 @@ const data = {
 const getters = {
   component: state => state.interactionPartners.component || {},
   reactions: state => state.interactionPartners.reactions || [],
-  title: (state, _getters) => (_getters.component.type === 'metabolite' ? chemicalName(_getters.component.name) : _getters.component.name),
+  title: (state, _getters) => (_getters.component.type === 'metabolite'
+    ? chemicalName(_getters.component.name || _getters.component.id)
+    : _getters.component.name || _getters.component.id
+  ),
   reactionsSet: (state, _getters) => new Set(_getters.reactions.map(r => r.id)),
   componentName: (state, _getters) => _getters.component.name || _getters.component.id,
 };

--- a/frontend/src/store/modules/interactionPartners.js
+++ b/frontend/src/store/modules/interactionPartners.js
@@ -16,7 +16,7 @@ const getters = {
   component: state => state.interactionPartners.component || {},
   reactions: state => state.interactionPartners.reactions || [],
   title: (state, _getters) => (_getters.component.type === 'metabolite'
-    ? chemicalName(_getters.component.name || _getters.component.id)
+    ? chemicalName(_getters.component.name) || _getters.component.id
     : _getters.component.name || _getters.component.id
   ),
   reactionsSet: (state, _getters) => new Set(_getters.reactions.map(r => r.id)),


### PR DESCRIPTION
This closes #586.