### PR TITLE
fix: only show gem-search when appropriate

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -277,10 +277,6 @@ export default {
     border-top: 0;
     z-index: 30;
 
-    .globalSearchLink{
-      text-decoration: none;
-    }
-
     .resList {
         max-height: 22rem;
         overflow-y: auto;


### PR DESCRIPTION
This PR implements:

_As a user, I would like the window switches to the global search directly after clicking the button "Search all integrated GEMs" in the GemSearch. Currently, the web-page is directed to the global search after clicking the button but it is grey and deactivated._

To test, try different searches in the gem search. When searching for things not existing, i.e. `POLR3F` in `Yeast-GEM`, make sure that the global search page is shown and that the gem search disappears 