### PR TITLE
Refactor: gem browser component template

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -379,7 +379,7 @@ html {
   }
 }
 
-#comparison-details, .model-table, .reaction-table, .gembrowser-table {
+#comparison-details, .table-template {
   .main-table tr td.td-key, #ed-table tr td.td-key {
     width: 150px;
   }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -379,7 +379,7 @@ html {
   }
 }
 
-#comparison-details, .metabolite-table, .model-table, .reaction-table, .subsystem-table {
+#comparison-details, .metabolite-table, .model-table, .reaction-table, .subsystem-table, .gembrowser-table {
   .main-table tr td.td-key, #ed-table tr td.td-key {
     width: 150px;
   }

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -379,7 +379,7 @@ html {
   }
 }
 
-#comparison-details, .metabolite-table, .model-table, .reaction-table, .subsystem-table, .gembrowser-table {
+#comparison-details, .model-table, .reaction-table, .gembrowser-table {
   .main-table tr td.td-key, #ed-table tr td.td-key {
     width: 150px;
   }

--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -74,7 +74,7 @@
           <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
             has-background-white"
                tabindex="0" @keyup.esc="showModelId = ''">
-            <div id="modal-info" class="model-table">
+            <div id="modal-info" class="table-template">
               <h4 class="title is-size-4">
                 <template v-if="selectedModel.short_name">
                   {{ selectedModel.full_name }}

--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="'compartment'" :component-name="compartment.name"
+    component-type="compartment" :component-name="compartment.name"
     query-component-action="compartments/getCompartmentSummary"
     :include-reaction-table="false"
   >
