### PR TITLE
fix: disable custom map for 3D viewer

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -15,7 +15,7 @@
           <div id="mapSidebar__header" class="has-background-lightgray pt-3">
             <div class="buttons has-addons is-centered padding-mobile m-0"
                  :title="`Switch to ${dimensionalState(!showing2D) }`"
-                 @click="$store.dispatch('maps/toggleShowing2D')">
+                 @click="currentMap && currentMap.type !== 'custom' && $store.dispatch('maps/toggleShowing2D')">
               <button v-for="dim in [true, false]" :key="dim"
                       class="button m-0"
                       :class="dim === showing2D ? 'is-selected is-primary has-text-weight-bold' : 'is-light'"

--- a/frontend/src/components/explorer/mapViewer/MapsListing.vue
+++ b/frontend/src/components/explorer/mapViewer/MapsListing.vue
@@ -43,15 +43,7 @@ export default {
       mapsListing: state => state.maps.mapsListing,
     }),
     categories() {
-      const categories = [];
-      const li = Object.keys(this.mapsListing).filter(c => this.mapsListing[c].length > 0).sort();
-      for (let i = 0; i < li.length; i += 1) {
-        const category = li[i];
-        if (category !== 'customs' || this.showing2D) {
-          categories.push(category);
-        }
-      }
-      return categories;
+      return Object.keys(this.mapsListing).filter(c => this.mapsListing[c].length > 0 && (c !== 'customs' || this.showing2D)).sort();
     },
   },
   methods: {

--- a/frontend/src/components/explorer/mapViewer/MapsListing.vue
+++ b/frontend/src/components/explorer/mapViewer/MapsListing.vue
@@ -1,34 +1,32 @@
 <template>
   <div id="maps-listing">
-    <div v-for="category in Object.keys(mapsListing).filter(c => mapsListing[c].length > 0).sort()"
+    <div v-for="category in categories"
          :key="category" class="card my-3">
-      <template v-if="category !== 'customs' || showing2D">
-        <p class="is-capitalized is-size-6 has-text-weight-bold">{{ category.replace(/.$/," maps") }}</p>
-        <span v-for="item in mapsListing[category]" :key="item.id">
-          <template v-if="showing2D">
-            <template v-if="item.svgs.length === 0">
-              {{ item.name }}
-            </template>
-            <template v-else-if="item.svgs.length === 1">
-              <a @click="changeToMap(item.svgs[0].id)">
-                {{ item.svgs[0].customName }}
-              </a>
-            </template>
-            <template v-else>
-              {{ item.name }}:
-              <a v-for="svg in [...item.svgs].sort((a, b) => a.customName.localeCompare(b.customName))"
-                :key="svg.id" class="inline" @click="changeToMap(svg.id)">
-                {{ svg.customName }}
-              </a>
-            </template>
+      <p class="is-capitalized is-size-6 has-text-weight-bold">{{ category.replace(/.$/," maps") }}</p>
+      <span v-for="item in mapsListing[category]" :key="item.id">
+        <template v-if="showing2D">
+          <template v-if="item.svgs.length === 0">
+            {{ item.name }}
           </template>
-          <template v-else>
-            <a @click="changeToMap(item.id)">
-              {{ item.name }}
+          <template v-else-if="item.svgs.length === 1">
+            <a @click="changeToMap(item.svgs[0].id)">
+              {{ item.svgs[0].customName }}
             </a>
           </template>
-        </span>
-      </template>
+          <template v-else>
+            {{ item.name }}:
+            <a v-for="svg in [...item.svgs].sort((a, b) => a.customName.localeCompare(b.customName))"
+              :key="svg.id" class="inline" @click="changeToMap(svg.id)">
+              {{ svg.customName }}
+            </a>
+          </template>
+        </template>
+        <template v-else>
+          <a @click="changeToMap(item.id)">
+            {{ item.name }}
+          </a>
+        </template>
+      </span>
     </div>
   </div>
 </template>
@@ -44,6 +42,17 @@ export default {
       showing2D: state => state.maps.showing2D,
       mapsListing: state => state.maps.mapsListing,
     }),
