### PR TITLE
fix: broken missing reactions modal

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -7,6 +7,9 @@
         </div>
       </template>
       <template v-else>
+        <MissingReactionModal :current-map="currentMap"
+                               :missing-reaction-list="missingReactionList"
+                               :show-modal.sync="showModal"/>
         <div id="mapSidebar" ref="mapSidebar"
              class="column is-one-fifth-widescreen is-one-quarter-desktop
                     is-one-quarter-tablet has-background-lightgray om-2 pt-0
@@ -31,6 +34,8 @@
                                :dim="dimensionalState(showing2D)"
                                :current-map="currentMap"
                                :selection-data="selectionData"
+                               :show-modal.sync="showModal"
+                               :missing-reaction-list="missingReactionList"
                                @openSelectionCardContent="resetSidebarLayout" />
           </div>
           <div class="padding-mobile">
@@ -96,6 +101,7 @@ import { debounce } from 'vue-debounce';
 import DataOverlay from '@/components/explorer/mapViewer/DataOverlay.vue';
 import ErrorPanel from '@/components/shared/ErrorPanel';
 import MapsListing from '@/components/explorer/mapViewer/MapsListing.vue';
+import MissingReactionModal from '@/components/explorer/mapViewer/MissingReactionModal.vue';
 import NotFound from '@/components/NotFound';
 import SidebarDataPanels from '@/components/explorer/mapViewer/SidebarDataPanels.vue';
 import Svgmap from '@/components/explorer/mapViewer/Svgmap';
@@ -113,6 +119,7 @@ export default {
     SidebarDataPanels,
     Svgmap,
     ThreeDViewer,
+    MissingReactionModal,
   },
   data() {
     return {
@@ -128,6 +135,7 @@ export default {
       mapNotFound: false,
       messages,
       sidebarLayoutReset: true,
+      showModal: false,
     };
   },
   computed: {
@@ -136,10 +144,18 @@ export default {
       showing2D: state => state.maps.showing2D,
       dataOverlayPanelVisible: state => state.maps.dataOverlayPanelVisible,
       mapsListing: state => state.maps.mapsListing,
+      mapReactionList: state => state.maps.svgReactionsIdList,
     }),
     ...mapGetters({
       queryParams: 'maps/queryParams',
     }),
+    missingReactionList() {
+      const modelReactionIdSet = new Set(this.currentMap.reactionList);
+      const mapReactionIdSet = new Set(this.mapReactionList);
+      const missingReactionIdSet = new Set([...modelReactionIdSet].filter(x => !mapReactionIdSet.has(x)));
+      const missingReactionList = Array.from(missingReactionIdSet);
+      return missingReactionList;
+    },
   },
   watch: {
     '$route.params': 'loadMapFromParams',

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -137,6 +137,8 @@ export default {
       messages,
       sidebarLayoutReset: true,
       showModal: false,
+      mapReactionList: null,
+      missingReactionList: null,
     };
   },
   computed: {
@@ -149,20 +151,6 @@ export default {
     ...mapGetters({
       queryParams: 'maps/queryParams',
     }),
-    mapReactionList() {
-      let mapReactionIdList = [];
-      this.currentMap.mapReactionIdSet.forEach((map) => {
-        mapReactionIdList = [...mapReactionIdList, ...map.mapReactionIdSet];
-      });
-      return mapReactionIdList;
-    },
-    missingReactionList() {
-      const modelReactionIdSet = new Set(this.currentMap.reactionList);
-      const mapReactionIdSet = new Set(this.mapReactionList);
-      const missingReactionIdSet = new Set([...modelReactionIdSet].filter(x => !mapReactionIdSet.has(x)));
-      const missingReactionList = Array.from(missingReactionIdSet);
-      return missingReactionList;
-    },
   },
   watch: {
     '$route.params': 'loadMapFromParams',
@@ -242,6 +230,8 @@ export default {
                   this.currentMap.mapReactionIdSet = item.svgs;
                   this.currentMap.type = categories[i].slice(0, -1);
                   this.mapNotFound = false;
+                  this.setMapReactionList();
+                  this.setMissingReactionList();
                   return;
                 }
               }
@@ -249,12 +239,28 @@ export default {
               this.currentMap = item;
               this.currentMap.type = categories[i].slice(0, -1);
               this.mapNotFound = false;
+              this.currentMap.mapReactionIdSet = item.svgs;
+              this.setMapReactionList();
+              this.setMissingReactionList();
               return;
             }
             this.mapNotFound = true;
           }
         }
       }
