### PR TITLE
fix: align logo with the rest of the page

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -306,7 +306,7 @@ html {
 }
 
 #navbarContainer {
-  @media screen and (min-width: $desktop) and (max-width: 1620px) {
+  @media screen and (min-width: $desktop) and (max-width: $fullhd + $navbar-margin-threshold) {
     margin-left: 50px;
   }
   @media screen  and (max-width: $desktop) {

--- a/frontend/src/style/vars.scss
+++ b/frontend/src/style/vars.scss
@@ -30,3 +30,5 @@ $navbar-height: 4rem;
 $footer-height: 3.5rem;
 // Custom height for the 2D and 3D Map Viewers on mobile
 $viewer-height: 450px;
+// Custom variable to align the logo with the other content of the web page
+$navbar-margin-threshold: 44px;


### PR DESCRIPTION
This PR closes #594

The logo is now aligned with a majority of the titles and content of the web page. Please visit different pages with different widths to verify that everything looks neat.

Note that the right side spacing is not modified in accordance with the discussion of #594