### PR TITLE
feat: improve reaction formatting

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -56,7 +56,7 @@
                 {{ rr.id }}
               </router-link>:&nbsp;
               <span v-html="reformatChemicalReactionHTML(
-                {reaction: rr, noLink : true, model : model.short_name, comp : true})"/>
+                {reaction: rr, noLink : true, model : model.short_name, comp : true})" />
             </p>
           </td>
         </tr>

--- a/frontend/src/components/explorer/gemBrowser/Reaction.vue
+++ b/frontend/src/components/explorer/gemBrowser/Reaction.vue
@@ -51,13 +51,13 @@
         <tr v-if="relatedReactions.length !== 0">
           <td class="td-key has-background-primary has-text-white-bis">Related reaction(s)</td>
           <td>
-            <span v-for="rr in relatedReactions" :key="rr.id">
+            <p v-for="rr in relatedReactions" :key="rr.id">
               <router-link :to="{ name: 'reaction', params: { model: model.short_name, id: rr.id } }">
                 {{ rr.id }}
               </router-link>:&nbsp;
               <span v-html="reformatChemicalReactionHTML(
-                {reaction: rr, noLink : true, model : model.short_name, comp : true})"></span>
-            </span>
+                {reaction: rr, noLink : true, model : model.short_name, comp : true})"/>
+            </p>
           </td>
         </tr>
       </table>

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -2,6 +2,10 @@ export default function chemicalFormula(formula, charge) {
   if (formula === null || formula === undefined) {
     return '';
   }
+  if (/-\w/g.test(formula)) {
+    // avoid bad formatting of metabolite names
+    return formula;
+  }
   let form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
   if (charge) {
     form = `${form}<sup>${Math.abs(charge) !== 1 ? Math.abs(charge) : ''}${charge > 0 ? '+' : '-'}</sup>`;

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -9,6 +9,8 @@ export default function chemicalFormula(formula, charge) {
   let form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
   if (charge) {
     form = `${form}<sup>${Math.abs(charge) !== 1 ? Math.abs(charge) : ''}${charge > 0 ? '+' : '-'}</sup>`;
+  } else {
+    form = form.replace(/([-+])$/, '<sup>$1</sup>');
   }
   return form;
 }

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -10,6 +10,8 @@ export default function chemicalFormula(formula, charge) {
   if (charge) {
     form = `${form}<sup>${Math.abs(charge) !== 1 ? Math.abs(charge) : ''}${charge > 0 ? '+' : '-'}</sup>`;
   } else {
+    // if no explicit charge is provided, check if the form includes one
+    // useful for showing eg NADP+ rather than the formal charge NADP3-
     form = form.replace(/([-+])$/, '<sup>$1</sup>');
   }
   return form;

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -86,7 +86,7 @@ export function reformatChemicalReactionHTML({ reaction, model, noLink = false, 
   const type = 'metabolite';
   const stoichiometry = x => (Math.abs(x.stoichiometry) !== 1 ? `${x.stoichiometry} ` : '');
   // use super- and subscript for charge and number of atoms, if in html mode
-  const chemName = ({ name, charge }) => (html ? chemicalFormula(name.replace(/([-+])$/, ''), charge) : name);
+  const chemName = ({ name }) => (html ? chemicalFormula(name, null) : name);
   const getComponentName = x => (noLink ? chemName(x) : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: chemName(x) }));
 
   function formatReactionElement(x) {

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -83,7 +83,9 @@ export function reformatChemicalReactionHTML({ reaction, model, noLink = false, 
   const addComp = comp || reaction.compartment_str.includes('=>');
   const type = 'metabolite';
   const stoichiometry = x => (Math.abs(x.stoichiometry) !== 1 ? `${x.stoichiometry} ` : '');
-  const getComponentName = x => (noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name }));
+  // superscript + and - at the end of names
+  const supName = ({ name }) => (html ? name.replace(/([-+])$/, '<sup>$1</sup>') : name);
+  const getComponentName = x => (noLink ? supName(x) : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: supName(x) }));
 
   function formatReactionElement(x) {
     if (!addComp) {

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -53,6 +53,7 @@ const sortByName = metabolites => [...metabolites].sort((a, b) => ((a.name > b.n
 /** Get the compartement from a reactant or product */
 const getCompartment = ({ fullName }) => fullName.match(/\[[a-z]{1,3}\]/)[0];
 
+
 /** Extract the compartements from the full names,
   * discard duplicates and return as a string  */
 const uniqueCompartments = xs => Array.from(new Set(xs.map(r => getCompartment(r)))).join(' + ');
@@ -82,14 +83,16 @@ export function reformatChemicalReactionHTML({ reaction, model, noLink = false, 
   const addComp = comp || reaction.compartment_str.includes('=>');
   const type = 'metabolite';
   const stoichiometry = x => (Math.abs(x.stoichiometry) !== 1 ? `${x.stoichiometry} ` : '');
+  const getComponentName = x => (noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name }));
+
   function formatReactionElement(x) {
     if (!addComp) {
-      return `${stoichiometry(x)}${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })}`;
+      return `${stoichiometry(x)}${getComponentName(x)}`;
     }
 
     const compStr = html ? `<span title="${x.compartment}">${getCompartment(x)}</span>` : getCompartment(x);
 
-    return `${stoichiometry(x)}${noLink ? x.name : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: x.name })} ${compStr}`;
+    return `${stoichiometry(x)}${getComponentName(x)} ${compStr}`;
   }
 
   const reactants = sortByName(reaction.reactants).map(formatReactionElement).join(' + ');

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -1,3 +1,5 @@
+import chemicalFormula from '@/helpers/chemical-formatters';
+
 export const buildCustomLink = ({ model, type, id, title, cssClass }) => `<a href="/explore/${model}/gem-browser/${type}/${id}" class="custom-router-link ${cssClass || ''}">${title}</a>`;
 
 export function capitalize(value) {
@@ -83,9 +85,9 @@ export function reformatChemicalReactionHTML({ reaction, model, noLink = false, 
   const addComp = comp || reaction.compartment_str.includes('=>');
   const type = 'metabolite';
   const stoichiometry = x => (Math.abs(x.stoichiometry) !== 1 ? `${x.stoichiometry} ` : '');
-  // superscript + and - at the end of names
-  const supName = ({ name }) => (html ? name.replace(/([-+])$/, '<sup>$1</sup>') : name);
-  const getComponentName = x => (noLink ? supName(x) : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: supName(x) }));
+  // use super- and subscript for charge and number of atoms, if in html mode
+  const chemName = ({ name, charge }) => (html ? chemicalFormula(name.replace(/([-+])$/, ''), charge) : name);
+  const getComponentName = x => (noLink ? chemName(x) : buildCustomLink({ model, type, id: x.id, cssClass: x.id === sourceMet ? 'cms' : undefined, title: chemName(x) }));
 
   function formatReactionElement(x) {
     if (!addComp) {


### PR DESCRIPTION
### Related issue(s) and PR(s)
This PR closes [private issue #116]( https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/116) and relates to #743.

### A description of the changes proposed in the pull request.
#### Type of change
Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

 
#### List of changes made
- Line break between related reactions
- Superscripting `+` and `-` in names

#### Screenshot of the fix
![superscript](https://user-images.githubusercontent.com/1029190/140950773-f8bed413-b150-47df-8136-10b5e50c4345.png)
Also `-` is superscripted, as can be seen here (O2-):
![minus](https://user-images.githubusercontent.com/1029190/140950786-2bf99cab-3551-495e-8b82-0498a5e6ab0a.png)

### Testing
See eg `/explore/Human-GEM/gem-browser/reaction/MAR02041`. 
This fix affects reactions in multiple places (reaction equation, related reactions, reactions in the search results...), but should not change the `Reaction table` tsv.
To see the change in the search result, search for eg `MAR01303` in the quick search.
It would be very good if someone familiar with the api could dobule check that everything looks good (`reaction.js` and `search.js` ~are affected by this~ uses this code, but not with the parameter `html`, so they are not affected).

### Further comments
If you approve of this change, maybe it should be applied to even more places, eg in metabolites like `/explore/Human-GEM/gem-browser/metabolite/MAM02039m` ?

# Checklist:
Please delete options that are not relevant.
- [X] My code follows the [style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
