### PR TITLE
feat: incorporate feedback for the identifiers page

### DIFF
--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -8,17 +8,23 @@
         This database identifier is associated with the following Metabolic Atlas
         {{ components.length === 1 ? 'component' : 'components' }}:
       </p>
+
       <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
-        <li v-for="c in components" :key="c.id + c.model + c.version" class="my-1">
-          <span class="tag is-light is-medium">
-            <router-link :to="{ name: c.componentType.toLowerCase(), params: { model:
-              c.model, id: c.id } }">
-              {{ c.id }}
-            </router-link>
-          </span>
-          from {{ c.model }} {{ c.version }}
+        <li v-for="(components, model) in compGroupedByModel" :key="model" class="my-1">
+          {{ model }}
+          <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
+            <li v-for="c in components" :key="c.id + c.model + c.version" class="my-1">
+              <span class="tag is-light is-medium">
+                <router-link :to="{ name: c.componentType.toLowerCase(), params: { model:
+                  c.model, id: c.id } }">
+                  {{ c.id }}
+                </router-link>
+              </span>
+            </li>
+          </ul>
         </li>
       </ul>
+
       <p v-if="externalDb.url">
         For more details, visit <a :href="externalDb.url" target="_blank"> {{ externalDb.url }} </a>.
       </p>
@@ -36,6 +42,21 @@ export default {
       components: state => state.externalDb.components,
       externalDb: state => state.externalDb.externalDb,
     }),
+    compGroupedByModel() {
+      const result = this.components.reduce((r, a) => { // eslint-disable-next-line
+        r[a.model] = r[a.model] || [];
+        r[a.model].push(a);
+        return r;
+      }, Object.create(null));
+      const orderedRst = Object.keys(result).sort().reduce(
+        (obj, key) => { // eslint-disable-next-line
+          obj[key] = result[key];
+          return obj;
+        },
+        {}
+      );
+      return orderedRst;
+    },
   },
   async beforeMount() {
     await this.$store.dispatch('externalDb/getComponentsForExternalDb', {

--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -7,8 +7,10 @@
       <p class="my-3">
         This database identifier is associated with the following Metabolic Atlas
         {{ components.length === 1 ? 'component' : 'components' }}:
+        <template v-if="externalDb.url">
+          <br>(please visit <a :href="externalDb.url" target="_blank">{{ externalDb.url }}</a> for more detailes)
+        </template>
       </p>
-
       <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
         <li v-for="(components, model) in compGroupedByModel" :key="model" class="my-1">
           {{ model }} {{ components[0].version }}
@@ -24,10 +26,6 @@
           </ul>
         </li>
       </ul>
-
-      <p v-if="externalDb.url">
-        For more details, visit <a :href="externalDb.url" target="_blank"> {{ externalDb.url }} </a>.
-      </p>
     </div>
   </section>
 </template>

--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -11,7 +11,7 @@
 
       <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
         <li v-for="(components, model) in compGroupedByModel" :key="model" class="my-1">
-          {{ model }}
+          {{ model }} {{ components[0].version }}
           <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
             <li v-for="c in components" :key="c.id + c.model + c.version" class="my-1">
               <span class="tag is-light is-medium">

--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -10,7 +10,6 @@
       </p>
       <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
         <li v-for="c in components" :key="c.id + c.model + c.version" class="my-1">
-          {{ c.componentType }}
           <span class="tag is-light is-medium">
             <router-link :to="{ name: c.componentType.toLowerCase(), params: { model:
               c.model, id: c.id } }">

--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -71,4 +71,7 @@ export default {
 ul {
   list-style: disc outside none;
 }
+ul ul {
+  list-style: circle outside none;
+}
 </style>

--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -47,14 +47,12 @@ export default {
         r[a.model] = r[a.model] || [];
         r[a.model].push(a);
         return r;
-      }, Object.create(null));
+      }, {});
       const orderedRst = Object.keys(result).sort().reduce(
         (obj, key) => { // eslint-disable-next-line
           obj[key] = result[key];
           return obj;
-        },
-        {}
-      );
+        }, {});
       return orderedRst;
     },
   },

--- a/frontend/src/components/ExternalDb.vue
+++ b/frontend/src/components/ExternalDb.vue
@@ -8,7 +8,7 @@
         This database identifier is associated with the following Metabolic Atlas
         {{ components.length === 1 ? 'component' : 'components' }}:
         <template v-if="externalDb.url">
-          <br>(please visit <a :href="externalDb.url" target="_blank">{{ externalDb.url }}</a> for more detailes)
+          <br>(visit <a :href="externalDb.url" target="_blank">{{ externalDb.url }}</a> for more detailes)
         </template>
       </p>
       <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">

--- a/frontend/src/components/explorer/gemBrowser/ExtIdTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ExtIdTable.vue
@@ -9,8 +9,10 @@
             <td>
               <template v-for="(el, index) in externalDbs[k]">
                 <template v-if="index !== 0">{{ '; ' }}</template>
-                <template v-if="el.url">
-                  <a :key="el.id" :href="`${el.url}`" target="_blank">{{ el.id }}</a>
+                <template v-if="true">
+                <!-- <template v-if="el.url"> -->
+                  <!-- <a :key="el.id" :href="`${el.url}`" target="_blank">{{ el.id }}</a> -->
+                  <a :key="el.id" :href="`/identifier/${k}/${el.id}`" target="_blank">{{ el.id }}</a>
                 </template>
                 <template v-else>
                   {{ el.id }}

--- a/frontend/src/components/explorer/gemBrowser/ExtIdTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ExtIdTable.vue
@@ -9,14 +9,7 @@
             <td>
               <template v-for="(el, index) in externalDbs[k]">
                 <template v-if="index !== 0">{{ '; ' }}</template>
-                <template v-if="true">
-                <!-- <template v-if="el.url"> -->
-                  <!-- <a :key="el.id" :href="`${el.url}`" target="_blank">{{ el.id }}</a> -->
-                  <a :key="el.id" :href="`/identifier/${k}/${el.id}`" target="_blank">{{ el.id }}</a>
-                </template>
-                <template v-else>
-                  {{ el.id }}
-                </template>
+                <a :key="el.id" :href="`/identifier/${k}/${el.id}`" target="_blank">{{ el.id }}</a>
               </template>
             </td>
           </tr>


### PR DESCRIPTION
This PR closes #637 
Some points of the issue may still need to be clarified, see comment in the issue #637 

Linking from the section External databases in the Gem Browser to the identifiers page has been implemented at the commit c36b1d8c, but not sure if it is the desired feature. 
For some external pages, e.g. `/identifier/HMR%202.0/m00357c`, there is not url to the real external web-page, I think it might be better to mention that the external webpage for HMR2.0 does not exist. 
