### PR TITLE
fix: work break for long names in MapsAvailable.vue

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -435,4 +435,8 @@ span.sc {
   white-space: nowrap;
 }
 
+.break-word {
+  word-break: break-word;
+}
+
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -437,6 +437,10 @@ span.sc {
 
 .break-word {
   word-break: break-word;
+  -webkit-hyphens: auto;
+  -moz-hyphens: auto;
+  -ms-hyphens: auto;
+  hyphens: auto;
 }
 
 </style>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -438,8 +438,6 @@ span.sc {
 .break-word {
   word-break: break-word;
   -webkit-hyphens: auto;
-  -moz-hyphens: auto;
-  -ms-hyphens: auto;
   hyphens: auto;
 }
 

--- a/frontend/src/components/explorer/GemBrowser.vue
+++ b/frontend/src/components/explorer/GemBrowser.vue
@@ -31,7 +31,7 @@
               <br>
             </div>
           </div>
-          <div v-if="tileComponents" id="gem-browser-tiles" class="tile is-ancestor">
+          <div v-if="tileComponents" id="gem-browser-tiles" class="tile is-ancestor break-word">
             <div class="tile">
               <div class="tile is-vertical is-9">
                 <div class="tile">
@@ -127,7 +127,6 @@ export default {
 <style lang="scss">
 
 #gem-browser-tiles {
-  word-wrap: anywhere;
   .tile.is-child {
     ul {
       list-style-type: disc;

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -14,7 +14,7 @@
         <div id="mapSidebar" ref="mapSidebar"
              class="column is-one-fifth-widescreen is-one-quarter-desktop
                     is-one-quarter-tablet has-background-lightgray om-2 pt-0
-                    fixed-height-desktop scrollable"
+                    fixed-height-desktop scrollable break-word"
              v-on="sidebarLayoutReset ? { scroll: () => handleSidebarScroll() } : {}">
           <div id="mapSidebar__header" class="has-background-lightgray pt-3">
             <div class="buttons has-addons is-centered padding-mobile m-0"
@@ -277,8 +277,6 @@ export default {
 #mapViewerContainer {
 
   #mapSidebar {
-    word-wrap: break-word;
-
     &__header {
       @media screen and (min-width: $tablet) {
         position: sticky;

--- a/frontend/src/components/explorer/gemBrowser/MapsAvailable.vue
+++ b/frontend/src/components/explorer/gemBrowser/MapsAvailable.vue
@@ -10,7 +10,7 @@
       <table class="table maps-table">
         <tbody class="has-text-left">
           <tr v-for="component in mapsAvailable" :key="component.id">
-            <td> {{ component.customName }} </td>
+            <td style="word-break: break-word;"> {{ component.customName }} </td>
             <td v-if="component.svgMaps.length===0"> </td>
             <td v-else-if="component.svgMaps.length===1">
               <button class="button is-outlined is-small link-button"

--- a/frontend/src/components/explorer/gemBrowser/MapsAvailable.vue
+++ b/frontend/src/components/explorer/gemBrowser/MapsAvailable.vue
@@ -10,7 +10,7 @@
       <table class="table maps-table">
         <tbody class="has-text-left">
           <tr v-for="component in mapsAvailable" :key="component.id">
-            <td style="word-break: break-word;"> {{ component.customName }} </td>
+            <td class="break-word"> {{ component.customName }} </td>
             <td v-if="component.svgMaps.length===0"> </td>
             <td v-else-if="component.svgMaps.length===1">
               <button class="button is-outlined is-small link-button"

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -30,7 +30,7 @@
               <a href="/api/v2" target="_blank">API</a></p>
           </div>
           <slot v-if="isMetabolite" name="chebi" />
-          <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered">
+          <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered" style="min-width: 350px;">
             <router-link v-if="interactionPartner" class="button is-info is-fullwidth is-outlined"
                          :to="{
                            name: 'interaction',

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -30,7 +30,7 @@
               <a href="/api/v2" target="_blank">API</a></p>
           </div>
           <slot v-if="isMetabolite" name="chebi" />
-          <div class="column is-3-widescreen is-3-desktop is-half-tablet has-text-centered" style="min-width: 350px;">
+          <div class="column is-3-widescreen is-4-desktop is-6-tablet has-text-centered">
             <router-link v-if="interactionPartner" class="button is-info is-fullwidth is-outlined"
                          :to="{
                            name: 'interaction',


### PR DESCRIPTION
This PR closes #675, i.e. fixing map names taking up too much space if very long.

Some examples links to test:

/explore/Human-GEM/gem-browser/reaction/MAR08387
/explore/Human-GEM/gem-browser/metabolite/MAM03556m
/explore/Human-GEM/gem-browser/gene/ENSG00000088179

But please play around with the gem browser as well and different screen sizes to see if you can find weird cases I've missed
