### PR TITLE
fix: broken ascii arrows in reaction table

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -62,9 +62,9 @@
                 </template>
               </td>
               <td>
-                <template v-for="(RP, i) in r.compartment_str.split(' => ')">
+                <template v-for="(RP, i) in r.compartment_str.split(new RegExp(['&#8658;|&#8660;']))">
                   <template v-if="i !== 0">{{ r.reversible ? ' &#8660; ' : ' &#8658; ' }}</template>
-                  <template v-for="(compo, j) in RP.split(' + ')">
+                  <template v-for="(compo, j) in RP.split(' ,')">
                     <template v-if="j != 0"> + </template>
                     <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
                     <a :href="`/explore/${model.short_name}/gem-browser/compartment/${idfy(compo)}`" @click="handleRouterClick">{{ compo }}</a>

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -62,12 +62,12 @@
                 </template>
               </td>
               <td>
-                <template v-for="(RP, i) in r.compartment_str.split(/&#8658;|&#8660;/)">
-                  <template v-if="i !== 0">{{ r.reversible ? ' &#8660; ' : ' &#8658; ' }}</template>
-                  <template v-for="(compo, j) in RP.split(' ,')">
+                <template v-for="(w, i) in r.compartment_str.split(/⇔|⇒/)">
+                  <template v-if="i !== 0">{{ r.reversible ? ' ⇔ ' : ' ⇒ ' }}</template>
+                  <template v-for="(comp, j) in w.split(' + ')">
                     <template v-if="j != 0"> + </template>
                     <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
-                    <a :href="`/explore/${model.short_name}/gem-browser/compartment/${idfy(compo)}`" @click="handleRouterClick">{{ compo }}</a>
+                    <a :href="`/explore/${model.short_name}/gem-browser/compartment/${idfy(comp)}`" @click="handleRouterClick">{{ comp }}</a>
                   </template>
                 </template>
               </td>

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -62,7 +62,7 @@
                 </template>
               </td>
               <td>
-                <template v-for="(RP, i) in r.compartment_str.split(new RegExp(['&#8658;|&#8660;']))">
+                <template v-for="(RP, i) in r.compartment_str.split(/&#8658;|&#8660;/)">
                   <template v-if="i !== 0">{{ r.reversible ? ' &#8660; ' : ' &#8658; ' }}</template>
                   <template v-for="(compo, j) in RP.split(' ,')">
                     <template v-if="j != 0"> + </template>

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -31,7 +31,7 @@ export function reformatStringToLink(value, link) {
 }
 
 export function equationSign(isReversible) {
-  return isReversible ? '&#8660;' : '&#8658;';
+  return isReversible ? '⇔' : '⇒';
 }
 
 export function addMassUnit(value) {
@@ -132,13 +132,13 @@ export const constructCompartmentStr = (reaction) => {
     products.map(r => compartments[r.compartmentId].name).sort()
   );
 
-  const reactantsCompartmentsStr = Array.from(reactantsCompartments).join(' , ');
+  const reactantsCompartmentsStr = Array.from(reactantsCompartments).join(' + ');
   if (JSON.stringify([...reactantsCompartments])
     === JSON.stringify([...productsCompartments])) {
     return reactantsCompartmentsStr;
   }
 
-  const productsCompartmentsStr = Array.from(productsCompartments).join(' , ');
+  const productsCompartmentsStr = Array.from(productsCompartments).join(' + ');
   return `${reactantsCompartmentsStr} ${equationSign(reaction.reversible)} ${productsCompartmentsStr}`;
 };
 


### PR DESCRIPTION
This PR fixes the broken ascii symbols and links in the Reaction Tables. 

Some examples:

/explore/Human-GEM/gem-browser/metabolite/mdz_s
/explore/Human-GEM/gem-browser/metabolite/m01202c
/explore/Human-GEM/gem-browser/metabolite/m03106c