### PR TITLE
refactor: show chebi image only if exists with a single request

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -53,12 +53,16 @@
       </table>
     </template>
     <template v-slot:chebi>
-      <div v-if="chebiImageLink"
+      <div v-if="metabolite.externalDbs && metabolite.externalDbs.ChEBI"
            class="column is-3-widescreen is-2-desktop is-full-tablet has-text-centered px-2">
         <a :href="metabolite.externalDbs.ChEBI[0].url" target="_blank">
-          <img id="chebi-img" :src="chebiImageLink" class="hoverable" />
+          <img id="chebi-img"
+               :src="`https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${metabolite.externalDbs.ChEBI[0].id.slice(6)}&dimensions=400`"
+               class="hoverable"
+               onerror="this.onerror=null;this.parentElement.parentElement.style.display='none';" />
           <a :href="metabolite.externalDbs.ChEBI[0].url" target="_blank" style="display: block;">
-            {{ metabolite.name }} via ChEBI</a>
+            {{ metabolite.name }} via ChEBI
+          </a>
         </a>
       </div>
     </template>
@@ -66,7 +70,6 @@
 </template>
 
 <script>
-import axios from 'axios';
 import { mapState } from 'vuex';
 import ComponentLayout from '@/layouts/explorer/gemBrowser/ComponentLayout';
 import { default as chemicalFormula } from '@/helpers/chemical-formatters';
@@ -92,7 +95,6 @@ export default {
         { name: 'compartment' },
       ],
       activePanel: 'table',
-      chebiImageLink: null,
     };
   },
   computed: {
@@ -129,14 +131,6 @@ export default {
   },
   methods: {
     async handleCallback() {
-      if (this.metabolite.externalDbs.ChEBI) {
-        const link = `https://www.ebi.ac.uk/chebi/displayImage.do?defaultImage=true&imageIndex=0&chebiId=${this.metabolite.externalDbs.ChEBI[0].id.slice(6)}`;
-        const { data } = await axios.get(link);
-        if (data !== '') {
-          this.chebiImageLink = `${link}&dimensions=400`;
-        }
-      }
-
       try {
         const payload = { model: this.model, id: this.metaboliteId };
         await this.$store.dispatch('metabolites/getRelatedMetabolites', payload);


### PR DESCRIPTION
The original version created two requests in order to verify that a ChEBI image exists https://github.com/MetabolicAtlas/MetabolicAtlas/pull/589.

In this PR the refactoring is focused on triggering a single request by using the technique described in [point 2 here](https://blog.imagekit.io/how-to-handle-loading-images-that-may-not-exist-on-your-website-92e6c3c6ea63) which also resolves bugs such as mentioned in https://github.com/MetabolicAtlas/private-issues/issues/117. While it has been reported that `onerror` is deprecated for `img`, it is still a valid HTML attribute, and as commented in various forums, it is still okay to use. Since the request to ChEBI was done prior to requesting the related metabolites, the website might also appear to load faster by having this request handled in parallel by the browser.

As in the original PR, here are the test cases:

>Fix so no broken ChEBI images are shown
With image
http://localhost/explore/Human-GEM/gem-browser/metabolite/MAM03362p
With broken image
http://localhost/explore/Human-GEM/gem-browser/metabolite/MAM02576c
With no ChEBI entry at all
http://localhost/explore/Human-GEM/gem-browser/metabolite/MAM02865c
