### PR TITLE
fix: set the image to 14-alpine to solve the node-sass problem

### DIFF
--- a/nginx/prod.Dockerfile
+++ b/nginx/prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS frontend
+FROM node:14-alpine AS frontend
 WORKDIR /project
 COPY frontend .
 RUN yarn && yarn build


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR relates to the [private issue 139](https://app.zenhub.com/workspaces/metatlas-sprint-607745622d49260019ce115a/issues/metabolicatlas/private-issues/139)

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Set the base image to `node:14-alpine` for the nginx production Dockerfile

**Testing**  
<!-- Please delete options that are not relevant -->
Please follow the instructions at https://github.com/MetabolicAtlas/docs/wiki/Deployment-via-Docker to deploy the stack to the dev server. For Linux users, might need to use `docker-compose` instead of `docker compose`. see related issue #781 


**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
