### PR TITLE
feat: show model in error message for component id errors

### DIFF
--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -4,6 +4,7 @@
       <template v-if="type">
         <p class="title is-size-5">
           <span class="is-capitalized">{{ type }}</span><code>{{ componentId }}</code>not found
+          <template v-if="type !== 'model'">in<code>{{ model.short_name }}</code></template>
         </p>
         <p v-if="type === 'model'">{{ messages.modelNotFound }}</p>
         <p v-else>
@@ -32,6 +33,7 @@
 </template>
 <script>
 
+import { mapState } from 'vuex';
 import { default as messages } from '@/content/messages';
 
 export default {
@@ -44,6 +46,11 @@ export default {
     return {
       messages,
     };
+  },
+  computed: {
+    ...mapState({
+      model: state => state.models.model,
+    }),
   },
 };
 


### PR DESCRIPTION
As a user, I want to easily understand why an ID is not found, so that I find out how to look for it, or where the problem is.

At the moment, visiting an url with a wrong identifier, for example [this](https://metabolicatlas.org/explore/Human-GEM/gem-browser/reaction/m00524), shows:

<img width="434" alt="image" src="https://user-images.githubusercontent.com/23480589/128426662-eacfa44a-0247-4422-ba48-a1af9cd29745.png">

With the changes in this PR, it will show:

<img width="445" alt="image" src="https://user-images.githubusercontent.com/23480589/128426727-a0bf5121-cb22-418f-a224-a77fd2281f91.png">

This will help clarify that the ID was not found in the selected model, which can be different than what the user intended to select.
