### PR TITLE
feat: show compartments

### DIFF
--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -14,7 +14,7 @@ const fetchReactionData = async ({ id, model, version }) => {
 
   return {
     ...data,
-    equation: reformatChemicalReactionHTML(data, true, model.short_name),
+    equation: reformatChemicalReactionHTML({ reaction: data, noLink: true, model: model.short_name }),
   };
 };
 

--- a/frontend/src/api/search.js
+++ b/frontend/src/api/search.js
@@ -20,7 +20,7 @@ const search = async ({ searchTerm, model, version, limit }) => {
         products: r.metabolites.filter(m => !m.outgoing),
       })).map(r => ({
         ...r,
-        equation: reformatChemicalReactionHTML(r, true, model.short_name),
+        equation: reformatChemicalReactionHTML({ reaction: r, noLink: true, model: model.short_name }),
       })),
     };
 

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -56,7 +56,7 @@
                 {{ rr.id }}
               </router-link>:&nbsp;
               <span v-html="reformatChemicalReactionHTML(
-                {reaction: rr, noLink : true, model : model.short_name, comp : true, addSummary: true})"></span>
+                {reaction: rr, noLink : true, model : model.short_name, comp : true})"></span>
             </span>
           </td>
         </tr>
@@ -122,7 +122,7 @@ export default {
       }
     },
     reformatEquation() {
-      return reformatChemicalReactionHTML({ reaction: this.reaction, model: this.model.short_name, comp: true, addSummary: true });
+      return reformatChemicalReactionHTML({ reaction: this.reaction, model: this.model.short_name, comp: true });
     },
 
     reformatGenes() {

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -55,7 +55,8 @@
               <router-link :to="{ name: 'reaction', params: { model: model.short_name, id: rr.id } }">
                 {{ rr.id }}
               </router-link>:&nbsp;
-              <span v-html="reformatChemicalReactionHTML(rr, true, model.short_name, '', true, true)"></span>
+              <span v-html="reformatChemicalReactionHTML(
+                {reaction: rr, noLink : true, model : model.short_name, comp : true, addSummary: true})"></span>
             </span>
           </td>
         </tr>
@@ -120,7 +121,9 @@ export default {
         this.$store.dispatch('reactions/clearRelatedReactions');
       }
     },
