### PR TITLE
fix: clear selected element from map viewer if the new map does not contain it

### DIFF
--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -445,6 +445,7 @@ export default {
     },
     async selectElement(element, routeSelect = false) {
       if (!element) {
+        this.unSelectElement();
         return;
       }
       const [id, type] = this.getElementIdAndType(element);


### PR DESCRIPTION
This closes #630 

The following steps can be used to test the intended behavior of keeping the selected element card if the new map contains it and clearing it if the new map doesn't.

1. Visit `/explore/Human-GEM/gem-browser/reaction/MAR03306`.
2. Click the "2D" button next to "Beta oxidation of di-unsaturated fatty acids (n-6) (peroxisomal)".
3. Verify that the "Reaction: MAR03306" card is **in** the map viewer sidebar after the page finishes loading.
4. Click the "Peroxisome" link under "Compartment Maps".
5. Verify that the "Reaction: MAR03306" card is **still in** the map viewer sidebar after the page finishes loading.
6. Click on any other link in the list of maps, for example: "Endoplasmic reticulum".
7. Verify that the "Reaction: MAR03306" card is **no longer in** the map viewer sidebar after the page finishes loading.