### PR TITLE
fix: make handleCallback methods use the new and not old id

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Metabolite.vue
+++ b/frontend/src/components/explorer/gemBrowser/Metabolite.vue
@@ -130,9 +130,9 @@ export default {
     };
   },
   methods: {
-    async handleCallback() {
+    async handleCallback(model, id) {
       try {
-        const payload = { model: this.model, id: this.metaboliteId };
+        const payload = { model, id };
         await this.$store.dispatch('metabolites/getRelatedMetabolites', payload);
       } catch {
         this.$store.dispatch('metabolites/clearRelatedMetabolites');

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -114,9 +114,9 @@ export default {
     };
   },
   methods: {
-    async handleCallback() {
+    async handleCallback(model, id) {
       try {
-        const payload = { model: this.model, id: this.rId };
+        const payload = { model, id };
         await this.$store.dispatch('reactions/getRelatedReactionsForReaction', payload);
       } catch {
         this.$store.dispatch('reactions/clearRelatedReactions');

--- a/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
+++ b/frontend/src/layouts/explorer/gemBrowser/ComponentLayout.vue
@@ -126,7 +126,7 @@ export default {
         await this.$store.dispatch(this.queryComponentAction, payload);
         this.componentNotFound = false;
         if (this.$listeners && this.$listeners.handleCallback) {
-          this.$emit('handleCallback');
+          this.$emit('handleCallback', this.model, this.componentId);
         }
         this.showLoaderMessage = '';
       } catch {


### PR DESCRIPTION
This PR closes #680

That the related reactions was not refreshed was due to that the `handleCallback` method used to get related reactions for a new reaction (i.e, when clicking on the link on a related reaction) was not using the new reaction id. This bug was also occurring for related metabolites. 

`/explore/Human-GEM/gem-browser/reaction/MAR05029` was the reported example of a misbehaving reaction, but please play around in `/explore/Human-GEM/gem-browser` and choose some random reactions/metabolites to see that their related reactions/metabolites are functioning.