### PR TITLE
feat: add redirects for links that previously should have worked

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -40,6 +40,12 @@ const routes = [
   { path: '/resources', name: 'resources', component: Resources },
   { path: '/documentation', name: 'documentation', component: Documentation },
   { path: '/identifier/:dbName/:identifierId', name: 'identifier', component: ExternalDb },
+
+  // redirects
+  { path: '/explore/gem-browser/human1*', redirect: '/explore/Human-GEM/gem-browser*' },
+  { path: '/explore/map-viewer/human1*', redirect: '/explore/Human-GEM/map-viewer*' },
+
+  // catch rest
   { path: '/*', name: 'fourOfour', component: FourOFour },
 ];
 


### PR DESCRIPTION
This PR closes [#123](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/123)

The following paths should successfully redirect:

- `/explore/gem-browser/human1`
- `/explore/gem-browser/human1/gene/ENSG00000088179`
- `/explore/map-viewer/human1`
- `/explore/map-viewer/human1/acyl_coa_hydrolysis?dim=3d`
- `/api` <- this was already working from before