### PR TITLE
feat: reuse data overlay component in interaction partners page

### DIFF
--- a/frontend/src/components/explorer/InteractionPartners.vue
+++ b/frontend/src/components/explorer/InteractionPartners.vue
@@ -944,6 +944,7 @@ export default {
 
     .dropdown-menu {
       display: block;
+      min-width: unset;
     }
   }
 

--- a/frontend/src/components/explorer/InteractionPartners.vue
+++ b/frontend/src/components/explorer/InteractionPartners.vue
@@ -166,42 +166,40 @@
                   </div>
                 </div>
                 <div id="cy" ref="cy" class="card p0">
+                  <div id="dropdownMenuExport" class="dropdown">
+                    <div class="dropdown-trigger">
+                      <a v-show="showNetworkGraph" class="button is-white" aria-haspopup="true"
+                         aria-controls="dropdown-menu" @click="showMenuExport=!showMenuExport">
+                        <span class="icon is-large"><i class="fa fa-download"></i></span>
+                        <span>Export</span>
+                        <span class="icon is-large"><i class="fa fa-caret-down"></i></span>
+                      </a>
+                    </div>
+                    <div v-show="showMenuExport" id="dropdown-menu"
+                         class="dropdown-menu" role="menu"
+                         @mouseleave="showMenuExport = false">
+                      <div class="dropdown-content">
+                        <a class="dropdown-item" @click="exportGraphml">
+                          Graphml
+                        </a>
+                        <a class="dropdown-item" @click="exportPNG">
+                          PNG
+                        </a>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </template>
             <div class="column">
+              <sidebar id="sidebar" class="mb-2"
+                       :selected-elm="clickedElm" :show-ip-button="clickedElmId !== mainNodeID" />
               <template v-if="showNetworkGraph">
-                <div id="dropdownMenuExport" class="dropdown">
-                  <div class="dropdown-trigger">
-                    <a v-show="showNetworkGraph" class="button is-primary is-outlined" aria-haspopup="true"
-                       aria-controls="dropdown-menu" @click="showMenuExport=!showMenuExport">
-                      <span class="icon is-large"><i class="fa fa-download"></i></span>
-                      <span>Export graph</span>
-                      <span class="icon is-large"><i class="fa fa-caret-down"></i></span>
-                    </a>
-                  </div>
-                  <div v-show="showMenuExport" id="dropdown-menu"
-                       class="dropdown-menu" role="menu"
-                       @mouseleave="showMenuExport = false">
-                    <div class="dropdown-content">
-                      <a class="dropdown-item" @click="exportGraphml">
-                        Graphml
-                      </a>
-                      <a class="dropdown-item" @click="exportPNG">
-                        PNG
-                      </a>
-                    </div>
-                  </div>
-                </div>
-                <br>
-                <sidebar id="sidebar" :selected-elm="clickedElm" :show-ip-button="clickedElmId !== mainNodeID" />
-                <br>
-                <div class="card ">
+                <div class="card mb-2">
                   <div class="card-content py-2 p-3">
                     <DataOverlay :map-name="mainNodeID" position="relative" class="has-background-white" />
                   </div>
                 </div>
-                <br>
                 <div v-if="compartmentList.length !== 0 || subsystemList.length != 0" class="card">
                   <header class="card-header">
                     <p class="card-header-title">
@@ -930,6 +928,7 @@ export default {
     margin: auto;
     width: 100%;
     height: 100%;
+    position: relative;
   }
 
   #sidebar {
@@ -938,6 +937,11 @@ export default {
   }
 
   #dropdownMenuExport {
+    position: absolute;
+    z-index: 1;
+    top: 0;
+    right: 0;
+
     .dropdown-menu {
       display: block;
     }

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="dataOverlayBox"
-       class="column is-one-fifth-widescreen is-one-quarter-desktop
-         is-one-quarter-tablet has-background-lightgray">
+       :class="{ 'is-one-fifth-widescreen is-one-quarter-desktop is-one-quarter-tablet': position === 'absolute'}"
+       class="column has-background-lightgray">
     <div class="title is-size-4 has-text-centered">Expression data</div>
     <div class="has-text-centered"
          title="Load a TSV file with IDs and TPM values.
