### PR TITLE
fix: maps and mapsearch behind gemsearch in firefox as well

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -59,7 +59,8 @@
             <a @click="showingMapListing = true">Show the map list and choose a compartment or subsystem map</a>
           </p>
         </div>
-        <div v-else class="column is-unselectable om-1 fixed-height-desktop fixed-height-mobile p-0 m-0">
+        <div v-else id="mapWrapper"
+             class="column is-unselectable om-1 fixed-height-desktop fixed-height-mobile p-0 m-0">
           <Svgmap v-if="showing2D"
                   :map-data="currentMap"
                   @unSelect="unSelect" @updatePanelSelectionData="updatePanelSelectionData">
@@ -302,6 +303,9 @@ export default {
         }
       }
     }
+  }
+  #mapWrapper {
+    z-index: 5;
   }
 
   .padding-mobile {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #736 and was created by @e0 and @inghylt 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
z-index has been added to the 2D and 3D maps to make sure it is behind gem search in firefox

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![image](https://user-images.githubusercontent.com/32480198/144027700-5fd5760e-614f-48e8-a647-505bfda10c7b.png)


**Testing**  
<!-- Please delete options that are not relevant -->
1. Open Firefox
2. Visit /explore/Fruitfly-GEM/map-viewer/peroxisome?dim=3d&panel=0&sel=MAM03419p&search=MAM03419p&coords=0,0,1,0,0,500&datatype=None&datasource=None&dataSet=None
3. Try searching for something in quick search

Please also play around with other maps and map search options in 2D and 3D to make sure we haven't missed anything


**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