+    },
+    setMapReactionList() {
+      let mapReactionIdList = [];
+      this.currentMap.mapReactionIdSet.forEach((map) => {
+        mapReactionIdList = [...mapReactionIdList, ...map.mapReactionIdSet];
+      });
+      this.mapReactionList = mapReactionIdList;
+    },
+    setMissingReactionList() {
+      const modelReactionIdSet = new Set(this.currentMap.reactionList);
+      const mapReactionIdSet = new Set(this.mapReactionList);
+      const missingReactionIdSet = new Set([...modelReactionIdSet].filter(x => !mapReactionIdSet.has(x)));
+      this.missingReactionList = Array.from(missingReactionIdSet);
     },
     showMessage(errorMessage) {
       this.loadMapErrorMessage = errorMessage;

--- a/frontend/src/components/explorer/mapViewer/MissingReactionModal.vue
+++ b/frontend/src/components/explorer/mapViewer/MissingReactionModal.vue
@@ -1,0 +1,112 @@
+<template>
+  <div v-if="showModal" class="modal is-active">
+    <div class="modal-background" @click="closeModal"></div>
+    <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
+    has-background-white">
+      <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
+      <p class="pb-4">
+        There are {{ missingReactionList.length }} reactions not shown on the map. Some reactions
+        are missing as the {{ currentMap.type }} is being updated much more often than the maps.
+        Also, as the maps are manually curated, occasionally some reactions cannot be added.
+        The number of reactions shown are {{ mapReactionList.length }}.
+      </p>
+      <table class="table main-table is-fullwidth m-0">
+        <tbody>
+          <tr>
+            <td class="td-key has-background-primary has-text-white-bis">Missing reactions on the map</td>
+            <td>
+              <div v-html="missingReactionIdListHtml"></div>
+              <div v-if="!showFullReactionListMissing && missingReactionList.length > displayedReaction">
+                <br>
+                <button class="is-small button" @click="showFullReactionListMissing=true">
+                  ... and {{ missingReactionList.length - displayedReaction }} more
+                </button>
+              </div>
+            </td>
+          </tr>
+          <tr>
+            <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
+            <td>
+              <div v-html="mapReactionIdListHtml"></div>
+              <div v-if="!showFullReactionListMap && mapReactionList.length > displayedReaction">
+                <br>
+                <button class="is-small button" @click="showFullReactionListMap=true">
+                  ... and {{ mapReactionList.length - displayedReaction }} more
+                </button>
+              </div>
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+    <button class="modal-close is-large" @click="closeModal"></button>
+  </div>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { buildCustomLink } from '@/helpers/utils';
+
+export default {
+  name: 'MissingReactionsModal',
+  props: {
+    currentMap: Object,
+    missingReactionList: Array,
+    showModal: Boolean,
+  },
+  data() {
+    return {
+      showFullReactionListMissing: false,
+      showFullReactionListMap: false,
+      displayedReaction: 40,
+    };
+  },
+  computed: {
+    ...mapState({
+      model: state => state.models.model,
+      mapReactionList: state => state.maps.svgReactionsIdList,
+    }),
+    mapReactionIdListHtml() {
+      const l = ['<span class="tags">'];
+      for (let i = 0; i < this.mapReactionList.length; i += 1) {
+        const r = this.mapReactionList[i];
+        if (!this.showFullReactionListMap && i === this.displayedReaction) {
+          break;
+        }
+        const customLink = buildCustomLink({ model: this.model.short_name, type: 'reaction', id: r, title: r, cssClass: 'target="_blank"' });
+        l.push(
+          `<span id="${r}" class="tag">${customLink}</span>`
+        );
+      }
+      l.push('</span>');
+      return l.join('');
+    },
+    missingReactionIdListHtml() {
+      const l = ['<span class="tags">'];
+      for (let i = 0; i < this.missingReactionList.length; i += 1) {
+        const r = this.missingReactionList[i];
+        if (!this.showFullReactionListMissing && i === this.displayedReaction) {
+          break;
+        }
+        const customLink = buildCustomLink({ model: this.model.short_name, type: 'reaction', id: r, title: r, cssClass: 'target="_blank"' });
+        l.push(
+          `<span id="${r}" class="tag">${customLink}</span>`
+        );
+      }
+      l.push('</span>');
+      return l.join('');
+    },
+  },
+  methods: {
+    closeModal() {
+      this.$emit('update:showModal', false);
+      this.showFullReactionListMissing = false;
+      this.showFullReactionListMap = false;
+    },
+  },
+};
+</script>
+
+<style lang="scss" scoped>
+
+</style>

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -9,16 +9,15 @@
       </header>
       <div v-if="dim==='2d' && currentMap.reactionList && missingReactionList.length > 0"
            class="card-content p-4">
-        <div v-if="currentMap.mapReactionIdSet.length == 1" class="content mb-0">
+        <template v-if="currentMap.mapReactionIdSet.length == 1">
           Please note that {{ missingReactionList.length }}
           of the reactions in the {{ currentMap.type }} are not shown on the map.
-          <a @click="$emit('update:showModal', true)"> See comparison </a>
-        </div>
-        <div v-else class="content mb-0">
+        </template>
+        <template v-else>
           Please note that {{ missingReactionList.length }} of the reactions in the
           {{ currentMap.type }} are not shown on any of the {{ currentMap.name }} maps.
-          <a @click="$emit('update:showModal', true)"> See comparison </a>
-        </div>
+        </template>
+        <a @click="$emit('update:showModal', true)"> See comparison </a>
       </div>
       <footer v-if="currentMap.type !== 'custom'" class="card-footer sidebarCardHover">
         <router-link class="p-0 is-info is-outlined card-footer-item has-text-centered"

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -12,49 +12,7 @@
         <div class="content mb-0">
           Please note that {{ missingReactionList.length }}
           of the reactions in the {{ currentMap.type }} are not shown on the map.
-          <a @click="showModal = true"> See comparison </a>
-        </div>
-        <div v-if="showModal" class="modal is-active">
-          <div class="modal-background" @click="closeModal"></div>
-          <div class="modal-content p-5 column is-6-fullhd is-8-desktop is-10-tablet is-full-mobile
-          has-background-white">
-            <h4 class="title is-size-4 m-0 mb-2"> List of missing and total reactions on the map </h4>
-            <p class="pb-4">
-              There are {{ missingReactionList.length }} reactions not shown on the map. Some reactions
-              are missing as the {{ currentMap.type }} is being updated much more often than the maps.
-              Also, as the maps are manually curated, occasionally some reactions cannot be added.
-              The number of reactions shown are {{ mapReactionList.length }}.
-            </p>
-            <table class="table main-table is-fullwidth m-0">
-              <tbody>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Missing reactions on the map</td>
-                  <td>
-                    <div v-html="missingReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionListMissing && missingReactionList.length > displayedReaction">
-                      <br>
-                      <button class="is-small button" @click="showFullReactionListMissing=true">
-                        ... and {{ missingReactionList.length - displayedReaction }} more
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-                <tr>
-                  <td class="td-key has-background-primary has-text-white-bis">Reactions shown on the map</td>
-                  <td>
-                    <div v-html="mapReactionIdListHtml"></div>
-                    <div v-if="!showFullReactionListMap && mapReactionList.length > displayedReaction">
-                      <br>
-                      <button class="is-small button" @click="showFullReactionListMap=true">
-                        ... and {{ mapReactionList.length - displayedReaction }} more
-                      </button>
-                    </div>
-                  </td>
-                </tr>
-              </tbody>
-            </table>
-          </div>
-          <button class="modal-close is-large" @click="closeModal"></button>
+          <a @click="$emit('update:showModal', true)"> See comparison </a>
         </div>
       </div>
       <footer v-if="currentMap.type !== 'custom'" class="card-footer sidebarCardHover">
@@ -176,7 +134,7 @@
 
 <script>
 import { mapState } from 'vuex';
-import { capitalize, reformatStringToLink, reformatChemicalReactionHTML, buildCustomLink } from '@/helpers/utils';
+import { capitalize, reformatStringToLink, reformatChemicalReactionHTML } from '@/helpers/utils';
 import { chemicalFormula } from '@/helpers/chemical-formatters';
 import { default as messages } from '@/helpers/messages';
 
@@ -187,6 +145,8 @@ export default {
     currentMap: Object,
     mapsData: Object,
     selectionData: Object,
+    showModal: Boolean,
+    missingReactionList: Array,
   },
   data() {
     return {
@@ -210,11 +170,6 @@ export default {
       showMapCardContent: true,
       showSelectionCardContent: true,
       messages,
-      showModal: false,
-      showFullReactionListMissing: false,
-      showFullReactionListMap: false,
-      displayedReaction: 40,
-      missingNumberOfReactions: null,
     };
   },
   computed: {
@@ -223,46 +178,6 @@ export default {
       loading: state => state.maps.loadingElement,
       mapReactionList: state => state.maps.svgReactionsIdList,
     }),
-    modelNumberOfReactions() {
-      return this.currentMap.reactionList ? this.currentMap.reactionList.length : null;
-    },
-    mapReactionIdListHtml() {
-      const l = ['<span class="tags">'];
-      for (let i = 0; i < this.mapReactionList.length; i += 1) {
-        const r = this.mapReactionList[i];
-        if (!this.showFullReactionListMap && i === this.displayedReaction) {
-          break;
-        }
-        const customLink = buildCustomLink({ model: this.model.short_name, type: 'reaction', id: r, title: r, cssClass: 'target="_blank"' });
-        l.push(
-          `<span id="${r}" class="tag">${customLink}</span>`
-        );
-      }
-      l.push('</span>');
-      return l.join('');
-    },
-    missingReactionList() {
-      const modelReactionIdSet = new Set(this.currentMap.reactionList);
-      const mapReactionIdSet = new Set(this.mapReactionList);
-      const missingReactionIdSet = new Set([...modelReactionIdSet].filter(x => !mapReactionIdSet.has(x)));
-      const missingReactionList = Array.from(missingReactionIdSet);
-      return missingReactionList;
-    },
-    missingReactionIdListHtml() {
-      const l = ['<span class="tags">'];
-      for (let i = 0; i < this.missingReactionList.length; i += 1) {
-        const r = this.missingReactionList[i];
-        if (!this.showFullReactionListMissing && i === this.displayedReaction) {
-          break;
-        }
-        const customLink = buildCustomLink({ model: this.model.short_name, type: 'reaction', id: r, title: r, cssClass: 'target="_blank"' });
-        l.push(
-          `<span id="${r}" class="tag">${customLink}</span>`
-        );
-      }
-      l.push('</span>');
-      return l.join('');
-    },
   },
   watch: {
     selectionData() {
@@ -290,11 +205,6 @@ export default {
     reformatStringToLink,
     chemicalFormula,
     reformatChemicalReactionHTML,
-    closeModal() {
-      this.showModal = false;
-      this.showFullReactionListMissing = false;
-      this.showFullReactionListMap = false;
-    },
     toggleSelectionCardContent() {
       if (this.showSelectionCardContent) {
         this.hideSelectionCardContent();


### PR DESCRIPTION
This PR closes issue #648

Please test out MapViewer and see if everything is working as it should. Please try out edge cases, such as switching between 2d and 3d, selecting another map while inside 2d and 3d and so on, to see if there are any sneaky bugs I have missed.

The modal (now in a separate component called MissingReactionModal) was moved to not be a child under `<div id="mapSidebar__header"...>` to avoid the bug introduced by the new styling in commit 8f43b0df6104b255bd9f9a60b9be8b46c683bb33. Some related information is available at https://stackoverflow.com/questions/31646746/z-index-behaviour-is-different-in-chrome-to-firefox/31710969#31710969