-    reformatEquation() { return reformatChemicalReactionHTML(this.reaction, false, this.model.short_name, '', true, true); },
+    reformatEquation() {
+      return reformatChemicalReactionHTML({ reaction: this.reaction, model: this.model.short_name, comp: true, addSummary: true });
+    },
 
     reformatGenes() {
       if (!this.reaction.geneRule) {

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -55,9 +55,7 @@
               <router-link :to="{ name: 'reaction', params: { model: model.short_name, id: rr.id } }">
                 {{ rr.id }}
               </router-link>:&nbsp;
-              <span v-html="reformatChemicalReactionHTML(rr, true, model.short_name)"></span>:
-              (<span v-html="equationSign(rr.reversible)">
-              </span>)
+              <span v-html="reformatChemicalReactionHTML(rr, true, model.short_name, '', true, true)"></span>
             </span>
           </td>
         </tr>
@@ -122,7 +120,8 @@ export default {
         this.$store.dispatch('reactions/clearRelatedReactions');
       }
     },
-    reformatEquation() { return reformatChemicalReactionHTML(this.reaction, false, this.model.short_name); },
+    reformatEquation() { return reformatChemicalReactionHTML(this.reaction, false, this.model.short_name, '', true, true); },
+
     reformatGenes() {
       if (!this.reaction.geneRule) {
         return '-';

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -82,7 +82,7 @@ import { mapState } from 'vuex';
 import Loader from '@/components/Loader';
 import { default as compare } from '@/helpers/compare';
 import ExportTSV from '@/components/shared/ExportTSV';
-import { idfy, reformatChemicalReactionHTML, getChemicalReaction } from '@/helpers/utils';
+import { idfy, reformatChemicalReactionHTML } from '@/helpers/utils';
 
 export default {
   name: 'ReactionTable',
@@ -216,7 +216,7 @@ export default {
       tsvContent += this.sortedReactions.map((r) => {
         const arr = [];
         arr.push(r.id);
-        arr.push(getChemicalReaction(r));
+        arr.push(reformatChemicalReactionHTML(r, true, undefined, '', true, true, false));
         arr.push(r.genes.map(g => g.name || g.id).join('; '));
         if (this.showCP) {
           arr.push(r.cp);

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -220,7 +220,8 @@ export default {
         arr.push(r.id);
 
         arr.push(
-          reformatChemicalReactionHTML({ reaction: r, noLink: true, model: undefined, comp: true, html: false }));
+          reformatChemicalReactionHTML({ reaction: r, noLink: true, model: undefined, comp: true, html: false })
+        );
         arr.push(r.genes.map(g => g.name || g.id).join('; '));
         if (this.showCP) {
           arr.push(r.cp);

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -45,7 +45,7 @@
                   {{ r.id }}
                 </a>
               </td>
-              <td v-html="reformatChemicalReactionHTML(r, false, model.short_name, selectedElmId)"></td>
+              <td v-html="reformatChemicalReactionHTML(r, false, model.short_name, selectedElmId, true, true)"></td>
               <td>
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
                 <template v-for="(m, index) in r.genes">{{ index == 0 ? '' : ', ' }}<a :class="{'cms' : sourceName === m.name }" :href="`/explore/${model.short_name}/gem-browser/gene/${m.id}`" @click="handleRouterClick">{{ m.name || m.id }}</a>

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -45,7 +45,9 @@
                   {{ r.id }}
                 </a>
               </td>
-              <td v-html="reformatChemicalReactionHTML(r, false, model.short_name, selectedElmId, true, true)"></td>
+              <td v-html="
+                reformatChemicalReactionHTML({ reaction: r, model: model.short_name, sourceMet: selectedElmId,
+                                               comp: true, addSummary: true })" />
               <td>
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
                 <template v-for="(m, index) in r.genes">{{ index == 0 ? '' : ', ' }}<a :class="{'cms' : sourceName === m.name }" :href="`/explore/${model.short_name}/gem-browser/gene/${m.id}`" @click="handleRouterClick">{{ m.name || m.id }}</a>
@@ -216,7 +218,9 @@ export default {
       tsvContent += this.sortedReactions.map((r) => {
         const arr = [];
         arr.push(r.id);
-        arr.push(reformatChemicalReactionHTML(r, true, undefined, '', true, true, false));
+
+        arr.push(
+          reformatChemicalReactionHTML({ reaction: r, noLink: true, model: undefined, comp: true, html: false, addSummary: true }));
         arr.push(r.genes.map(g => g.name || g.id).join('; '));
         if (this.showCP) {
           arr.push(r.cp);

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -47,7 +47,7 @@
               </td>
               <td v-html="
                 reformatChemicalReactionHTML({ reaction: r, model: model.short_name, sourceMet: selectedElmId,
-                                               comp: true, addSummary: true })" />
+                                               comp: true })" />
               <td>
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
                 <template v-for="(m, index) in r.genes">{{ index == 0 ? '' : ', ' }}<a :class="{'cms' : sourceName === m.name }" :href="`/explore/${model.short_name}/gem-browser/gene/${m.id}`" @click="handleRouterClick">{{ m.name || m.id }}</a>
@@ -220,7 +220,7 @@ export default {
         arr.push(r.id);
 
         arr.push(
-          reformatChemicalReactionHTML({ reaction: r, noLink: true, model: undefined, comp: true, html: false, addSummary: true }));
+          reformatChemicalReactionHTML({ reaction: r, noLink: true, model: undefined, comp: true, html: false }));
         arr.push(r.genes.map(g => g.name || g.id).join('; '));
         if (this.showCP) {
           arr.push(r.cp);

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -99,7 +99,8 @@
               <template v-else-if="item.name === 'equation'">
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
                 <p><span class="has-text-weight-bold" v-html="capitalize(item.display || item.name) + ':'"></span><br>
-                  <span v-html="reformatChemicalReactionHTML(selectionData.data, false, model.short_name)"></span>
+                  <span v-html="reformatChemicalReactionHTML(
+                    { reaction: selectionData.data, model: model.short_name })"></span>
                 </p>
               </template>
               <template v-else-if="item.name === 'formula'">

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -100,7 +100,8 @@
                 <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key -->
                 <p><span class="has-text-weight-bold" v-html="capitalize(item.display || item.name) + ':'"></span><br>
                   <span v-html="reformatChemicalReactionHTML(
-                    { reaction: selectionData.data, model: model.short_name })"></span>
+                    { reaction: selectionData.data, model: model.short_name })">
+                  </span>
                 </p>
               </template>
               <template v-else-if="item.name === 'formula'">

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -47,18 +47,6 @@ export function getSimpleEquation(reaction) {
   return `${reactants} ${equationSign(reaction.reversible)} ${products}`;
 }
 
-export function getChemicalReaction(reaction) {
-  if (reaction === null) {
-    return '';
-  }
-  const reactants = reaction.reactants.map(
-    x => `${x.stoichiometry !== 1 ? `${x.stoichiometry} ` : ''}${x.fullName}`
-  ).join(' + ');
-  const products = reaction.products.map(
-    x => `${x.stoichiometry !== 1 ? `${x.stoichiometry} ` : ''}${x.fullName}`
-  ).join(' + ');
-  return `${reactants} ${equationSign(reaction.reversible)} ${products}`;
-}
 
 const sortByName = metabolites => [...metabolites].sort((a, b) => ((a.name > b.name) ? 1 : -1));
 

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -71,7 +71,7 @@ export const formatCompartmentStr = (reaction) => {
   /** Extract the compartements from the full names, discard
     * duplicates and return as a string  */
   function uniqueCompartments(xs) {
-    return Array.from(new Set(xs.map(r => r.fullName.match(/\[.*\]/)))).join(' + ');
+    return Array.from(new Set(xs.map(r => r.fullName.match(/\[.*\]/)[0]))).join(' + ');
   }
   const reactantsCompartments = uniqueCompartments(reactants);
   const productsCompartments = uniqueCompartments(products);

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -71,7 +71,7 @@ export const formatCompartmentStr = (reaction) => {
   /** Extract the compartements from the full names, discard
     * duplicates and return as a string  */
   function uniqueCompartments(xs) {
-    return Array.from(new Set(xs.map(r => r.fullName.match(/\[.*\]/)[0]))).join(' + ');
+    return Array.from(new Set(xs.map(r => r.fullName.match(/\[[a-z]{1,3}\]/)[0]))).join(' + ');
   }
   const reactantsCompartments = uniqueCompartments(reactants);
   const productsCompartments = uniqueCompartments(products);

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -51,7 +51,8 @@ export function getSimpleEquation(reaction) {
 const sortByName = metabolites => [...metabolites].sort((a, b) => ((a.name > b.name) ? 1 : -1));
 
 /** Get the compartement from a reactant or product */
-const getCompartment = component => component.fullName.match(/\[[a-z]{1,3}\]/)[0];
+const getCompartment = ({ fullName }) => fullName.match(/\[[a-z]{1,3}\]/)[0];
+
 
 
 /** Create  the compartements for the summary, as used in Equation and Related Reactions */

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -92,11 +92,15 @@ export function reformatChemicalReactionHTML(reaction, noLink = false, model = '
   const type = 'metabolite';
   function formatReactionElement(x) {
     if (!addComp) {
-      return `${Math.abs(x.stoichiometry) !== 1 ? x.stoichiometry : ''} ${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })}`;
+      return `${Math.abs(x.stoichiometry) !== 1 ? x.stoichiometry : ''}
+              ${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })}`;
     }
     const regex = /.+\[([a-z]{1,3})\]$/;
     const match = regex.exec(x.fullName);
-    return `${Math.abs(x.stoichiometry !== 1) ? x.stoichiometry : ''} ${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })}<span class="sc" title="${x.compartment}">${match[1]}</span>`;
+    return `${Math.abs(x.stoichiometry !== 1) ? x.stoichiometry : ''}
+            ${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })}
+            <span title="${x.compartment}">[ ${match[1]} ] </span>
+            `;
   }
 
   const reactants = sortByName(reaction.reactants).map(formatReactionElement).join(' + ');

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -53,6 +53,9 @@ const sortByName = metabolites => [...metabolites].sort((a, b) => ((a.name > b.n
 /** Get the compartement from a reactant or product */
 const getCompartment = ({ fullName }) => fullName.match(/\[[a-z]{1,3}\]/)[0];
 
+/** Extract the compartements from the full names,
+  * discard duplicates and return as a string  */
+const uniqueCompartments = xs => Array.from(new Set(xs.map(r => getCompartment(r)))).join(' + ');
 
 
 /** Create  the compartements for the summary, as used in Equation and Related Reactions */
@@ -60,11 +63,6 @@ export const formatCompartmentStr = (reaction) => {
   const reactants = reaction.metabolites.filter(m => m.outgoing);
   const products = reaction.metabolites.filter(m => !m.outgoing);
 
-  /** Extract the compartements from the full names,
-    * discard duplicates and return as a string  */
-  function uniqueCompartments(xs) {
-    return Array.from(new Set(xs.map(r => getCompartment(r)))).join(' + ');
-  }
   const reactantsCompartments = uniqueCompartments(reactants);
   const productsCompartments = uniqueCompartments(products);
 

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -73,9 +73,8 @@ export const formatCompartmentStr = (reaction) => {
 };
 
 
-// TODO: consider using an object as param
-export function reformatChemicalReactionHTML(reaction, noLink = false, model = 'human-gem',
-  sourceMet = '', comp = false, addSummary = false, html = true) {
+export function reformatChemicalReactionHTML({ reaction, model, noLink = false, sourceMet = '', comp = false,
+  addSummary = false, html = true }) {
   if (reaction === null) {
     return '';
   }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -101,7 +101,7 @@ export function reformatChemicalReactionHTML(reaction, noLink = false, model = '
     const match = regex.exec(x.fullName);
     return `${Math.abs(x.stoichiometry !== 1) ? x.stoichiometry : ''}
             ${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })}
-            <span title="${x.compartment}">[ ${match[1]} ] </span>
+            <span title="${x.compartment}">[${match[1]}] </span>
             `;
   }
 

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -68,11 +68,13 @@ export const formatCompartmentStr = (reaction) => {
   const reactants = reaction.metabolites.filter(m => m.outgoing);
   const products = reaction.metabolites.filter(m => !m.outgoing);
 
-  function fix(xs) {
+  /** Extract the compartements from the full names, discard
+    * duplicates and return as a string  */
+  function uniqueCompartments(xs) {
     return Array.from(new Set(xs.map(r => r.fullName.match(/\[.*\]/)))).join(' + ');
   }
-  const reactantsCompartments = fix(reactants);
-  const productsCompartments = fix(products);
+  const reactantsCompartments = uniqueCompartments(reactants);
+  const productsCompartments = uniqueCompartments(products);
 
   if (reactantsCompartments === productsCompartments) {
     return reactantsCompartments;


### PR DESCRIPTION
### Related issue(s) and PR(s)
This PR closes #681  and relates to [improve formatting of related reactions](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/116).

### A description of the changes proposed in the pull request.
#### Type of change
Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

 
#### List of changes made
- Functionality for adding compartments and summary to equations
- Updated background of compartments, to remove grey background

#### Screenshot of the fix
![reaction2](https://user-images.githubusercontent.com/1029190/139808174-6fda945d-1e0f-44d3-affb-e6c4a9546326.png)

### Testing
See eg `/explore/Human-GEM/gem-browser/reaction/MAR01377`. The Reaction Table should not be changed, see `/explore/Human-GEM/gem-browser/gene/ENSG00000117394`.
Please test any other location which you suspect might be effected by this, or just point them out so that I can test them.

### Further comments
I've added the summary at the end of the equations, but I'll remove them if not wanted.

Code wise, I've tried to reuse and adapt already existing code, but also keeping the functions as intact as possible, in order not to mess up functionality elsewhere.
`constructCompartmentStr` at line 150 is thus unchanged.
[`formatCompartmentStr`](https://github.com/MetabolicAtlas/MetabolicAtlas/compare/feat/show-compartmets?expand=1#diff-aca785bc9b0ea8ad133ab97de0856016128fdac75a6d1d1d30f3d14c45fb18adR67) is a modified version of this.
Maybe they can be merged, or one of them deleted?

# Checklist:
Please delete options that are not relevant.
- [X] My code follows the [style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings