### PR TITLE
fix: update the selected model for search when the global model is updated

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -124,6 +124,11 @@ export default {
       return 'uracil, SULT1A3, ATP => cAMP + PPi, subsystem or compartment';
     },
   },
+  watch: {
+    model(m) {
+      this.searchModel = m;
+    },
+  },
   async created() {
     await this.getIntegratedModelList();
   },
@@ -138,7 +143,6 @@ export default {
         this.$router.replace({ params: { model: modelKey } });
       }
       this.$store.dispatch('models/selectModel', modelKey);
-      this.searchModel = this.models[modelKey];
     },
     async handleModelChange(e) {
       e.preventDefault();


### PR DESCRIPTION
This closes https://github.com/MetabolicAtlas/private-issues/issues/17

### Steps to verify
1. Visit the landing page (`/`).
2. Click on the search icon in the menubar.
3. Verify that the selected model for search is `Fruitfly-GEM`, which is the first one in the list of models.
4. Dismiss the search by clicking outside the search bar.
5. Click on the `GEM Browser` link (below the hero block), which leads to the `/explore/Human-GEM/gem-browser` page.
6. Click on the search icon in the menubar.
7. Verify that the selected model for search is now `Human-GEM` instead of staying as `Fruitily-GEM`.