### PR TITLE
fix: non existing 2d map when going back to map viewer

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -218,7 +218,7 @@ export default {
         for (let i = 0; i < categories.length; i += 1) {
           for (let j = 0; j < items[i].length; j += 1) {
             const item = items[i][j];
-            if (this.showing2D) {
+            if (this.showing2D && item.svgs.length > 0) {
               for (let k = 0; k < item.svgs.length; k += 1) {
                 if (item.svgs[k].id === id) {
                   this.currentMap = { ...item };

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -235,9 +235,11 @@ export default {
               this.currentMap = item;
               this.currentMap.type = categories[i].slice(0, -1);
               this.mapNotFound = false;
-              this.currentMap.mapReactionIdSet = item.svgs;
-              this.setMapReactionList();
-              this.setMissingReactionList();
+              if (item.svgs.length > 0) {
+                this.currentMap.mapReactionIdSet = item.svgs;
+                this.setMapReactionList();
+                this.setMissingReactionList();
+              }
               return;
             }
             this.mapNotFound = true;

--- a/frontend/src/components/explorer/mapViewer/MapSearch.vue
+++ b/frontend/src/components/explorer/mapViewer/MapSearch.vue
@@ -5,7 +5,7 @@
              :class="searchInputClass"
              title="Exact search by id, name, alias. Press Enter for results" class="input"
              placeholder="Exact search by id, name, alias"
-             :disabled="loading"
+             :disabled="loading || (showing2D && !svgMap)"
              :value="searchTerm"
              type="text" @input="e => handleChange(e.target.value)"
              @keyup.enter="e => search(e.target.value)" />
@@ -61,6 +61,8 @@ export default {
       searchTerm: state => state.maps.searchTerm,
       idsFound: state => state.maps.idsFound,
       loading: state => state.maps.loading,
+      svgMap: state => state.maps.svgMap,
+      showing2D: state => state.maps.showing2D,
     }),
   },
   watch: {

--- a/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
+++ b/frontend/src/components/explorer/mapViewer/SidebarDataPanels.vue
@@ -7,7 +7,7 @@
           <i>{{ currentMap.name }}</i>
         </p>
       </header>
-      <div v-if="dim==='2d' && currentMap.reactionList && missingReactionList.length > 0"
+      <div v-if="dim==='2d' && missingReactionList && missingReactionList.length > 0"
            class="card-content p-4">
         <template v-if="currentMap.mapReactionIdSet.length == 1">
           Please note that {{ missingReactionList.length }}

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -158,6 +158,7 @@ export default {
       if (this.mapData.svgs.length === 0) {
         this.$store.dispatch('maps/clearSvgMap');
         this.errorMessage = messages.mapNotFound;
+        this.$store.dispatch('maps/setLoading', false);
         return;
       }
       this.errorMessage = '';

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -468,7 +468,6 @@ export default {
       }
 
       const selectionData = { type, data: null, error: false };
-
       this.unHighlight(this.selectedElemsHL, 'selhl');
       if (!element.hasClass('subsystem')) {
         // HL all nodes type but subsystems


### PR DESCRIPTION
### Related issue(s) and PR(s)
This PR closes #737

### A description of the changes proposed in the pull request.
#### Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
 
#### List of changes made
- If visiting `/explore/:model/map-viewer/:map_id?` where the map_id only has a associated 3D map and not a 2D map as well, the map viewer will not be broken. Instead, now you can still click "Switch to 3D".
- If there is no 2D map, there will be no summary of missing ID:s shown in the Sidebar Panel in the 2D view
- If there is no 2D, the search bar is disabled for the 2D view

### Testing
Please delete options that are not relevant.
1. Visit /explore/Fruitfly-GEM/gem-browser/reaction/MAR06749
2. Press Phenylalanine, tyrosine and tryptophan biosynthesis 3D
3. Press 2D
4. Press gem browser link (subsystem or reaction does not matter)
5. Press backwards button
6. Note that the error message is same as in step 3 and that you can click on Switch to 3D

But please play around as well with 2D and 3D for other maps and going from gem browser components to the map viewer to see that nothing is broken/weird.

Note that a `map_id` that does not belong to 2D or 3D maps will still have the same error message and non clickable 3D button as before, e.g. `/explore/Fruitfly-GEM/map-viewer/phenylalanine_tyrosine_and_tryptophan_biosynthesisxxx?dim=2d`


### Further comments
#### Question
During step 2-3, there is a section in the Sidebar Panel for both 2D and 3D called Reaction: MAR06749. During step 6, this is gone. It will occur again if you press 3D again, and still be there if you press 2D, but will disappear if you follow 4-6 once more. I'm not sure if this needs to be fixed or not. Tried looking in to it but did not find a quick fix. If a fix is needed, should it always disappear when there is no 2D map?

#### Discovered bug
#745 was discovered when working on this issue.


### Checklist:
Please delete options that are not relevant.
- [x] My code follows the [style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API