### PR TITLE
fix: use node 14 for api container

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:14-alpine
 RUN apk add --no-cache fontconfig
 WORKDIR /project
 COPY . .


### PR DESCRIPTION
### Related issue(s) and PR(s)
This PR applies the same Docker image fix that was required for the `frontend` in https://github.com/MetabolicAtlas/MetabolicAtlas/pull/757

### A description of the changes proposed in the pull request.
#### Type of change
Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)
 
#### List of changes made
The node version in the `api` Dockerfile.

#### Screenshot of the fix
Attach screenshot if relevant

### Testing
Deploy the stack after stopping the stack and running `docker system prune -f`.