### PR TITLE
refactor: remove redundant usage of reactionCount 

### DIFF
--- a/api/src/neo4j/queries/map.js
+++ b/api/src/neo4j/queries/map.js
@@ -41,11 +41,6 @@ CALL apoc.cypher.run("
   UNION
   
   MATCH (:Compartment${m} {id: $cid})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)
-  RETURN { id: $cid, reactionCount: COUNT(DISTINCT(r)) } as data
-  
-  UNION
-
-  MATCH (:Compartment${m} {id: $cid})-[${v}]-(:CompartmentalizedMetabolite)-[${v}]-(r:Reaction)
   RETURN { id: $cid, reactionList: COLLECT(DISTINCT(r.id)) } as data
   
   UNION
@@ -64,11 +59,6 @@ CALL apoc.cypher.run("
   MATCH (ss:SubsystemState)-[${v}]-(s:Subsystem {id: $sid})
   RETURN ss { id: $sid, .* } as data
   
-  UNION
-  
-  MATCH (:Subsystem${m} {id: $sid})-[${v}]-(r:Reaction)
-  RETURN { id: $sid, reactionCount: COUNT(DISTINCT(r)) } as data
-
   UNION
   
   MATCH (:Subsystem${m} {id: $sid})-[${v}]-(r:Reaction)


### PR DESCRIPTION
This PR closes #603 

#### Changes made:
   The querying of `reactionCount` in the file `api/src/neo4j/queries/map.js` is unnecessary and thus removed since the querying of `reactionList` is used. 

#### Note
   The variable `reactionList` is not used in neither `frontend/src/components/explorer/MapViewer.vue` nor `frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue`, and therefore, changes only need to be made in the API. 