@@ -52,11 +52,8 @@ export default {
   },
   data() {
     return {
-      modelNotFound: false,
       showFullSubsystem: false,
       limitSubsystem: 30,
-      componentNotFound: false,
-      showLoaderMessage: '',
     };
   },
   computed: {

--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -1,88 +1,57 @@
 <template>
-  <div class="section extended-section">
-    <div class="container is-fullhd">
-      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
-        <NotFound
-          :type="modelNotFound ? 'model' : type"
-          :component-id="modelNotFound ? $route.params.model : cName" />
-      </div>
-      <div v-else>
-        <div class="columns">
-          <div class="column">
-            <h3 class="title is-3"><span class="is-capitalized">{{ type }}</span> {{ compartment.name }}</h3>
-          </div>
-        </div>
-        <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
-        <div v-else class="columns is-multiline is-variable is-8">
-          <div class="subsystem-table column is-10-widescreen is-9-desktop is-full-tablet">
-            <div class="table-container">
-              <table v-if="compartment && Object.keys(compartment).length != 0"
-                     class="table main-table is-fullwidth">
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Name</td>
-                  <td> {{ compartment.name }}</td>
-                </tr>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Subsystems</td>
-                  <td>
-                    <div v-html="subsystemListHtml"></div>
-                    <div v-if="!showFullSubsystem && subsystems.length > limitSubsystem">
-                      <br>
-                      <button class="is-small button" @click="showFullSubsystem=true">
-                        ... and {{ subsystems.length - limitSubsystem }} more
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Reactions</td>
-                  <td> {{ compartment.reactionsCount }}</td>
-                </tr>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Metabolites</td>
-                  <td> {{ compartment.metabolitesCount }}</td>
-                </tr>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Genes</td>
-                  <td> {{ compartment.genesCount }}</td>
-                </tr>
-              </table>
+  <component-layout
+      :component-type="type" :component-name="compartment.name"
+      query-component-action="compartments/getCompartmentSummary"
+      :include-reaction-table="false"
+  >
+    <template v-slot:table>
+      <table v-if="compartment && Object.keys(compartment).length != 0"
+              class="table main-table is-fullwidth">
+        <tr>
+          <td class="td-key has-background-primary has-text-white-bis">Name</td>
+          <td> {{ compartment.name }}</td>
+        </tr>
+        <tr>
+          <td class="td-key has-background-primary has-text-white-bis">Subsystems</td>
+          <td>
+            <div v-html="subsystemListHtml"></div>
+            <div v-if="!showFullSubsystem && subsystems.length > limitSubsystem">
+              <br>
+              <button class="is-small button" @click="showFullSubsystem=true">
+                ... and {{ subsystems.length - limitSubsystem }} more
+              </button>
             </div>
-            <p v-if="model">The
-              <a :href="`/api/v2/${model.apiVersion}/compartments/${cName}?full=true`"
-                 target="_blank">complete list in JSON format</a>
-              of reactions / metabolites / genes is available using our
-              <a href="/api/v2" target="_blank">API</a></p>
-          </div>
-          <div class="column is-2-widescreen is-3-desktop is-half-tablet has-text-centered">
-            <maps-available :id="cName" :type="type" :element-i-d="''" />
-            <gem-contact :id="cName" :type="type" />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+          </td>
+        </tr>
+        <tr>
+          <td class="td-key has-background-primary has-text-white-bis">Reactions</td>
+          <td> {{ compartment.reactionsCount }}</td>
+        </tr>
+        <tr>
+          <td class="td-key has-background-primary has-text-white-bis">Metabolites</td>
+          <td> {{ compartment.metabolitesCount }}</td>
+        </tr>
+        <tr>
+          <td class="td-key has-background-primary has-text-white-bis">Genes</td>
+          <td> {{ compartment.genesCount }}</td>
+        </tr>
+      </table>
+    </template>
+  </component-layout>
 </template>
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import Loader from '@/components/Loader';
-import NotFound from '@/components/NotFound';
-import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
-import GemContact from '@/components/shared/GemContact';
+import ComponentLayout from '@/layouts/explorer/gemBrowser/ComponentLayout';
 import { buildCustomLink } from '@/helpers/utils';
 
 export default {
   name: 'Compartment',
   components: {
-    NotFound,
-    Loader,
-    MapsAvailable,
-    GemContact,
+    ComponentLayout,
   },
   data() {
     return {
-      cName: '',
       type: 'compartment',
       modelNotFound: false,
       showFullSubsystem: false,
@@ -112,32 +81,6 @@ export default {
       }
       l.push('</span>');
       return l.join('');
-    },
-  },
-  watch: {
-    '$route.params': 'setup',
-  },
-  async created() {
-    if (!this.model || this.model.short_name !== this.$route.params.model) {
-      const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
-      if (!modelSelectionSuccessful) {
-        this.modelNotFound = true;
-      }
-    }
-    this.setup();
-  },
-  methods: {
-    async setup() {
-      this.showLoaderMessage = 'Loading compartment data';
-      this.cName = this.$route.params.id;
-      try {
-        const payload = { model: this.model, id: this.cName };
-        await this.$store.dispatch('compartments/getCompartmentSummary', payload);
-        this.componentNotFound = false;
-        this.showLoaderMessage = '';
-      } catch {
-        this.componentNotFound = true;
-      }
     },
   },
 };

--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="type" :component-name="compartment.name"
+    :component-type="'compartment'" :component-name="compartment.name"
     query-component-action="compartments/getCompartmentSummary"
     :include-reaction-table="false"
   >
@@ -52,7 +52,6 @@ export default {
   },
   data() {
     return {
-      type: 'compartment',
       modelNotFound: false,
       showFullSubsystem: false,
       limitSubsystem: 30,

--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -1,12 +1,12 @@
 <template>
   <component-layout
-      :component-type="type" :component-name="compartment.name"
-      query-component-action="compartments/getCompartmentSummary"
-      :include-reaction-table="false"
+    :component-type="type" :component-name="compartment.name"
+    query-component-action="compartments/getCompartmentSummary"
+    :include-reaction-table="false"
   >
     <template v-slot:table>
       <table v-if="compartment && Object.keys(compartment).length != 0"
-              class="table main-table is-fullwidth">
+             class="table main-table is-fullwidth">
         <tr>
           <td class="td-key has-background-primary has-text-white-bis">Name</td>
           <td> {{ compartment.name }}</td>

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -54,9 +54,6 @@ export default {
         { name: 'function' },
       ],
       limitReaction: 200,
-      componentNotFound: false,
-      showLoaderMessage: '',
-      modelNotFound: false,
       messages,
     };
   },

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -1,88 +1,46 @@
 <template>
-  <div class="section extended-section">
-    <div class="container is-fullhd">
-      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
-        <NotFound
-          :type="modelNotFound ? 'model' : type"
-          :component-id="modelNotFound ? $route.params.model : geneId" />
-      </div>
-      <div v-else>
-        <div class="container is-fullhd columns">
-          <div class="column">
-            <h3 class="title is-3">
-              <span class="is-capitalized">{{ type }}</span> {{ gene.geneName }}
-            </h3>
-          </div>
-        </div>
-        <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
-        <div v-else class="columns">
-          <div class="column">
-            <div class="columns is-multiline is-variable is-8">
-              <div id="gene-details" class="reaction-table column is-9-widescreen is-9-desktop is-full-tablet">
-                <div class="table-contaner">
-                  <table v-if="gene && Object.keys(gene).length !== 0" class="table main-table is-fullwidth">
-                    <tr v-for="el in mainTableKey" :key="el.name">
-                      <td v-if="'display' in el"
-                          class="td-key has-background-primary has-text-white-bis"
-                          v-html="el.display"></td>
-                      <td v-else-if="el.name === 'id'"
-                          class="td-key has-background-primary has-text-white-bis">
-                        {{ model? model.short_name : '' }} ID
-                      </td>
-                      <td v-else
-                          class="td-key has-background-primary has-text-white-bis">{{ reformatTableKey(el.name) }}</td>
-                      <td v-if="gene[el.name]">
-                        <span v-if="'modifier' in el" v-html="el.modifier(gene)">
-                        </span>
-                        <span v-else>
-                          {{ gene[el.name] }}
-                        </span>
-                      </td>
-                      <td v-else> - </td>
-                    </tr>
-                  </table>
-                </div>
-                <ExtIdTable :type="type" :external-dbs="gene.externalDbs"></ExtIdTable>
-              </div>
-              <div class="column is-3-widescreen is-3-desktop is-full-tablet has-text-centered">
-                <router-link v-if="model && gene.id" class="button is-info is-fullwidth is-outlined"
-                             :to="{ name: 'interaction', params: { model: model.short_name, id: gene.id } }">
-                  <span class="icon"><i class="fa fa-connectdevelop fa-lg"></i></span>&nbsp;
-                  <span>{{ messages.interPartName }}</span>
-                </router-link>
-                <br>
-                <maps-available :id="geneId" :type="type" :viewer-selected-i-d="gene.id" />
-                <gem-contact :id="geneId" :type="type" />
-              </div>
-            </div>
-            <reaction-table v-if="model && geneName" :source-name="geneName" :type="type" :selected-elm-id="geneName" />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <component-layout
+    :component-type="type" :component-name="gene.geneName"
+    :external-dbs="gene.externalDbs" query-component-action="genes/getGeneData"
+    :interaction-partner="true" :viewer-selected-i-d="gene.id"
+  >
+    <template v-slot:table>
+      <table v-if="gene && Object.keys(gene).length !== 0" class="table main-table is-fullwidth">
+        <tr v-for="el in mainTableKey" :key="el.name">
+          <td v-if="'display' in el"
+              class="td-key has-background-primary has-text-white-bis"
+              v-html="el.display"></td>
+          <td v-else-if="el.name === 'id'"
+              class="td-key has-background-primary has-text-white-bis">
+            {{ model? model.short_name : '' }} ID
+          </td>
+          <td v-else
+              class="td-key has-background-primary has-text-white-bis">{{ reformatTableKey(el.name) }}</td>
+          <td v-if="gene[el.name]">
+            <span v-if="'modifier' in el" v-html="el.modifier(gene)">
+            </span>
+            <span v-else>
+              {{ gene[el.name] }}
+            </span>
+          </td>
+          <td v-else> - </td>
+        </tr>
+      </table>
+    </template>
+  </component-layout>
 </template>
+
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import NotFound from '@/components/NotFound';
-import Loader from '@/components/Loader';
-import ExtIdTable from '@/components/explorer/gemBrowser/ExtIdTable';
-import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
-import ReactionTable from '@/components/explorer/gemBrowser/ReactionTable';
-import GemContact from '@/components/shared/GemContact';
+import ComponentLayout from '@/layouts/explorer/gemBrowser/ComponentLayout';
 import { reformatTableKey } from '@/helpers/utils';
 import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'Gene',
   components: {
-    NotFound,
-    Loader,
-    MapsAvailable,
-    ReactionTable,
-    GemContact,
-    ExtIdTable,
+    ComponentLayout,
   },
   data() {
     return {
@@ -115,29 +73,7 @@ export default {
   watch: {
     '$route.params': 'setup',
   },
-  async created() {
-    if (!this.model || this.model.short_name !== this.$route.params.model) {
-      const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
-      if (!modelSelectionSuccessful) {
-        this.modelNotFound = true;
-      }
-    }
-    this.setup();
-  },
   methods: {
-    async setup() {
-      this.showLoaderMessage = 'Loading gene data';
-      this.geneId = this.$route.params.id;
-      try {
-        const payload = { model: this.model, id: this.geneId };
-        await this.$store.dispatch('genes/getGeneData', payload);
-        this.componentNotFound = false;
-        this.showLoaderMessage = '';
-      } catch {
-        this.reactions = [];
-        this.componentNotFound = true;
-      }
-    },
     reformatTableKey(k) { return reformatTableKey(k); },
   },
 };

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="'gene'" :component-name="gene.geneName"
+    component-type="gene" :component-name="gene.geneName"
     :external-dbs="gene.externalDbs" query-component-action="genes/getGeneData"
     :interaction-partner="true" :viewer-selected-i-d="gene.id"
   >

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="type" :component-name="gene.geneName"
+    :component-type="'gene'" :component-name="gene.geneName"
     :external-dbs="gene.externalDbs" query-component-action="genes/getGeneData"
     :interaction-partner="true" :viewer-selected-i-d="gene.id"
   >
@@ -46,7 +46,6 @@ export default {
     return {
       showReactionLoader: true,
       geneId: '',
-      type: 'gene',
       mainTableKey: [
         { name: 'id' },
         { name: 'name', display: 'Gene&nbsp;name' },

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -35,7 +35,6 @@
 import { mapGetters, mapState } from 'vuex';
 import ComponentLayout from '@/layouts/explorer/gemBrowser/ComponentLayout';
 import { generateSocialMetaTags, reformatTableKey } from '@/helpers/utils';
-import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'Gene',
@@ -54,7 +53,6 @@ export default {
         { name: 'function' },
       ],
       limitReaction: 200,
-      messages,
     };
   },
   computed: {

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -90,9 +90,6 @@ export default {
       }],
     };
   },
-  watch: {
-    '$route.params': 'setup',
-  },
   methods: {
     reformatTableKey(k) { return reformatTableKey(k); },
   },

--- a/frontend/src/components/explorer/gemBrowser/MapsAvailable.vue
+++ b/frontend/src/components/explorer/gemBrowser/MapsAvailable.vue
@@ -93,7 +93,7 @@ export default {
 .link-button {
   border-radius: 4px;
 }
-.maps-table tr td:first-child {
-  max-width: 150px;
+.table {
+  width: 100%;
 }
 </style>

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -5,6 +5,7 @@
     :external-dbs="metabolite.externalDbs" query-component-action="metabolites/getMetaboliteData"
     :interaction-partner="true" :viewer-selected-i-d="metabolite.id"
     :related-met-count="relatedMetabolites.length" :is-metabolite="true"
+    :selected-elm-id="true"
     @handleCallback="handleCallback"
   >
     <template v-slot:table>

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -5,7 +5,7 @@
     :external-dbs="metabolite.externalDbs" query-component-action="metabolites/getMetaboliteData"
     :interaction-partner="true" :viewer-selected-i-d="metabolite.id"
     :related-met-count="relatedMetabolites.length" :is-metabolite="true"
-    @doAfterLoad="doAfterLoad"
+    @handleCallback="handleCallback"
   >
     <template v-slot:table>
       <table v-if="metabolite" class="table main-table is-fullwidth">
@@ -108,7 +108,7 @@ export default {
     }),
   },
   methods: {
-    async doAfterLoad() {
+    async handleCallback() {
       if (this.metabolite.externalDbs.ChEBI) {
         const link = `https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${this.metabolite.externalDbs.ChEBI[0].id.slice(6)}`;
         const { data } = await axios.get(link);

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -71,7 +71,6 @@ import { mapState } from 'vuex';
 import ComponentLayout from '@/layouts/explorer/gemBrowser/ComponentLayout';
 import { chemicalFormula } from '@/helpers/chemical-formatters';
 import { generateSocialMetaTags, reformatTableKey } from '@/helpers/utils';
-import { default as messages } from '@/helpers/messages';
 
 export default {
   name: 'Metabolite',
@@ -93,7 +92,6 @@ export default {
         { name: 'compartment' },
       ],
       activePanel: 'table',
-      messages,
       chebiImageLink: null,
     };
   },

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -93,9 +93,6 @@ export default {
         { name: 'compartment' },
       ],
       activePanel: 'table',
-      componentNotFound: false,
-      showLoaderMessage: '',
-      modelNotFound: false,
       messages,
       chebiImageLink: null,
     };

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="type" :component-name="metabolite.name"
+    :component-type="'metabolite'" :component-name="metabolite.name"
     :compartment-name="(metabolite && metabolite.compartment) ? metabolite.compartment.name : ''"
     :external-dbs="metabolite.externalDbs" query-component-action="metabolites/getMetaboliteData"
     :interaction-partner="true" :viewer-selected-i-d="metabolite.id"
@@ -80,7 +80,6 @@ export default {
   },
   data() {
     return {
-      type: 'metabolite',
       metaboliteId: this.$route.params.id,
       mainTableKey: [
         { name: 'id' },

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -3,7 +3,7 @@
       :component-type="type" :component-name="metabolite.name"
       :compartment-name="(metabolite && metabolite.compartment) ? metabolite.compartment.name : ''"
       :external-dbs="metabolite.externalDbs" query-component-action="metabolites/getMetaboliteData"
-      :chebi="this.metabolite.externalDbs.ChEBI ? metabolite.externalDbs.ChEBI[0] : {}"
+      :chebi="this.metabolite.externalDbs.ChEBI ? metabolite.externalDbs.ChEBI[0] : null"
       :interaction-partner="true" :viewer-selected-i-d="metabolite.id"
       :related-met-count="relatedMetabolites.length"
   >

--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="'metabolite'" :component-name="metabolite.name"
+    component-type="metabolite" :component-name="metabolite.name"
     :compartment-name="(metabolite && metabolite.compartment) ? metabolite.compartment.name : ''"
     :external-dbs="metabolite.externalDbs" query-component-action="metabolites/getMetaboliteData"
     :interaction-partner="true" :viewer-selected-i-d="metabolite.id"

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -89,10 +89,7 @@ export default {
         { name: 'compartments', display: 'Compartment(s)' },
         { name: 'subsystems', display: 'Subsystem(s)' },
       ],
-      modelNotFound: false,
-      showLoaderMessage: '',
       mapsAvailable: {},
-      componentNotFound: false,
     };
   },
   computed: {

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -4,7 +4,7 @@
     :external-dbs="reaction.externalDbs" query-component-action="reactions/getReactionData"
     :viewer-selected-i-d="reaction.id" :include-reaction-table="false"
     :reference-list="referenceList"
-     @doAfterLoad="doAfterLoad"
+     @handleCallback="handleCallback"
   >
     <template v-slot:table>
       <table v-if="reaction && Object.keys(reaction).length !== 0" class="table main-table is-fullwidth">
@@ -105,7 +105,7 @@ export default {
     }),
   },
   methods: {
-    async doAfterLoad() {
+    async handleCallback() {
       try {
         const payload = { model: this.model, id: this.rId };
         await this.$store.dispatch('reactions/getRelatedReactionsForReaction', payload);

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -1,10 +1,10 @@
 <template>
-<component-layout
+  <component-layout
     :component-type="type" :component-name="reaction.id"
     :external-dbs="reaction.externalDbs" query-component-action="reactions/getReactionData"
     :viewer-selected-i-d="reaction.id" :include-reaction-table="false"
     :reference-list="referenceList"
-     @handleCallback="handleCallback"
+    @handleCallback="handleCallback"
   >
     <template v-slot:table>
       <table v-if="reaction && Object.keys(reaction).length !== 0" class="table main-table is-fullwidth">

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="type" :component-name="reaction.id"
+    :component-type="'reaction'" :component-name="reaction.id"
     :external-dbs="reaction.externalDbs" query-component-action="reactions/getReactionData"
     :viewer-selected-i-d="reaction.id" :include-reaction-table="false"
     :reference-list="referenceList"
@@ -79,7 +79,6 @@ export default {
   data() {
     return {
       rId: this.$route.params.id,
-      type: 'reaction',
       mainTableKey: [
         { name: 'id' },
         { name: 'equation', modifier: this.reformatEquation },

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -1,110 +1,80 @@
 <template>
-  <div class="section extended-section">
-    <div class="container is-fullhd">
-      <div v-if="modelNotFound || componentNotFound" class="columns is-centered">
-        <NotFound
-          :type="modelNotFound ? 'model' : type"
-          :component-id="modelNotFound ? $route.params.model : rId" />
-      </div>
-      <div v-else>
-        <div class="columns">
-          <div class="column">
-            <h3 class="title is-size-3"><span class="is-capitalized">{{ type }}</span> {{ reaction.id }}</h3>
-          </div>
-        </div>
-        <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
-        <div v-else class="columns is-multiline is-variable is-8">
-          <div class="reaction-table column is-10-widescreen is-9-desktop is-full-tablet">
-            <div class="table-container">
-              <table v-if="reaction && Object.keys(reaction).length !== 0" class="table main-table is-fullwidth">
-                <tr v-for="el in mainTableKey" :key="el.name">
-                  <td v-if="'display' in el"
-                      class="td-key has-background-primary has-text-white-bis"
-                      v-html="el.display"></td>
-                  <td v-else-if="el.name === 'id'"
-                      class="td-key has-background-primary has-text-white-bis">
-                    {{ model.short_name }} ID</td>
-                  <td v-else class="td-key has-background-primary has-text-white-bis">
-                    {{ reformatTableKey(el.name) }}
-                  </td>
-                  <td v-if="reaction[el.name]">
-                    <template v-if="'modifier' in el"><span v-html="el.modifier()"></span></template>
-                    <template v-else-if="el.name === 'subsystems'">
-                      <template v-for="(v, i) in reaction[el.name]">
-                        <template v-if="i !== 0">; </template>
-                        <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
-                        <router-link :to="{ name: 'subsystem', params: { model: model.short_name, id: v.id } }"> {{ v.name }}</router-link>
-                      </template>
-                    </template>
-                    <template v-else-if="el.name === 'compartments'">
-                      <div class="tags">
-                        <template v-for="c in reaction[el.name]">
-                          <span :key="c.id" class="tag">
-                            <!-- eslint-disable-next-line max-len -->
-                            <router-link :to="{ name: 'compartment', params: { model: model.short_name, id: c.id } }">{{ c.name }}</router-link>
-                          </span>
-                        </template>
-                      </div>
-                    </template>
-                    <template v-else-if="el.name === 'ec'">
-                      <!-- eslint-disable-next-line max-len -->
-                      <router-link v-for="eccode in reaction[el.name].split('; ')" :key="eccode" :to="{ name: 'search', query: { term: eccode }}">
-                        {{ eccode }}
-                      </router-link>
-                    </template>
-                    <template v-else>{{ reaction[el.name] }}</template>
-                  </td>
-                  <td v-else-if="'modifier' in el"><span v-html="el.modifier()"></span></td>
-                  <td v-else> - </td>
-                </tr>
-                <tr v-if="relatedReactions.length !== 0">
-                  <td class="td-key has-background-primary has-text-white-bis">Related reaction(s)</td>
-                  <td>
-                    <span v-for="rr in relatedReactions" :key="rr.id">
-                      <router-link :to="{ name: 'reaction', params: { model: model.short_name, id: rr.id } }">
-                        {{ rr.id }}
-                      </router-link>:&nbsp;
-                      <span v-html="reformatChemicalReactionHTML(rr, true, model.short_name)"></span>:
-                      (<span v-html="equationSign(rr.reversible)">
-                      </span>)
-                    </span>
-                  </td>
-                </tr>
-              </table>
-            </div>
-            <ExtIdTable :type="type" :external-dbs="reaction.externalDbs"></ExtIdTable>
-            <br>
-            <references :reference-list="referenceList" />
-          </div>
-          <div class="column is-2-widescreen is-3-desktop is-half-tablet has-text-centered">
-            <maps-available :id="rId" :type="type" :viewer-selected-i-d="reaction.id" />
-            <gem-contact :id="rId" :type="type" />
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+<component-layout
+    :component-type="type" :component-name="reaction.id"
+    :external-dbs="reaction.externalDbs" query-component-action="reactions/getReactionData"
+    :viewer-selected-i-d="reaction.id" :include-reaction-table="false"
+    :reference-list="referenceList"
+     @doAfterLoad="doAfterLoad"
+  >
+    <template v-slot:table>
+      <table v-if="reaction && Object.keys(reaction).length !== 0" class="table main-table is-fullwidth">
+        <tr v-for="el in mainTableKey" :key="el.name">
+          <td v-if="'display' in el"
+              class="td-key has-background-primary has-text-white-bis"
+              v-html="el.display"></td>
+          <td v-else-if="el.name === 'id'"
+              class="td-key has-background-primary has-text-white-bis">
+            {{ model.short_name }} ID</td>
+          <td v-else class="td-key has-background-primary has-text-white-bis">
+            {{ reformatTableKey(el.name) }}
+          </td>
+          <td v-if="reaction[el.name]">
+            <template v-if="'modifier' in el"><span v-html="el.modifier()"></span></template>
+            <template v-else-if="el.name === 'subsystems'">
+              <template v-for="(v, i) in reaction[el.name]">
+                <template v-if="i !== 0">; </template>
+                <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
+                <router-link :to="{ name: 'subsystem', params: { model: model.short_name, id: v.id } }"> {{ v.name }}</router-link>
+              </template>
+            </template>
+            <template v-else-if="el.name === 'compartments'">
+              <div class="tags">
+                <template v-for="c in reaction[el.name]">
+                  <span :key="c.id" class="tag">
+                    <!-- eslint-disable-next-line max-len -->
+                    <router-link :to="{ name: 'compartment', params: { model: model.short_name, id: c.id } }">{{ c.name }}</router-link>
+                  </span>
+                </template>
+              </div>
+            </template>
+            <template v-else-if="el.name === 'ec'">
+              <!-- eslint-disable-next-line max-len -->
+              <router-link v-for="eccode in reaction[el.name].split('; ')" :key="eccode" :to="{ name: 'search', query: { term: eccode }}">
+                {{ eccode }}
+              </router-link>
+            </template>
+            <template v-else>{{ reaction[el.name] }}</template>
+          </td>
+          <td v-else-if="'modifier' in el"><span v-html="el.modifier()"></span></td>
+          <td v-else> - </td>
+        </tr>
+        <tr v-if="relatedReactions.length !== 0">
+          <td class="td-key has-background-primary has-text-white-bis">Related reaction(s)</td>
+          <td>
+            <span v-for="rr in relatedReactions" :key="rr.id">
+              <router-link :to="{ name: 'reaction', params: { model: model.short_name, id: rr.id } }">
+                {{ rr.id }}
+              </router-link>:&nbsp;
+              <span v-html="reformatChemicalReactionHTML(rr, true, model.short_name)"></span>:
+              (<span v-html="equationSign(rr.reversible)">
+              </span>)
+            </span>
+          </td>
+        </tr>
+      </table>
+    </template>
+  </component-layout>
 </template>
 
 <script>
 import { mapState } from 'vuex';
-import Loader from '@/components/Loader';
-import NotFound from '@/components/NotFound';
-import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
-import ExtIdTable from '@/components/explorer/gemBrowser/ExtIdTable';
-import GemContact from '@/components/shared/GemContact';
-import References from '@/components/shared/References';
+import ComponentLayout from '@/layouts/explorer/gemBrowser/ComponentLayout';
 import { buildCustomLink, reformatTableKey, capitalize, convertCamelCase, addMassUnit, reformatChemicalReactionHTML, equationSign } from '@/helpers/utils';
 
 export default {
   name: 'Reaction',
   components: {
-    NotFound,
-    Loader,
-    MapsAvailable,
-    ExtIdTable,
-    GemContact,
-    References,
+    ComponentLayout,
   },
   data() {
     return {
@@ -134,33 +104,8 @@ export default {
       relatedReactions: state => state.reactions.relatedReactions,
     }),
   },
-  watch: {
-    '$route.params': 'setup',
-  },
-  async created() {
-    if (!this.model || this.model.short_name !== this.$route.params.model) {
-      const modelSelectionSuccessful = await this.$store.dispatch('models/selectModel', this.$route.params.model);
-      if (!modelSelectionSuccessful) {
-        this.modelNotFound = true;
-      }
-    }
-    this.setup();
-  },
   methods: {
-    async setup() {
-      this.showLoaderMessage = 'Loading reaction data';
-      this.rId = this.$route.params.id;
-      try {
-        const payload = { model: this.model, id: this.rId };
-        await this.$store.dispatch('reactions/getReactionData', payload);
-        this.componentNotFound = false;
-        this.showLoaderMessage = '';
-        await this.getRelatedReactions();
-      } catch {
-        this.componentNotFound = true;
-      }
-    },
-    async getRelatedReactions() {
+    async doAfterLoad() {
       try {
         const payload = { model: this.model, id: this.rId };
         await this.$store.dispatch('reactions/getRelatedReactionsForReaction', payload);

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="'reaction'" :component-name="reaction.id"
+    component-type="reaction" :component-name="reaction.id"
     :external-dbs="reaction.externalDbs" query-component-action="reactions/getReactionData"
     :viewer-selected-i-d="reaction.id" :include-reaction-table="false"
     :reference-list="referenceList"

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -3,7 +3,7 @@
     <div v-if="showReactionLoader">
       <loader />
     </div>
-    <div v-else class="column reaction-table">
+    <div v-else class="column table-template">
       <h4 class="subtitle is-4">Reactions</h4>
       <div v-if="errorMessage" class="notification is-danger">
         {{ errorMessage }}

--- a/frontend/src/components/explorer/gemBrowser/Subsystem.vue
+++ b/frontend/src/components/explorer/gemBrowser/Subsystem.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="type" :component-name="info.name"
+    :component-type="'subsystem'" :component-name="info.name"
     :external-dbs="info.externalDbs" query-component-action="subsystems/getSubsystemSummary"
   >
     <template v-slot:table>
@@ -80,7 +80,6 @@ export default {
   data() {
     return {
       sName: this.$route.params.id,
-      type: 'subsystem',
       mainTableKey: [
         { name: 'name', display: 'Name' },
       ],

--- a/frontend/src/components/explorer/gemBrowser/Subsystem.vue
+++ b/frontend/src/components/explorer/gemBrowser/Subsystem.vue
@@ -1,6 +1,6 @@
 <template>
   <component-layout
-    :component-type="'subsystem'" :component-name="info.name"
+    component-type="subsystem" :component-name="info.name"
     :external-dbs="info.externalDbs" query-component-action="subsystems/getSubsystemSummary"
   >
     <template v-slot:table>

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -56,7 +56,7 @@
             </select>
           </div>
         </div>
-        <p>{{dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data'}}</p>
+        <p>{{ dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data' }}</p>
         <div class="control">
           <div class="select is-fullwidth">
             <select
@@ -85,7 +85,7 @@
             </select>
           </div>
         </div>
-        <div>{{dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data'}}</div>
+        <div>{{ dataSourcesAvailable ? 'Or uploaded data' : 'RNA levels from uploaded data' }}</div>
         <div class="control">
           <div class="select is-fullwidth">
             <select

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -87,7 +87,7 @@ export default {
     selectedElmId: { type: Boolean, required: false, default: false },
     relatedMetCount: { type: Number, required: false, default: 0 },
     isMetabolite: { type: Boolean, default: false },
-    referenceList: { type: Object, default: null },
+    referenceList: { type: Array, default: null },
   },
   data() {
     return {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -18,7 +18,7 @@
         </div>
         <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
         <div v-else class="columns is-multiline is-variable is-8 is-centered">
-          <div class="gembrowser-table column">
+          <div class="table-template column">
             <div class="table-container">
               <slot name="table" />
             </div>

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -16,12 +16,20 @@
         </div>
         <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
         <div v-else class="columns is-multiline is-variable is-8">
-          <div class="gembrowser-table column is-9-widescreen is-9-desktop is-full-tablet">
+          <div class="gembrowser-table column">
             <div class="table-container">
               <slot name="table" />
             </div>
             <ExtIdTable :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
           </div>
+          <div v-if="chebiImageLink"
+                 class="column is-3-widescreen is-2-desktop is-full-tablet has-text-centered px-2">
+              <a :href="chebi.url" target="_blank">
+                <img id="chebi-img" :src="chebiImageLink" class="hoverable" />
+                <a :href="chebi.url" target="_blank" style="display: block;">
+                  {{ componentName }} via ChEBI</a>
+              </a>
+            </div>
           <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered">
             <router-link v-if="interactionPartner" class="button is-info is-fullwidth is-outlined"
                             :to="{
@@ -46,7 +54,7 @@
 
 
 <script>
-
+import axios from 'axios';
 import { mapState } from 'vuex';
 import NotFound from '@/components/NotFound';
 import Loader from '@/components/Loader';
@@ -75,6 +83,8 @@ export default {
     viewerSelectedID: { type: String, default: '' },
     selectedElm: { type: Boolean, required: false, default: true },
     relatedMetCount: { type: Number, required: false, default: 0 },
+    chebi: { type: Object, required: false, default: () => {} },
+
   },
   data() {
     return {
@@ -83,6 +93,7 @@ export default {
       componentNotFound: false,
       showLoaderMessage: '',
       messages,
+      chebiImageLink: null,
     };
   },
   computed: {
@@ -112,6 +123,13 @@ export default {
         const payload = { model: this.model, id: this.componentId };
         await this.$store.dispatch(this.queryComponentAction, payload);
         this.componentNotFound = false;
+        if (this.chebi) {
+          const link = `https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${this.chebi.id.slice(6)}`;
+          const { data } = await axios.get(link);
+          if (data !== '') {
+            this.chebiImageLink = `${link}&dimensions=400`;
+          }
+        }
         this.showLoaderMessage = '';
       } catch {
         this.componentNotFound = true;

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -22,7 +22,12 @@
             <div class="table-container">
               <slot name="table" />
             </div>
-            <ExtIdTable :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
+            <ExtIdTable v-if="externalDbs" :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
+            <p v-if="model && !externalDbs">The
+            <a :href="`/api/v2/${model.apiVersion}/compartments/${componentId}?full=true`"
+                target="_blank">complete list in JSON format</a>
+            of reactions / metabolites / genes is available using our
+            <a href="/api/v2" target="_blank">API</a></p>
             <references v-if="referenceList" :reference-list="referenceList" />
           </div>
           <slot v-if="isMetabolite" name="chebi" />
@@ -74,7 +79,7 @@ export default {
     componentType: { type: String },
     componentName: { type: String },
     compartmentName: { type: String, default: '' },
-    externalDbs: { type: Object, default: () => {} },
+    externalDbs: { type: Object, default: null },
     queryComponentAction: { type: String },
     includeReactionTable: { type: Boolean, default: true },
     interactionPartner: { type: Boolean, default: false },

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -26,7 +26,7 @@
             <router-link v-if="interactionPartnerId" class="button is-info is-fullwidth is-outlined"
                             :to="{
                             name: 'interaction',
-                            params: { model: interactionPartnerModel, id: interactionPartnerId }
+                            params: { model: model.short_name, id: interactionPartnerId }
                             }">
                 <span class="icon"><i class="fa fa-connectdevelop fa-lg"></i></span>&nbsp;
                 <span>{{ messages.interPartName }}</span>
@@ -72,7 +72,6 @@ export default {
     queryComponentAction: { type: String },
     includeReactionTable: { type: Boolean, default: true },
     interactionPartnerId: { type: String, default: '' },
-    interactionPartnerModel: { type: String, default: '' },
     viewerSelectedID: { type: String, default: '' },
     selectedElmId: { type: String, required: false, default: null },
     relatedMetCount: { type: Number, required: false, default: 0 },

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -23,6 +23,15 @@
             <ExtIdTable :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
           </div>
           <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered">
+            <router-link v-if="interactionPartnerId" class="button is-info is-fullwidth is-outlined"
+                            :to="{
+                            name: 'interaction',
+                            params: { model: interactionPartnerModel, id: interactionPartnerId }
+                            }">
+                <span class="icon"><i class="fa fa-connectdevelop fa-lg"></i></span>&nbsp;
+                <span>{{ messages.interPartName }}</span>
+            </router-link>
+            <br>
             <maps-available :id="componentId" :type="componentType" :element-i-d="''"></maps-available>
             <gem-contact :id="componentId" :type="componentType" />
           </div>
@@ -43,6 +52,7 @@ import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
 import ExtIdTable from '@/components/explorer/gemBrowser/ExtIdTable';
 import ReactionTable from '@/components/explorer/gemBrowser/ReactionTable';
 import GemContact from '@/components/shared/GemContact';
+import { default as messages } from '@/helpers/messages';
 
 export default {
   components: {
@@ -59,6 +69,8 @@ export default {
     externalDbs: { type: Object, default: () => {} },
     queryComponentAction: { type: String },
     includeReactionTable: { type: Boolean, default: true },
+    interactionPartnerId: { type: String, default: '' },
+    interactionPartnerModel: { type: String, default: '' },
   },
   data() {
     return {
@@ -66,6 +78,7 @@ export default {
       modelNotFound: false,
       componentNotFound: false,
       showLoaderMessage: '',
+      messages,
     };
   },
   computed: {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -47,7 +47,7 @@
         </div>
         <references v-if="referenceList" :reference-list="referenceList" />
         <reaction-table v-if="model && includeReactionTable" :source-name="componentId" :type="componentType"
-                        :selected-elm-id="selectedElm ? componentId : null" :related-met-count="relatedMetCount" />
+                        :selected-elm-id="selectedElmId ? componentId : null" :related-met-count="relatedMetCount" />
       </div>
     </div>
   </div>
@@ -84,7 +84,7 @@ export default {
     includeReactionTable: { type: Boolean, default: true },
     interactionPartner: { type: Boolean, default: false },
     viewerSelectedID: { type: String, default: '' },
-    selectedElm: { type: Boolean, required: false, default: true },
+    selectedElmId: { type: Boolean, required: false, default: false },
     relatedMetCount: { type: Number, required: false, default: 0 },
     isMetabolite: { type: Boolean, default: false },
     referenceList: { type: Object, default: null },

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -37,7 +37,8 @@
             <gem-contact :id="componentId" :type="componentType" />
           </div>
         </div>
-        <reaction-table v-if="model && includeReactionTable" :source-name="componentId" :type="componentType" />
+        <reaction-table v-if="model && includeReactionTable" :source-name="componentId" :type="componentType"
+        :selected-elm-id="selectedElmId" :related-met-count="relatedMetCount"/>
       </div>
     </div>
   </div>
@@ -73,6 +74,8 @@ export default {
     interactionPartnerId: { type: String, default: '' },
     interactionPartnerModel: { type: String, default: '' },
     viewerSelectedID: { type: String, default: '' },
+    selectedElmId: { type: String, required: false, default: null },
+    relatedMetCount: { type: Number, required: false, default: 0 },
   },
   data() {
     return {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -23,6 +23,7 @@
               <slot name="table" />
             </div>
             <ExtIdTable :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
+            <references v-if="referenceList" :reference-list="referenceList" />
           </div>
           <slot v-if="isMetabolite" name="chebi" />
           <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered">
@@ -56,6 +57,7 @@ import MapsAvailable from '@/components/explorer/gemBrowser/MapsAvailable';
 import ExtIdTable from '@/components/explorer/gemBrowser/ExtIdTable';
 import ReactionTable from '@/components/explorer/gemBrowser/ReactionTable';
 import GemContact from '@/components/shared/GemContact';
+import References from '@/components/shared/References';
 import { default as messages } from '@/helpers/messages';
 
 export default {
@@ -66,6 +68,7 @@ export default {
     ReactionTable,
     ExtIdTable,
     GemContact,
+    References,
   },
   props: {
     componentType: { type: String },
@@ -79,6 +82,7 @@ export default {
     selectedElm: { type: Boolean, required: false, default: true },
     relatedMetCount: { type: Number, required: false, default: 0 },
     isMetabolite: { type: Boolean, default: false },
+    referenceList: { type: Object, default: null },
   },
   data() {
     return {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -38,7 +38,7 @@
           </div>
         </div>
         <reaction-table v-if="model && includeReactionTable" :source-name="componentId" :type="componentType"
-        :selected-elm-id="selectedElmId" :related-met-count="relatedMetCount"/>
+        :selected-elm-id="selectedElm ? componentId : null" :related-met-count="relatedMetCount"/>
       </div>
     </div>
   </div>
@@ -73,7 +73,7 @@ export default {
     includeReactionTable: { type: Boolean, default: true },
     interactionPartner: { type: Boolean, default: false },
     viewerSelectedID: { type: String, default: '' },
-    selectedElmId: { type: String, required: false, default: null },
+    selectedElm: { type: Boolean, required: false, default: true },
     relatedMetCount: { type: Number, required: false, default: 0 },
   },
   data() {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -24,10 +24,10 @@
             </div>
             <ExtIdTable v-if="externalDbs" :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
             <p v-if="model && !externalDbs">The
-            <a :href="`/api/v2/${model.apiVersion}/compartments/${componentId}?full=true`"
-                target="_blank">complete list in JSON format</a>
-            of reactions / metabolites / genes is available using our
-            <a href="/api/v2" target="_blank">API</a></p>
+              <a :href="`/api/v2/${model.apiVersion}/compartments/${componentId}?full=true`"
+                 target="_blank">complete list in JSON format</a>
+              of reactions / metabolites / genes is available using our
+              <a href="/api/v2" target="_blank">API</a></p>
             <references v-if="referenceList" :reference-list="referenceList" />
           </div>
           <slot v-if="isMetabolite" name="chebi" />

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -23,10 +23,10 @@
             <ExtIdTable :type="componentType" :external-dbs="externalDbs"></ExtIdTable>
           </div>
           <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered">
-            <router-link v-if="interactionPartnerId" class="button is-info is-fullwidth is-outlined"
+            <router-link v-if="interactionPartner" class="button is-info is-fullwidth is-outlined"
                             :to="{
                             name: 'interaction',
-                            params: { model: model.short_name, id: interactionPartnerId }
+                            params: { model: model.short_name, id: componentId }
                             }">
                 <span class="icon"><i class="fa fa-connectdevelop fa-lg"></i></span>&nbsp;
                 <span>{{ messages.interPartName }}</span>
@@ -71,7 +71,7 @@ export default {
     externalDbs: { type: Object, default: () => {} },
     queryComponentAction: { type: String },
     includeReactionTable: { type: Boolean, default: true },
-    interactionPartnerId: { type: String, default: '' },
+    interactionPartner: { type: Boolean, default: false },
     viewerSelectedID: { type: String, default: '' },
     selectedElmId: { type: String, required: false, default: null },
     relatedMetCount: { type: Number, required: false, default: 0 },

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -45,7 +45,7 @@
             <gem-contact :id="componentId" :type="componentType" />
           </div>
         </div>
-        <references v-if="referenceList" :reference-list="referenceList" />
+        <references v-if="referenceList && !showLoaderMessage" :reference-list="referenceList" />
         <reaction-table v-if="model && includeReactionTable" :source-name="componentId" :type="componentType"
                         :selected-elm-id="selectedElmId ? componentId : null" :related-met-count="relatedMetCount" />
       </div>

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -32,7 +32,8 @@
                 <span>{{ messages.interPartName }}</span>
             </router-link>
             <br>
-            <maps-available :id="componentId" :type="componentType" :element-i-d="''"></maps-available>
+            <maps-available :id="componentId" :type="componentType"
+            :viewer-selected-i-d="viewerSelectedID"></maps-available>
             <gem-contact :id="componentId" :type="componentType" />
           </div>
         </div>
@@ -71,6 +72,7 @@ export default {
     includeReactionTable: { type: Boolean, default: true },
     interactionPartnerId: { type: String, default: '' },
     interactionPartnerModel: { type: String, default: '' },
+    viewerSelectedID: { type: String, default: '' },
   },
   data() {
     return {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -125,8 +125,8 @@ export default {
         const payload = { model: this.model, id: this.componentId };
         await this.$store.dispatch(this.queryComponentAction, payload);
         this.componentNotFound = false;
-        if (this.$listeners && this.$listeners.doAfterLoad) {
-          this.$emit('doAfterLoad');
+        if (this.$listeners && this.$listeners.handleCallback) {
+          this.$emit('handleCallback');
         }
         this.showLoaderMessage = '';
       } catch {

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -17,7 +17,7 @@
           </div>
         </div>
         <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
-        <div v-else class="columns is-multiline is-variable is-8">
+        <div v-else class="columns is-multiline is-variable is-8 is-centered">
           <div class="gembrowser-table column">
             <div class="table-container">
               <slot name="table" />
@@ -28,7 +28,6 @@
                  target="_blank">complete list in JSON format</a>
               of reactions / metabolites / genes is available using our
               <a href="/api/v2" target="_blank">API</a></p>
-            <references v-if="referenceList" :reference-list="referenceList" />
           </div>
           <slot v-if="isMetabolite" name="chebi" />
           <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered">
@@ -46,6 +45,7 @@
             <gem-contact :id="componentId" :type="componentType" />
           </div>
         </div>
+        <references v-if="referenceList" :reference-list="referenceList" />
         <reaction-table v-if="model && includeReactionTable" :source-name="componentId" :type="componentType"
                         :selected-elm-id="selectedElm ? componentId : null" :related-met-count="relatedMetCount" />
       </div>

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -16,7 +16,7 @@
         </div>
         <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
         <div v-else class="columns is-multiline is-variable is-8">
-          <div class="column is-9-widescreen is-9-desktop is-full-tablet">
+          <div class="gembrowser-table column is-9-widescreen is-9-desktop is-full-tablet">
             <div class="table-container">
               <slot name="table" />
             </div>

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -83,7 +83,7 @@ export default {
     viewerSelectedID: { type: String, default: '' },
     selectedElm: { type: Boolean, required: false, default: true },
     relatedMetCount: { type: Number, required: false, default: 0 },
-    chebi: { type: Object, required: false, default: () => {} },
+    chebi: { type: Object, required: false, default: null },
 
   },
   data() {


### PR DESCRIPTION
This PR closes #617

Please visit http://localhost/explore/Human-GEM/gem-browser and see if each component looks good and not too different from before.

There was some workaround needed for Metabolite ChEBI images and Reaction references, I think it looks good though

No chebi
http://localhost/explore/Human-GEM/gem-browser/metabolite/m02247l

Chebi
http://localhost/explore/Human-GEM/gem-browser/metabolite/m02604c

Chebi broken link
http://localhost/explore/Human-GEM/gem-browser/metabolite/m02576c

Reaction with references
http://localhost/explore/Human-GEM/gem-browser/reaction/HMR_4882

Also, some components used  `<maps-available :id="cName" :type="type" :element-i-d="''" />` before they were refactored. I did not add element-i-d as an option to reusable component layout since maps-available does not have or use :element-i-d prop. 

This PR also ensure proper responsiveness as discussed in https://github.com/MetabolicAtlas/MetabolicAtlas/pull/622#pullrequestreview-688373852