### PR TITLE
Feat/include old ids in search

### DIFF
--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -309,7 +309,7 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-		WHEN EXISTS(node.id) THEN { id: node.id, labels: labelList, score: score }
+		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END
 ) as r 
@@ -334,7 +334,6 @@ LIMIT ${limit}
   }, {});
 
   const ids = Object.assign({}, ...Object.keys(uniqueIds).map(c => ({ [c]: Array.from(uniqueIds[c]) })));
-
   const [
     compartmentalizedMetabolites,
     metabolites,

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -324,12 +324,14 @@ LIMIT ${limit}
 
   const results = await queryListResult(statement);
 
+  const idsToScore = {};
   const uniqueIds = results.reduce((o, r) => {
     const c = intersect(componentTypes, r.labels);
     if (!o[c]) {
       o[c] = new Set();
     }
     o[c].add(r.id);
+    idsToScore[r.id] = r.score;
     return o;
   }, {});
 
@@ -350,13 +352,33 @@ LIMIT ${limit}
     fetchCompartments({ ids: ids["Compartment"], model, version: v, includeCounts: true }),
   ]);
 
-  // formatting for simple (gem browser) search
+  const resObj = {compartmentalizedMetabolites,
+    metabolites,
+    genes,
+    reactions,
+    subsystems,
+    compartments}
+    const resWithScore = {};
+    for (const [component, result] of Object.entries(resObj)) {
+        if (result) {
+            resWithScore[component] = result.map(obj => {
+                    const objWithScore = {
+                        ...obj,
+                        score: idsToScore[obj.id]
+                    }
+                    return objWithScore;
+                })
+        } else {
+            resWithScore[component] = []
+        }
+    }
+
   return {
-    metabolite: [...compartmentalizedMetabolites || [], ...metabolites || []],
-    gene: genes || [],
-    reaction: reactions || [],
-    subsystem: subsystems || [],
-    compartment: compartments || [],
+    metabolite: [...resWithScore.compartmentalizedMetabolites, ...resWithScore.metabolites],
+    gene: resWithScore.genes,
+    reaction: resWithScore.reactions,
+    subsystem: resWithScore.subsystems,
+    compartment: resWithScore.compartments,
   };
 };
 

--- a/frontend/src/components/SearchTable.vue
+++ b/frontend/src/components/SearchTable.vue
@@ -173,7 +173,7 @@ import Loader from '@/components/Loader';
 import ExportTSV from '@/components/shared/ExportTSV';
 import 'vue-good-table/dist/vue-good-table.css';
 import { default as chemicalFormula } from '@/helpers/chemical-formatters';
-import { sortResults } from '@/helpers/utils';
+import { sortResultsScore, sortResultsSearchTerm } from '@/helpers/utils';
 import { default as messages } from '@/content/messages';
 
 export default {
@@ -497,8 +497,8 @@ export default {
       // store choice only once in a dict
       Object.keys(this.searchResults).forEach((componentType) => {
         const compoList = this.searchResults[componentType];
-        // sort
-        compoList.sort((a, b) => this.sortResults(a, b, this.searchedTerm));
+        compoList.sort((a, b) => sortResultsScore(a, b));
+        compoList.sort((a, b) => sortResultsSearchTerm(a, b, this.searchedTerm));
         compoList.forEach((el) => { // e.g. results list for metabolites
           if (componentType === 'metabolite') {
             Object.keys(filterTypeDropdown[componentType]).forEach((field) => {
@@ -673,7 +673,7 @@ export default {
       return `${header.join('\t')}\n${tsvContent}`;
     },
     chemicalFormula,
-    sortResults,
+    sortResultsScore,
   },
 };
 

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -84,7 +84,11 @@ export function reformatChemicalReactionHTML(reaction, noLink = false, model = '
   return `${reactants} ${equationSign(reaction.reversible)} ${products}`;
 }
 
-export function sortResults(a, b, searchTermString) {
+export function sortResultsScore(a, b) {
+  return b.score - a.score;
+}
+
+export function sortResultsSearchTerm(a, b, searchTermString) {
   let matchSizeDiffA = 100;
   let matchedStringA = '';
   Object.values(a).forEach((v) => {

--- a/frontend/src/store/modules/search.js
+++ b/frontend/src/store/modules/search.js
@@ -1,5 +1,5 @@
 import searchApi from '@/api/search';
-import { sortResults } from '@/helpers/utils';
+import { sortResultsSearchTerm } from '@/helpers/utils';
 
 const data = {
   categories: [
@@ -54,7 +54,7 @@ const getters = {
       if (v === 0) {
         return v;
       }
-      return v.sort((a, b) => sortResults(a, b, state.searchTermString));
+      return v.sort((a, b) => sortResultsSearchTerm(a, b, state.searchTermString));
     })()]));
   },
 };


### PR DESCRIPTION
This is a draft PR to get feedback for search should include old ids #118

Please have a look at the search functionality both by GemSearch (i.e the search bar always available at the top of the page which searches wihtin the chosen model) and the global search (when clicking `"search all intergated GEMs"` in the GemSearch or using `http://localhost/search?term=somesearchterm`)
 
### Testing 
##### Old ID:s 
Ids from `HMR 2.0`, e.g. `HMR_4797`, `m01016c`, seems to work fine both in GemSearch and global search. Though a hit for gene is returned now for m01016c in global search which was not the case before

Ids from `Recon3D` are not as neat. `r0760` becomes messy in GemSearch since there are results for not only reactions. Fine in global if you know you are looking for a reaction. Before nothing was returned in GemSearch, and only Yeast-Gem hits in global

`cspg_c` seems to work fine though.

More old ID:s  can be found by choosing a random reaction or metabolite in the GemBrowser and using their external `HMR 2.0` or `Recon3D` id)

##### MA ID:s 
Seems to work fine? Examples: `MAR07523`, `MAM03309s`

Note, if you try to search using parts of the id, e.g. 07523, nothing of value is returned in neither GemSearch or global. Before no results was returned at all.


##### Genes:
Seems to work fine for both? Examples: `POLR3F`, `HSD17B1`


##### Subsystems:
Seems to work fine? Examples `Glycerolipid metabolism` `Fatty acid biosynthesis`. Becomes messy in GemSearch since there are results for not only subsystems but that was the case before as well.

##### Compartments:
Seems to work fine? Examples `Golgi apparatus ` `Inner mitochondria`. Becomes messy in GemSearch since there are results for not only compartments but that was the case before as well.


### Questions:

- Do users use Recon3D or or mostly HMR 2.0?
- Do you think the GemSearch and global search are working as they should?
