### PR TITLE
feat: add API endpoints for data overlay sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ svg/
 
 # data folder in API
 api/src/data/*.json
+
+# dataOverlay folder in API
+api/dataOverlay

--- a/api/src/endpoints/dataOverlay.js
+++ b/api/src/endpoints/dataOverlay.js
@@ -1,0 +1,35 @@
+import express from 'express';
+import { readFileSync } from 'fs';
+
+const routes = express.Router();
+
+routes.get('/:model', async (req, res) => {
+  const { model } = req.params;
+  try {
+    const indexJson = readFileSync(
+      `/project/dataOverlay/${model}/index.json`,
+      'utf8',
+    );
+    res.json(JSON.parse(indexJson));
+  } catch (e) {
+    console.error(e.message);
+    res.sendStatus(404);
+  }
+});
+
+routes.get('/:model/:dataType/:filename', async (req, res) => {
+  const { model, dataType, filename } = req.params;
+  try {
+    const dataSourceFile = readFileSync(
+      `/project/dataOverlay/${model}/${dataType}/${filename}`,
+      'utf8',
+    );
+    res.setHeader('Content-Type', 'text/tsv');
+    res.send(dataSourceFile);
+  } catch (e) {
+    console.error(e.message);
+    res.sendStatus(404);
+  }
+});
+
+export default routes;

--- a/api/src/endpoints/index.js
+++ b/api/src/endpoints/index.js
@@ -2,6 +2,7 @@ import express from 'express';
 import neo4jRoutes from 'endpoints/neo4j';
 import repoRoutes from 'endpoints/repository';
 import hpaRoutes from 'endpoints/hpaRna';
+import dataOverlayRoutes from 'endpoints/dataOverlay';
 import swaggerRoutes from 'endpoints/swagger';
 
 const router = express.Router();
@@ -9,6 +10,7 @@ const router = express.Router();
 router.use(neo4jRoutes);
 router.use('/repository', repoRoutes);
 router.use('/rna', hpaRoutes);
+router.use('/data-overlay', dataOverlayRoutes);
 router.use(swaggerRoutes);
 
 export default router;

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -43,6 +43,7 @@ services:
       - ./api/svg:/project/svg
       - ./api/repository:/project/repository
       - ./api/public:/project/public
+      - ./api/dataOverlay:/project/dataOverlay
     command: yarn develop
 
   ftp:

--- a/proj.sh
+++ b/proj.sh
@@ -6,7 +6,8 @@ function generate-data {
   echo 'Data generation started.'
   source .env && yarn --cwd $DATA_GENERATOR_PATH start $DATA_FILES_PATH "$@"
   /bin/cp -rf $DATA_GENERATOR_PATH/data/* neo4j/import
-  /bin/cp  -f $DATA_GENERATOR_PATH/data/hpaRna.json api/src/data/
+  /bin/cp  -f $DATA_GENERATOR_PATH/data/hpaRna.json api/src/data/ # this line should be removed after HPA data is included in the dataOverlay folder
+  /bin/cp -rf $DATA_GENERATOR_PATH/data/dataOverlay api/
   /bin/cp  -f $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
   /bin/cp  -f $DATA_FILES_PATH/gemsRepository.json api/src/data/
   /bin/cp -rf $DATA_FILES_PATH/svg api/


### PR DESCRIPTION
This is related to MetabolicAtlas/private-issues#113.

After building and starting the project, the new endpoints can be reached at (examples):

- Index metadata for all data sources of a model: `/api/data-overlay/Human-GEM`.
- Data source file: `/api/data-overlay/Human-GEM/transcriptomics/protein1.mock.tsv`

After https://github.com/MetabolicAtlas/data-files/pull/14, https://github.com/MetabolicAtlas/neo4j-data-generation/pull/20, as well as this PR are approved and merged, MetabolicAtlas/private-issues#113 can be closed.