+    categories() {
+      const categories = [];
+      const li = Object.keys(this.mapsListing).filter(c => this.mapsListing[c].length > 0).sort();
+      for (let i = 0; i < li.length; i += 1) {
+        const category = li[i];
+        if (category !== 'customs' || this.showing2D) {
+          categories.push(category);
+        }
+      }
+      return categories;
+    },
   },
   methods: {
     changeToMap(newMapId) {

--- a/frontend/src/components/explorer/mapViewer/MapsListing.vue
+++ b/frontend/src/components/explorer/mapViewer/MapsListing.vue
@@ -16,7 +16,7 @@
           <template v-else>
             {{ item.name }}:
             <a v-for="svg in [...item.svgs].sort((a, b) => a.customName.localeCompare(b.customName))"
-              :key="svg.id" class="inline" @click="changeToMap(svg.id)">
+               :key="svg.id" class="inline" @click="changeToMap(svg.id)">
               {{ svg.customName }}
             </a>
           </template>

--- a/frontend/src/components/explorer/mapViewer/MapsListing.vue
+++ b/frontend/src/components/explorer/mapViewer/MapsListing.vue
@@ -2,31 +2,33 @@
   <div id="maps-listing">
     <div v-for="category in Object.keys(mapsListing).filter(c => mapsListing[c].length > 0).sort()"
          :key="category" class="card my-3">
-      <p class="is-capitalized is-size-6 has-text-weight-bold">{{ category.replace(/.$/," maps") }}</p>
-      <span v-for="item in mapsListing[category]" :key="item.id">
-        <template v-if="showing2D">
-          <template v-if="item.svgs.length === 0">
-            {{ item.name }}
-          </template>
-          <template v-else-if="item.svgs.length === 1">
-            <a @click="changeToMap(item.svgs[0].id)">
-              {{ item.svgs[0].customName }}
-            </a>
+      <template v-if="category !== 'customs' || showing2D">
+        <p class="is-capitalized is-size-6 has-text-weight-bold">{{ category.replace(/.$/," maps") }}</p>
+        <span v-for="item in mapsListing[category]" :key="item.id">
+          <template v-if="showing2D">
+            <template v-if="item.svgs.length === 0">
+              {{ item.name }}
+            </template>
+            <template v-else-if="item.svgs.length === 1">
+              <a @click="changeToMap(item.svgs[0].id)">
+                {{ item.svgs[0].customName }}
+              </a>
+            </template>
+            <template v-else>
+              {{ item.name }}:
+              <a v-for="svg in [...item.svgs].sort((a, b) => a.customName.localeCompare(b.customName))"
+                :key="svg.id" class="inline" @click="changeToMap(svg.id)">
+                {{ svg.customName }}
+              </a>
+            </template>
           </template>
           <template v-else>
-            {{ item.name }}:
-            <a v-for="svg in [...item.svgs].sort((a, b) => a.customName.localeCompare(b.customName))"
-               :key="svg.id" class="inline" @click="changeToMap(svg.id)">
-              {{ svg.customName }}
+            <a @click="changeToMap(item.id)">
+              {{ item.name }}
             </a>
           </template>
-        </template>
-        <template v-else>
-          <a @click="changeToMap(item.id)">
-            {{ item.name }}
-          </a>
-        </template>
-      </span>
+        </span>
+      </template>
     </div>
   </div>
 </template>


### PR DESCRIPTION
This PR closes [#16](https://app.zenhub.com/workspaces/metabolic-atlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/16)

Description: Custom maps should not be shown in the sidebar for 3D viewer.

DoD: custom maps is shown on the sidebar for 2D map viewer (if available) but disappear when changing to 3D viewer. 

  