### PR TITLE
feat: do not copy hpaRna.json when deploying the stack

### DIFF
--- a/proj.sh
+++ b/proj.sh
@@ -6,7 +6,6 @@ function generate-data {
   echo 'Data generation started.'
   source .env && yarn --cwd $DATA_GENERATOR_PATH start $DATA_FILES_PATH "$@"
   /bin/cp -rf $DATA_GENERATOR_PATH/neo4j/* neo4j/import
-  /bin/cp  -f $DATA_GENERATOR_PATH/neo4j/hpaRna.json api/src/data/
   /bin/cp -rf $DATA_GENERATOR_PATH/dataOverlay api/
   /bin/cp  -f $DATA_FILES_PATH/integrated-models/integratedModels.json api/src/data/
   /bin/cp  -f $DATA_FILES_PATH/gemsRepository.json api/src/data/


### PR DESCRIPTION
This PR together [PR 18](https://github.com/MetabolicAtlas/data-files/pull/18) and [PR 23](https://github.com/MetabolicAtlas/data-generation/pull/23) with closes [#124](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/124)

Description: remove the code to copy the file `hpaRna.json` when deploying the stack since it has been replaced by the file in dataOverlay. 