### PR TITLE
Fix/interaction partner overlay error message

### DIFF
--- a/api/src/endpoints/dataOverlay.js
+++ b/api/src/endpoints/dataOverlay.js
@@ -19,8 +19,12 @@ routes.get('/:model', async (req, res) => {
     );
     res.json(JSON.parse(indexJson));
   } catch (e) {
-    console.error(e.message);
-    res.sendStatus(404);
+    if (e.code === 'ENOENT'){
+      res.json({});
+    } else {
+      console.error(e.message);
+      res.sendStatus(404);
+    }
   }
 });
 

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -34,37 +34,41 @@
     <div class="card my-3">
       <div class="card-content py-2 p-3">
         <div class="has-text-centered title is-size-6">Data</div>
-        <div v-if="Object.keys(dataSourcesIndex).length > 0" class="control">
-          <p>Select data type</p>
-          <div v-if="dataType" class="select is-fullwidth">
-            <select @change="handleDataTypeSelect">
-              <option v-for="type in Object.keys(dataSourcesIndex)" :key="type"
-                      :selected="type === dataType.name"
-                      :value="type"
-                      class="is-clickable is-capitalized">{{ type }}</option>
-            </select>
+        <div v-if="modelHasOverlayData()">
+          <div class="control">
+            <p>Select data type</p>
+            <div v-if="dataType" class="select is-fullwidth">
+              <select @change="handleDataTypeSelect">
+                <option v-for="type in Object.keys(dataSourcesIndex)" :key="type"
+                        :selected="type === dataType.name"
+                        :value="type"
+                        class="is-clickable is-capitalized">{{ type }}</option>
+              </select>
+            </div>
           </div>
-        </div>
-        <div v-if="Object.keys(dataSourcesIndex).length > 0" class="control">
-          <p>Select data source</p>
-          <div v-if="dataType" class="select is-fullwidth">
-            <select @change="handleDataSourceSelect">
-              <option v-for="s in dataSourcesIndex[dataType.name]" :key="s.filename"
-                      :selected="dataSource && s.filename === dataSource.filename"
-                      :value="s.filename"
-                      class="is-clickable is-capitalized">{{ s.name }}</option>
-            </select>
+          <div class="control">
+            <p>Select data source</p>
+            <div v-if="dataType" class="select is-fullwidth">
+              <select @change="handleDataSourceSelect">
+                <option v-for="s in dataSourcesIndex[dataType.name]" :key="s.filename"
+                        :selected="dataSource && s.filename === dataSource.filename"
+                        :value="s.filename"
+                        class="is-clickable is-capitalized">{{ s.name }}</option>
+              </select>
+            </div>
           </div>
-        </div>
-        <div v-if="dataSource" class="control">
-          <p>Levels from <a :href="dataSource.link" target="_blank">{{ dataSource.name }}</a></p>
-          <div class="select is-fullwidth">
-            <select :disabled="levelsDisabled" @change="(e) => setDataSet(e.target.value)">
-              <option>None</option>
-              <option v-for="t in dataSource.dataSets" :key="t"
-                      :selected="t === dataSet"
-                      class="is-clickable is-capitalized">{{ t }}</option>
-            </select>
+          <div class="control">
+            <div v-if="dataSource" class="control">
+              <p>Levels from <a :href="dataSource.link" target="_blank">{{ dataSource.name }}</a></p>
+              <div class="select is-fullwidth">
+                <select :disabled="levelsDisabled" @change="(e) => setDataSet(e.target.value)">
+                  <option>None</option>
+                  <option v-for="t in dataSource.dataSets" :key="t"
+                          :selected="t === dataSet"
+                          class="is-clickable is-capitalized">{{ t }}</option>
+                </select>
+              </div>
+            </div>
           </div>
         </div>
         <template v-if="customDataSource">
@@ -223,6 +227,9 @@ export default {
           .map(e => e.filename)
           .indexOf(this.$route.query.datasource) > -1
       );
+    },
+    modelHasOverlayData() {
+      return Object.keys(this.dataSourcesIndex).length > 0;
     },
     validDataSourceDataSetInQuery() {
       return (

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -162,6 +162,9 @@ export default {
     const dataSet = this.validDataSourceDataSetInQuery() ? this.$route.query.dataSet : 'None';
     await this.setDataSet(dataSet);
   },
+  destroyed() {
+    this.resetDataValues();
+  },
   methods: {
     ...mapActions({
       getDataSourcesIndex: 'dataOverlay/getIndex',
@@ -170,6 +173,7 @@ export default {
       setDataSet: 'dataOverlay/setDataSet',
       setCustomDataSource: 'dataOverlay/setCustomDataSource',
       setCustomDataSet: 'dataOverlay/setCustomDataSet',
+      resetDataValues: 'dataOverlay/resetValues',
     }),
     async handleDataTypeSelect(e) {
       const payload = {

--- a/frontend/src/store/modules/dataOverlay.js
+++ b/frontend/src/store/modules/dataOverlay.js
@@ -106,6 +106,12 @@ const actions = {
     }
     commit('setCustomDataSet', dataSet);
   },
+  resetValues({ commit }) {
+    commit('setIndex', {});
+    commit('setCurrentDataType', null);
+    commit('setCurrentDataSource', null);
+    commit('setDataSet', 'None');
+  },
 };
 
 const mutations = {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #770

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Backend does not throw 404 when models don't have a index for data overlay since this is expected for a majority of the models
- Frontend only shows custom data overlay functionality if there is no server data for this model
- Data overlay store values are reset when a data overlay component is destroyed

**Testing**  
<!-- Please delete options that are not relevant -->
Relative urls that can be reused both for production and local testing:

Error message:
    1. Visit /explore
    2. Click Worm-GEM, Mouse-GEM, Rat-GEM or Fruitfly-GEM
    3. Press Interaction Partners
    4. Press a random gene or metabolite
    5. Note that no error message is thrown and that only custom data upload functionality is provided
    
Reset values:
   1. Visit explore/Human-GEM/interaction-partners/ENSG00000168748
   2. Choose adipose tissue
   3. Visit /explore/Human-GEM/map-viewer?dim=2d
   4. Choose a map
   5. Note that the url contains `datatype=None&datasource=None&dataSet=None` and not `datatype=transcriptomics&datasource=hpaRna.tsv&dataSet=adipose tissue`
   6. Open data overlay sidebar
   7. Note that the url values for data overlay are the same as before the sidebar was opened

Please also play around with the Interaction Partner and Map Viewer for different models to make sure I haven't missed anything

**Further comments**  
<!-- Specify questions or related information -->
- The fix regarding resetting the values was not part of issue #770, but the bug was discovered during the development and required such a small fix that I though it make sense to include it in this PR. I can remove it if you feel it is bad to include in this PR

- Yeast-GEM has mock data deployed, these are removed in https://github.com/MetabolicAtlas/data-files/pull/25

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