@@ -107,6 +107,10 @@ export default {
     mapType: String,
     mapName: String,
     dim: String,
+    position: {
+      type: String,
+      default: 'absolute',
+    },
   },
   data() {
     return {
@@ -232,11 +236,6 @@ export default {
 </script>
 
 <style lang="scss">
-@media screen and (min-width: $tablet) {
-  #dataOverlayBox {
-    margin-right: -1rem;
-  }
-}
 
 #fileNameBox {
   display: flex;

--- a/frontend/src/graph-stylers/hmr-closest-interaction-partners.js
+++ b/frontend/src/graph-stylers/hmr-closest-interaction-partners.js
@@ -1,22 +1,21 @@
 import cytoscape from 'cytoscape';
 
+
+const ALLOWED_TYPES = ['gene', 'metabolite'];
+
 export default function (
   componentID, elms, rels, nodeDisplayParams, reactionHL, compartmentHL, subsystemHL) {
   const elmsjson = [];
-  const enzExpSource = nodeDisplayParams.geneExpSource;
-  const enzExpType = nodeDisplayParams.geneExpType;
-  const enzSample = nodeDisplayParams.geneExpSample;
+  const { expSource, expType, expSample } = nodeDisplayParams;
   /* eslint-disable no-param-reassign */
   Object.values(elms).forEach((elm) => {
-    if (elm.type === 'gene') {
+    if (ALLOWED_TYPES.includes(elm.type)) {
       if (!elm.expressionLvl) {
         elm.expressionLvl = {};
         elm.expressionLvl.false = {};
         elm.expressionLvl.false.false = {};
-        elm.expressionLvl.false.false.false = nodeDisplayParams.geneNodeColor.hex;
-      } else {
-        elm.expressionLvl.false.false.false = nodeDisplayParams.geneNodeColor.hex;
       }
+      elm.expressionLvl.false.false.false = nodeDisplayParams[`${elm.type}NodeColor`].hex;
       elmsjson.push({
         group: 'nodes',
         data: {
@@ -58,6 +57,7 @@ export default function (
     });
   });
 
+  const geneColor = nodeDisplayParams.geneNodeColor.hex;
   const metaboliteColor = nodeDisplayParams.metaboliteNodeColor.hex;
   const textColor = '#363636';
   const textColorHL = '#CC3636';
@@ -91,7 +91,15 @@ export default function (
     .selector('node[type="metabolite"]')
     .css({
       shape: nodeDisplayParams.metaboliteNodeShape,
-      'background-color': metaboliteColor,
+      'background-color': function f(e) {
+        if (!e.data('color')[expSource]) {
+          return metaboliteColor;
+        }
+        if (e.data('color')[expSource][expType][expSample]) {
+          return e.data('color')[expSource][expType][expSample];
+        }
+        return metaboliteColor;
+      },
       width: 15,
       height: 15,
       color: function f(e) {
@@ -120,13 +128,13 @@ export default function (
     .css({
       shape: nodeDisplayParams.geneNodeShape,
       'background-color': function f(e) {
-        if (!e.data('color')[enzExpSource]) {
-          return 'whitesmoke';
+        if (!e.data('color')[expSource]) {
+          return geneColor;
         }
-        if (e.data('color')[enzExpSource][enzExpType][enzSample]) {
-          return e.data('color')[enzExpSource][enzExpType][enzSample];
+        if (e.data('color')[expSource][expType][expSample]) {
+          return e.data('color')[expSource][expType][expSample];
         }
-        return 'whitesmoke';
+        return geneColor;
       },
       width: 20,
       height: 20,


### PR DESCRIPTION
This PR closes #709 

To test this PR, please use the following interaction partners page: `/explore/Human-GEM/interaction-partners/MAM01357c` to test metabolites that are included in the sample metabolomics data. Any page should work fine for transcriptomics.

Please also pay attention to the map viewer using the following page for example `/explore/Human-GEM/map-viewer/golgi_apparatus?dim=2d&panel=1&datatype=transcriptomics&datasource=hpaRna.tsv&dataSet=none`. There seems to be a difference in how the data overlay is rendered (please see comments of this PR for more details). Please let me know if the data overlay looks ok in the map viewer or if it looks similar to the one [posted by @mihai-sysbio](https://github.com/MetabolicAtlas/MetabolicAtlas/pull/723#issuecomment-947722719).

---

### Draft PR description

Creating a draft PR in case anyone wants to take a look at the progress so far. Currently I have added the `DataOverlay` component to the interaction partners page. The data overlay seems to be working as well. You can test with `transcriptomics` -> `Human Protein Atlas 20.1` -> any level/dataset on the following page (any other interaction partners page should work too):  `/explore/Human-GEM/interaction-partners/ENSG00000153015`.

Please don't mind the code too much right now. I would like to continue with some refactoring and clean-up after we clear up the questions below.

## Questions

- I had made some basic modifications to adapt the `DataOverlay` component so it looks acceptable on the interaction partners page. Do we think this is ok or would we like to improve it? Keep in mind that it should satisfy both the interaction partners page and the map viewer.
- So far only gene data works. Do we want to make sure metabolites data overlay works as well? I think it makes sense to only include gene data types for the interaction partners page's graph is very gene-centric since very few (usually 1 or 2) metabolites are displayed in the graph. 
- I have removed the `margin-right: -1rem;` in the `DataOverlay` component, which affects the map viewer as well. Does anyone remember/know why this was necessary? It was actually cropping the contents of the `DataOverlay` component in the map viewer so this would be an improvement there as well unless there is a good reason for not removing it.