### PR TITLE
refactor: use bulma classes and scoped css where possible

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -23,6 +23,7 @@
   <style>
     #init-loading {
       text-align: center;
+      display: none;
     }
 
     .multi-spinner-container {
@@ -136,7 +137,7 @@
     }
   </style>
   <div id="app">
-    <div id="init-loading" style="display: none">
+    <div id="init-loading">
       <h3>Loading Metabolic Atlas</h3>
       <!-- source https://codepen.io/camdenfoucht/pen/BVxawq -->
       <div class="multi-spinner-container">

--- a/frontend/src/components/FourOFour.vue
+++ b/frontend/src/components/FourOFour.vue
@@ -19,5 +19,4 @@ export default {
 
 </script>
 
-<style>
-</style>
+<style lang="scss"></style>

--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -342,3 +342,5 @@ export default {
 };
 
 </script>
+
+<style lang="scss"></style>

--- a/frontend/src/components/Resources.vue
+++ b/frontend/src/components/Resources.vue
@@ -132,3 +132,5 @@ export default {
 };
 
 </script>
+
+<style lang="scss"></style>

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -54,7 +54,7 @@
         <div v-if="!currentMap"
              class="column is-unselectable om-1 fixed-height-mobile p-0 m-0">
           <NotFound v-if="mapNotFound" type="map" :component-id="$route.params.map_id"></NotFound>
-          <p v-else class="is-size-5 has-text-centered" style="padding: 10%;">
+          <p v-else class="is-size-5 has-text-centered py-6 my-6">
             <a @click="showingMapListing = true">Show the map list and choose a compartment or subsystem map</a>
           </p>
         </div>
@@ -70,7 +70,8 @@
           <ErrorPanel :message="loadMapErrorMessage" @hideErrorPanel="loadMapErrorMessage=''" />
         </div>
         <div id="dataOverlayBar"
-             class="column is-narrow has-text-white is-unselectable is-hidden-mobile fixed-height-desktop p-1"
+             class="column is-clickable is-narrow has-text-white
+                    is-unselectable is-hidden-mobile fixed-height-desktop p-1"
              :class="{'px-0 py-0': dataOverlayPanelVisible }"
              title="Click to show the data overlay panel"
              @click="$store.dispatch('maps/toggleDataOverlayPanelVisible')">
@@ -368,7 +369,6 @@ export default {
   display: flex;
   align-items: center;
   background: $primary;
-  cursor: pointer;
   line-height: 17px;
   &:hover{
     background: $primary-light;

--- a/frontend/src/components/explorer/gemBrowser/Compartment.vue
+++ b/frontend/src/components/explorer/gemBrowser/Compartment.vue
@@ -95,5 +95,4 @@ export default {
 };
 </script>
 
-<style lang="scss">
-</style>
+<style lang="scss"></style>

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -26,7 +26,7 @@
         <span v-show="showSearchCharAlert" class="has-text-info icon is-right" style="width: 270px">
           Type at least 2 characters
         </span>
-        <span id="clear-search-icon" class="icon is-medium is-right has-text-grey-dark" @click="handleClearSearch()">
+        <span id="clear-search-icon" class="icon is-medium is-right has-text-grey-dark is-clickable" @click="handleClearSearch()">
           <i class="fa fa-times-circle" />
         </span>
       </p>
@@ -261,7 +261,6 @@ export default {
   }
 
   #clear-search-icon {
-    cursor: pointer;
     pointer-events: auto;
   }
 

--- a/frontend/src/components/explorer/gemBrowser/Gene.vue
+++ b/frontend/src/components/explorer/gemBrowser/Gene.vue
@@ -95,5 +95,4 @@ export default {
 
 </script>
 
-<style lang="scss">
-</style>
+<style lang="scss"></style>

--- a/frontend/src/components/explorer/mapViewer/MapControls.vue
+++ b/frontend/src/components/explorer/mapViewer/MapControls.vue
@@ -117,3 +117,5 @@ export default {
 };
 
 </script>
+
+<style lang="scss"></style>

--- a/frontend/src/components/explorer/mapViewer/MapControls.vue
+++ b/frontend/src/components/explorer/mapViewer/MapControls.vue
@@ -2,18 +2,14 @@
   <div class="canvasOption overlay p-2">
     <span class="button" title="Zoom in" @click="zoomIn()"><i class="fa fa-search-plus"></i></span>
     <span class="button" title="Zoom out" @click="zoomOut()"><i class="fa fa-search-minus"></i></span>
-    <span class="button" title="Show/Hide genes"
-          style="padding: 4.25px;"
-          @click="toggleGenes()">
+    <span class="button p-2" title="Show/Hide genes" @click="toggleGenes()">
       <i class="fa fa-eye-slash">&thinsp;G</i>
     </span>
-    <span v-if="toggleLabels" class="button" title="Show/Hide labels"
-          style="padding: 4.25px;"
-          @click="toggleLabels()">
+    <span v-if="toggleLabels" class="button p-2" title="Show/Hide labels" @click="toggleLabels()">
       <i class="fa fa-eye-slash">&thinsp;L</i>
     </span>
     <span v-if="toggleSubsystems"
-          class="button" style="padding: 4.25px;"
+          class="button p-2"
           title="Show/Hide subsystem"
           @click="toggleSubsystems()">
       <i class="fa fa-eye-slash">&thinsp;S</i>
@@ -121,7 +117,3 @@ export default {
 };
 
 </script>
-
-<style lang="scss">
-
-</style>

--- a/frontend/src/components/explorer/mapViewer/RNALegend.vue
+++ b/frontend/src/components/explorer/mapViewer/RNALegend.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="card is-unselectable">
     <div class="card-content p-3">
-      <div class="columns is-gapless" style="margin-bottom: 10px;">
+      <div class="columns is-gapless mb-1">
         <div class="column is-narrow">{{ leftValue }}&nbsp;</div>
         <div class="column">
           <div :style="{ 'height': '20px',

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -12,13 +12,19 @@
       <div id="tooltip" ref="tooltip"></div>
     </div>
 
-    <MapControls wrapper-elem-selector=".viewer-container" :is-fullscreen="isFullscreen"
-                 :zoom-in="zoomIn" :zoom-out="zoomOut"
-                 :toggle-full-screen="toggleFullscreen" :toggle-genes="toggleGenes"
-                 :toggle-subsystems="toggleSubsystems" :download-canvas="downloadCanvas" />
-    <MapSearch ref="mapsearch" :matches="searchedNodesOnMap"
+    <MapControls wrapper-elem-selector=".viewer-container"
+                 :is-fullscreen="isFullscreen"
+                 :zoom-in="zoomIn"
+                 :zoom-out="zoomOut"
+                 :toggle-full-screen="toggleFullscreen"
+                 :toggle-genes="toggleGenes"
+                 :toggle-subsystems="toggleSubsystems"
+                 :download-canvas="downloadCanvas" />
+    <MapSearch ref="mapsearch"
+               :matches="searchedNodesOnMap"
                :fullscreen="isFullscreen"
-               @searchOnMap="searchIDsOnMap" @centerViewOn="centerElementOnSVG"
+               @searchOnMap="searchIDsOnMap"
+               @centerViewOn="centerElementOnSVG"
                @unHighlightAll="unHighlight" />
   </div>
 </template>

--- a/frontend/src/components/shared/ComparisonDetails.vue
+++ b/frontend/src/components/shared/ComparisonDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="comparison-details" class="card">
+  <div id="comparison-details" class="card p-0">
     <header class="card-header">
       <p class="card-header-title">
         Comparing&nbsp;
@@ -112,10 +112,6 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-  .card {
-    padding: 0;
-  }
-
   .compared-models:last-of-type {
     margin-right: -0.25em;
   }

--- a/frontend/src/components/shared/ComparisonMatrix.vue
+++ b/frontend/src/components/shared/ComparisonMatrix.vue
@@ -3,17 +3,20 @@
     <table class="table">
       <thead>
         <tr>
-          <th class="has-nowrap"></th>
-          <th class="has-nowrap" v-for="cn in columnNames" :key="cn">{{ cn }}</th>
+          <th class="has-nowrap px-3 py-3"></th>
+          <th v-for="cn in columnNames" :key="cn" class="has-nowrap">{{ cn }}</th>
         </tr>
       </thead>
       <tbody>
         <tr v-for="(rn, i) in rowNames" :key="rn + i">
           <th class="has-nowrap">{{ rn }}</th>
-          <td v-for="(cn, j) in columnNames" :key="cn + j" :class="{selected: isSelectedCell(i, j)}">
+          <td v-for="(cn, j) in columnNames"
+              :key="cn + j" class="p-0 is-clickable"
+              :class="{selected: isSelectedCell(i, j)}">
             <div>
               <span v-for="(type, k) in types" :key="cn + j + type"
                     :style="{backgroundColor: colors[k]}"
+                    class="px-2 py-3"
                     @click="handleSelectCell(i, j)">
                 {{ matrix[i][j][type] }}
               </span>
@@ -21,11 +24,11 @@
           </td>
         </tr>
       </tbody>
-      <caption>
+      <caption class="p-1">
         click a cell to see the comparison details
         <br />
         legend:
-        <span v-for="(type, k) of types" :key="type" :style="{backgroundColor: colors[k]}">
+        <span v-for="(type, k) of types" :key="type" :style="{backgroundColor: colors[k]}" class="p-1">
           {{ type }}
         </span>
       </caption>
@@ -167,22 +170,13 @@ table {
   caption {
     font-size: 0.9em;
     font-style: italic;
-    padding: 0.25em;
-
-    span {
-      padding: 0.25em;
-    }
   }
 
   th {
-    padding: 0.5em 0.75em;
     white-space: nowrap;
   }
 
   td {
-    cursor: pointer;
-    padding: 0;
-
     &.selected, &:hover {
       outline: 2px solid $black;
       outline-offset: -2px;
@@ -192,7 +186,6 @@ table {
       display: flex;
 
       span {
-        padding: 0.5em 0.75em;
         width: 50%;
       }
     }

--- a/frontend/src/components/shared/ComparisonMatrix.vue
+++ b/frontend/src/components/shared/ComparisonMatrix.vue
@@ -16,7 +16,7 @@
             <div>
               <span v-for="(type, k) in types" :key="cn + j + type"
                     :style="{backgroundColor: colors[k]}"
-                    class="px-2 py-3"
+                    class="px-3 py-2"
                     @click="handleSelectCell(i, j)">
                 {{ matrix[i][j][type] }}
               </span>


### PR DESCRIPTION
This PR aims to do a bit of refactoring that was spotted via #692 . It started from removing the inline CSS that was handling `padding` and `margin`, and expanded to also replace `cursor` with the corresponding classes.