### PR TITLE
fix: change layout of 2d viewer (to like in 3d) and remove previous workaround fix for enabling search

### DIFF
--- a/frontend/src/components/explorer/mapViewer/MapSearch.vue
+++ b/frontend/src/components/explorer/mapViewer/MapSearch.vue
@@ -33,7 +33,6 @@
 
 import { mapState } from 'vuex';
 import { debounce } from 'vue-debounce';
-import { default as EventBus } from '@/event-bus';
 import { default as messages } from '../../../helpers/messages';
 
 export default {
@@ -75,18 +74,9 @@ export default {
       }
       this.currentSearchMatch = 0;
     },
-    // workaround for the bug that 2D search bar can not type in text
-    loading(now, before) {
-      if (before === true && now === false) {
-        this.focusOnInputSearch();
-      }
-    },
   },
   created() {
     this.search = debounce(this.search, 300);
-    EventBus.$on('apply2DHPARNAlevels', () => {
-      this.focusOnInputSearch();
-    });
   },
   methods: {
     handleChange(term) {
@@ -146,9 +136,6 @@ export default {
         this.currentSearchMatch = 0;
       }
       this.$emit('centerViewOn', this.matches[this.currentSearchMatch]);
-    },
-    focusOnInputSearch() {
-      setTimeout(() => document.getElementById('searchInput').focus());
     },
   },
 };

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -1,14 +1,18 @@
 <template>
-  <div class="svgbox p-0 m-0">
-    <div v-if="errorMessage" class="columns is-centered">
-      <div class="column is-half has-text-centered">
-        <p class="notification has-background-danger-light" style="margin-top: 30%;" v-html="errorMessage"></p>
+  <div class="viewer-container">
+    <div class="svgbox p-0 m-0">
+      <div v-if="errorMessage" class="columns is-centered">
+        <div class="column is-half has-text-centered">
+          <p class="notification has-background-danger-light" style="margin-top: 30%;" v-html="errorMessage"></p>
+        </div>
       </div>
+      <MapLoader />
+      <div id="svg-wrapper" v-html="svgContent">
+      </div>
+      <div id="tooltip" ref="tooltip"></div>
     </div>
-    <MapLoader />
-    <div id="svg-wrapper" v-html="svgContent">
-    </div>
-    <MapControls wrapper-elem-selector=".svgbox" :is-fullscreen="isFullscreen"
+
+    <MapControls wrapper-elem-selector=".viewer-container" :is-fullscreen="isFullscreen"
                  :zoom-in="zoomIn" :zoom-out="zoomOut"
                  :toggle-full-screen="toggleFullscreen" :toggle-genes="toggleGenes"
                  :toggle-subsystems="toggleSubsystems" :download-canvas="downloadCanvas" />
@@ -16,7 +20,6 @@
                :fullscreen="isFullscreen"
                @searchOnMap="searchIDsOnMap" @centerViewOn="centerElementOnSVG"
                @unHighlightAll="unHighlight" />
-    <div id="tooltip" ref="tooltip"></div>
   </div>
 </template>
 
@@ -541,6 +544,14 @@ export default {
 </script>
 
 <style lang="scss">
+
+.viewer-container {
+  width: 100%;
+  height: 100%;
+  @media screen and (max-width: $tablet) {
+    height: $viewer-height;
+  }
+}
 
 .met, .rea, .enz {
   .shape, .lbl {


### PR DESCRIPTION
This closes #638 

This also fixes problems where the mouse "clicks through" the search and map controls. For example if you dragged over the search bar it would pan the map, this is no longer the behavior so interacting with the search and map controls do not interfere with the map itself.