### PR TITLE
fix: switch to 3d

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -162,7 +162,7 @@ export default {
       if (this.avail2D) {
         return `Switch to ${this.dimensionalState(!this.showing2D)}`;
       }
-      return 'This model only has 3D maps availabe';
+      return 'This model only has 3D maps available';
     },
   },
   watch: {

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -19,7 +19,7 @@
              v-on="sidebarLayoutReset ? { scroll: () => handleSidebarScroll() } : {}">
           <div id="mapSidebar__header" class="has-background-lightgray pt-3">
             <div class="buttons has-addons is-centered padding-mobile m-0"
-                 :title="`Switch to ${dimensionalState(!showing2D) }`"
+                 :title="switchTitle"
                  @click="(!currentMap || (currentMap && currentMap.type !== 'custom'))
                    && $store.dispatch('maps/toggleShowing2D')">
               <button v-for="dim in [true, false]" :key="dim"
@@ -157,6 +157,12 @@ export default {
     }),
     queryParams() {
       return { ...this.mapQueryParams, ...this.dataOverlayQueryParams };
+    },
+    switchTitle() {
+      if (this.avail2D) {
+        return `Switch to ${this.dimensionalState(!this.showing2D)}`;
+      }
+      return 'This model only has 3D maps availabe';
     },
   },
   watch: {

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -20,7 +20,8 @@
           <div id="mapSidebar__header" class="has-background-lightgray pt-3">
             <div class="buttons has-addons is-centered padding-mobile m-0"
                  :title="`Switch to ${dimensionalState(!showing2D) }`"
-                 @click="currentMap && currentMap.type !== 'custom' && $store.dispatch('maps/toggleShowing2D')">
+                 @click="(!currentMap || (currentMap && currentMap.type !== 'custom'))
+                   && $store.dispatch('maps/toggleShowing2D')">
               <button v-for="dim in [true, false]" :key="dim"
                       class="button m-0"
                       :class="dim === showing2D ? 'is-selected is-primary has-text-weight-bold' : 'is-light'"

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -149,6 +149,7 @@ export default {
       showing2D: state => state.maps.showing2D,
       dataOverlayPanelVisible: state => state.maps.dataOverlayPanelVisible,
       mapsListing: state => state.maps.mapsListing,
+      avail2D: state => state.maps.avail2D,
     }),
     ...mapGetters({
       mapQueryParams: 'maps/queryParams',

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -25,7 +25,7 @@
               <button v-for="dim in [true, false]" :key="dim"
                       class="button m-0"
                       :class="dim === showing2D ? 'is-selected is-primary has-text-weight-bold' : 'is-light'"
-                      :disabled="currentMap && currentMap.type === 'custom'">
+                      :disabled=" !avail2D || (currentMap && currentMap.type === 'custom')">
                 <span v-if="dim === showing2D" class="icon">
                   <i class="fa fa-check-square-o"></i>
                 </span>

--- a/frontend/src/store/modules/maps.js
+++ b/frontend/src/store/modules/maps.js
@@ -21,6 +21,7 @@ const data = {
     nodes: [],
     links: [],
   },
+  avail2D: true,
   showing2D: true,
   dataOverlayPanelVisible: false,
   coords: {
@@ -52,9 +53,15 @@ const getters = {
 };
 
 const actions = {
+
   async getMapsListing({ commit }, model) {
     const payload = { model: model.apiName, version: model.apiVersion };
     const mapsListing = await mapsApi.fetchMapsListing(payload);
+    let avail2D = false;
+    Object.keys(mapsListing).forEach((cat) => {
+      avail2D = mapsListing[cat].some(x => x.svgs.length === 1) || avail2D;
+    });
+    commit('setAvail2D', avail2D);
     commit('setMapsListing', mapsListing);
   },
 
@@ -203,6 +210,13 @@ const actions = {
 };
 
 const mutations = {
+  setAvail2D: (state, available) => {
+    if (!available) {
+      state.showing2D = false;
+    }
+    state.avail2D = available;
+  },
+
   setAvailableMaps: (state, maps) => {
     state.availableMaps = maps;
   },
@@ -228,7 +242,7 @@ const mutations = {
   },
 
   setShowing2D: (state, showing2D) => {
-    state.showing2D = showing2D;
+    state.showing2D = showing2D && state.avail2D;
   },
 
   setDataOverlayPanelVisible: (state, dataOverlayPanelVisible) => {

--- a/frontend/src/store/modules/maps.js
+++ b/frontend/src/store/modules/maps.js
@@ -58,9 +58,13 @@ const actions = {
     const payload = { model: model.apiName, version: model.apiVersion };
     const mapsListing = await mapsApi.fetchMapsListing(payload);
     let avail2D = false;
-    Object.keys(mapsListing).forEach((cat) => {
-      avail2D = mapsListing[cat].some(x => x.svgs.length === 1) || avail2D;
-    });
+    // eslint-disable-next-line
+    for (const { svgs } of Object.values(mapsListing).flat()) {
+      if (svgs.length > 0) {
+        avail2D = true;
+        break;
+      }
+    }
     commit('setAvail2D', avail2D);
     commit('setMapsListing', mapsListing);
   },


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #756 

Solves the issue of not being able to switch to 3D maps when there are no 2D maps, or when you end up on an invalid map page (eg `/explore/Fruitfly-GEM/map-viewer/phenylalanine_tyrosine_and_tryptophan_biosynthesisxxx?dim=2d`).

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
1. adds a state that keeps track of whether there are available 2D maps
2. defaults to 3D when there are no 2D maps
3. disables the switch buttons when there are no 2D maps
4. allows switching to 3D when visiting a non-existing 2D map
5. allows switching to 3D before choosing map.


**Testing**  
- To test 5:
    - go to `https://metabolicatlas.org/explore/Human-GEM/map-viewer?dim=2d`. Clicking `Switch to 3D` will not do anything
    - on this branch `/explore/Human-GEM/map-viewer?dim=2d`, clicking the same button will refresh the list of available maps
- To test 4, visit `/explore/Fruitfly-GEM/map-viewer/phenylalanine_tyrosine_and_tryptophan_biosynthesisxxx?dim=2d` and change to 3D.
- To test 2&3: visit the Map Viewer for Fruitfly.


**Further comments**  
I'm not very sure about the general design of the state and related functions. 

**Checklist**  
<!-- Please delete options that are not relevant -->
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
