### PR TITLE
fix: use styling to fix the height of the 3D viewer on mobile

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -365,7 +365,7 @@ export default {
 
 .fixed-height-mobile {
   @media screen and (max-width: $tablet) {
-    height: 450px;
+    height: $viewer-height;
   }
   position: relative;
 }

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -288,5 +288,8 @@ export default {
 .viewer-container, #viewer3d {
   width: 100%;
   height: 100%;
+  @media screen and (max-width: $tablet) {
+    height: $viewer-height;
+  }
 }
 </style>

--- a/frontend/src/style/vars.scss
+++ b/frontend/src/style/vars.scss
@@ -28,3 +28,5 @@ $black: hsl(0, 0%, 4%);
 // Custom variables for fullheight Map Viewer, same as Bulma defaults
 $navbar-height: 4rem;
 $footer-height: 3.5rem;
+
+$viewer-height: 450px;


### PR DESCRIPTION
The fix proposed by @e0 has proven to work - it was tested from the dev server and Android, and locally with Firefox/Chrome and responsive mode. Since this introduced a second use of the height value, a variable was defined.