### PR TITLE
fix: dispose 3D viewer when it's not in use

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "cytoscape-cola": "2.3.0",
     "file-saver": "^2.0.2",
     "jquery": "3.3.1",
-    "@metabolicatlas/3d-network-viewer": "^0.1.17",
+    "@metabolicatlas/3d-network-viewer": "^0.1.18",
     "@panzoom/panzoom": "^4.3.2",
     "vue": "^2.6.10",
     "vue-color": "2.0.9",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,7 +19,7 @@
     "cytoscape-cola": "2.3.0",
     "file-saver": "^2.0.2",
     "jquery": "3.3.1",
-    "@metabolicatlas/3d-network-viewer": "^0.1.14",
+    "@metabolicatlas/3d-network-viewer": "^0.1.17",
     "@panzoom/panzoom": "^4.3.2",
     "vue": "^2.6.10",
     "vue-color": "2.0.9",

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -123,7 +123,6 @@ export default {
     },
     async renderNetwork(customizedNetwork) {
       this.resetNetwork();
-
       this.controller = MetAtlasViewer('viewer3d');
 
       const graphData = customizedNetwork || this.network;

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -56,6 +56,7 @@ export default {
       controller: null,
       isFullscreen: false,
       searchedNodesOnMap: [],
+      currentLevels: {},
     };
   },
   computed: {
@@ -74,7 +75,6 @@ export default {
   },
   watch: {
     async currentMap() {
-      this.resetNetwork();
       await this.loadNetwork();
     },
     dataOverlayPanelVisible() {
@@ -88,6 +88,9 @@ export default {
   },
   async mounted() {
     await this.loadNetwork();
+  },
+  beforeDestroy() {
+    this.resetNetwork();
   },
   methods: {
     async loadNetwork() {
@@ -120,6 +123,7 @@ export default {
     },
     async renderNetwork(customizedNetwork) {
       this.resetNetwork();
+
       this.controller = MetAtlasViewer('viewer3d');
 
       const graphData = customizedNetwork || this.network;
@@ -177,6 +181,13 @@ export default {
       }
     },
     async applyColorsAndRenderNetwork(levels) {
+      if (this.currentLevels === levels
+          || (this.currentLevels === {} && Object.keys(levels).length > 0)
+      ) {
+        return;
+      }
+      this.currentLevels = levels;
+
       const nodes = this.network.nodes.map((node) => {
         let color = colorToRGBArray('#9df');
 
@@ -219,8 +230,10 @@ export default {
       this.$store.dispatch('maps/setCoords', payload);
     },
     resetNetwork() {
-      const viewer = document.getElementById('viewer3d');
-      viewer.innerHTML = '';
+      if (this.controller) {
+        this.controller.dispose();
+        this.controller = null;
+      }
     },
     zoomIn() {
       this.zoomBy(50);

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -735,10 +735,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@metabolicatlas/3d-network-viewer@^0.1.17":
-  version "0.1.17"
-  resolved "https://registry.yarnpkg.com/@metabolicatlas/3d-network-viewer/-/3d-network-viewer-0.1.17.tgz#e4c3f0b4c38765089a7894a36a59624197ef23cf"
-  integrity sha512-8B84hBLJ6rkBF3nPDfW/wmdfxr2Dq84QoybiKwqQE9gqJ+XEmq3I2ZE5OgpSQ4mDfv26RM3ZEPMQ7ID8OcGGBg==
+"@metabolicatlas/3d-network-viewer@^0.1.18":
+  version "0.1.18"
+  resolved "https://registry.yarnpkg.com/@metabolicatlas/3d-network-viewer/-/3d-network-viewer-0.1.18.tgz#2c58510d82bd05631fd2076217623c28032c2962"
+  integrity sha512-RqFZq/iEbs4ISaC3IoYz7flHPq7RVXcf+PLveYJw7MCOhAQ5A/rJBF5l6daGo1FXOdpeYwioULjl5p6kZ+PfrQ==
   dependencies:
     three "^0.126.0"
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -735,10 +735,10 @@
     cssnano-preset-default "^4.0.0"
     postcss "^7.0.0"
 
-"@metabolicatlas/3d-network-viewer@^0.1.14":
-  version "0.1.14"
-  resolved "https://registry.yarnpkg.com/@metabolicatlas/3d-network-viewer/-/3d-network-viewer-0.1.14.tgz#b5ffb6be2fb0f758a378889c418de866c7d7f729"
-  integrity sha512-0lKs6lLOidzANRGVCBBKjHKoHJW/HOpc1qXCo4gVO1hmrAHV5dGwB9jLZtaEs09sIOiM4n85dwIt3ls9DjGe+g==
+"@metabolicatlas/3d-network-viewer@^0.1.17":
+  version "0.1.17"
+  resolved "https://registry.yarnpkg.com/@metabolicatlas/3d-network-viewer/-/3d-network-viewer-0.1.17.tgz#e4c3f0b4c38765089a7894a36a59624197ef23cf"
+  integrity sha512-8B84hBLJ6rkBF3nPDfW/wmdfxr2Dq84QoybiKwqQE9gqJ+XEmq3I2ZE5OgpSQ4mDfv26RM3ZEPMQ7ID8OcGGBg==
   dependencies:
     three "^0.126.0"
 


### PR DESCRIPTION
This closes #664 

This was a bit of a tricky one. Had to do a deep dive in [how to dispose things in three.js](https://threejs.org/docs/#manual/en/introduction/How-to-dispose-of-objects). If I understand correctly, without manually disposing things as [now implemented](https://github.com/MetabolicAtlas/3d-network-viewer/blob/main/src/met-atlas-viewer.js#L1063) in the 3d-network-viewer library, there is no automatic garbage collection for resources used in three.js and this could potentially lead to memory leak in the RAM and GPU. Hope the fixes here covered the problem and can bring much better performance to the users.