### PR TITLE
fix: use v-html for error messages

### DIFF
--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -1,8 +1,7 @@
 <template>
   <section class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="errorMessage">
-        {{ errorMessage }}
+      <div v-if="errorMessage" v-html="errorMessage">
       </div>
       <div v-else>
         <h3 id="Integrated-models" class="title is-3">Integrated models</h3>

--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -1,8 +1,7 @@
 <template>
   <section class="section extended-section">
     <div class="container is-fullhd">
-      <div v-if="errorMessage" v-html="errorMessage">
-      </div>
+      <div v-if="errorMessage" v-html="errorMessage" />
       <div v-else>
         <h3 id="Integrated-models" class="title is-3">Integrated models</h3>
         <p class="has-text-justified">

--- a/frontend/src/components/explorer/GemBrowser.vue
+++ b/frontend/src/components/explorer/GemBrowser.vue
@@ -3,8 +3,7 @@
     <div class="container is-fullhd">
       <template v-if="errorMessage">
         <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered"
-             v-html="errorMessage">
-        </div>
+             v-html="errorMessage" />
       </template>
       <template v-else>
         <div class="columns">

--- a/frontend/src/components/explorer/GemBrowser.vue
+++ b/frontend/src/components/explorer/GemBrowser.vue
@@ -2,8 +2,8 @@
   <div class="section extended-section">
     <div class="container is-fullhd">
       <template v-if="errorMessage">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ errorMessage }}
+        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered"
+             v-html="errorMessage">
         </div>
       </template>
       <template v-else>

--- a/frontend/src/components/explorer/InteractionPartners.vue
+++ b/frontend/src/components/explorer/InteractionPartners.vue
@@ -2,8 +2,8 @@
   <div class="section extended-section">
     <div class="container is-fullhd">
       <div v-if="errorMessage">
-        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-          {{ errorMessage }}
+        <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered"
+             v-html="errorMessage">
         </div>
       </div>
       <div v-else class="interaction-partners">

--- a/frontend/src/components/explorer/InteractionPartners.vue
+++ b/frontend/src/components/explorer/InteractionPartners.vue
@@ -3,8 +3,7 @@
     <div class="container is-fullhd">
       <div v-if="errorMessage">
         <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered"
-             v-html="errorMessage">
-        </div>
+             v-html="errorMessage" />
       </div>
       <div v-else class="interaction-partners">
         <div v-if="!mainNodeID" class="columns">

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -4,7 +4,7 @@
       <template v-if="errorMessage">
         <div class="column is-danger is-half is-offset-one-quarter">
           <div class="notification is-danger is-danger has-text-centered"
-               v-html="errorMessage"></div>
+               v-html="errorMessage" />
         </div>
       </template>
       <template v-else>

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -3,7 +3,8 @@
     <div id="mapViewerContainer" class="columns ordered-mobile m-0">
       <template v-if="errorMessage">
         <div class="column is-danger is-half is-offset-one-quarter">
-          <div class="notification is-danger is-danger has-text-centered">{{ errorMessage }}</div>
+          <div class="notification is-danger is-danger has-text-centered"
+               v-html="errorMessage"></div>
         </div>
       </template>
       <template v-else>

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -5,8 +5,7 @@
     </div>
     <div v-else class="column table-template">
       <h4 class="subtitle is-4">Reactions</h4>
-      <div v-if="errorMessage" class="notification is-danger" v-html="errorMessage">
-      </div>
+      <div v-if="errorMessage" class="notification is-danger" v-html="errorMessage" />
       <p v-if="relatedMetCount" class="control field">
         <button class="button" @click="toggleExpandAllCompartment">
           {{ !expandAllCompartment ? "See reactions from all compartments" : "Restrict to current compartment" }}

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -5,8 +5,7 @@
     </div>
     <div v-else class="column table-template">
       <h4 class="subtitle is-4">Reactions</h4>
-      <div v-if="errorMessage" class="notification is-danger">
-        {{ errorMessage }}
+      <div v-if="errorMessage" class="notification is-danger" v-html="errorMessage">
       </div>
       <p v-if="relatedMetCount" class="control field">
         <button class="button" @click="toggleExpandAllCompartment">

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="viewer-container">
     <div v-if="errorMessage" class="columns is-centered">
-      <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered">
-        {{ errorMessage }}
+      <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered"
+           v-html="errorMessage">
       </div>
     </div>
     <div v-else id="viewer3d"></div>

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -2,8 +2,7 @@
   <div class="viewer-container">
     <div v-if="errorMessage" class="columns is-centered">
       <div class="column notification is-danger is-half is-offset-one-quarter has-text-centered"
-           v-html="errorMessage">
-      </div>
+           v-html="errorMessage" />
     </div>
     <div v-else id="viewer3d"></div>
     <MapControls wrapper-elem-selector=".viewer-container" :is-fullscreen="isFullscreen"


### PR DESCRIPTION
### Related issue(s) and PR(s)
This PR closes [#39](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/3d-network-viewer/39) and relates to [#725 ]

#### Type of change
- [X] Bug fix (non-breaking change which fixes an issue)

 
#### List of changes made
Using `v-html` for error messages, as these might contain html elements.

#### Screenshot of the fix
![2021-10-26-141432_644x179_scrot](https://user-images.githubusercontent.com/1029190/138876684-3d883909-d566-4297-ae4f-083f8c7c36cd.png)


### Testing
- Instructions on how to test
To test this, you can add
```
    this.errorMessage = messages.unknownError;
```
at line 437 in `InteractionPartners.vue` and visit `/explore/Human-GEM/interaction-partners`.
Note that the change has been done on multiple places, so please click around / experiment to verify that it's working in all places.


# Checklist:
- [X] My code follows the [style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings