### PR TITLE
fix: do not show NavigationDuplicated error when clicking a map twice

### DIFF
--- a/frontend/src/components/explorer/mapViewer/MapsListing.vue
+++ b/frontend/src/components/explorer/mapViewer/MapsListing.vue
@@ -55,7 +55,7 @@ export default {
       const oldDim = this.$router.currentRoute.query.dim;
       const newDim = this.showing2D ? '2d' : '3d';
       if (oldMapId !== newMapId || oldDim !== newDim) {
-        this.$router.push({ params: { map_id: newMapId }, query: { dim: this.showing2D ? '2d' : '3d' } });
+        this.$router.push({ params: { map_id: newMapId }, query: { dim: newDim } });
       }
     },
   },


### PR DESCRIPTION
This PR closes #697 

DoD: The error message `NavigationDuplicated` does not show in the console when clicking a map twice in the Map viewer for both 2D and 3D maps. 