### PR TITLE
feat: deploy improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,7 @@ bh_unicode_properties.cache
 GitHub.sublime-settings
 
 # local env files
-.env*
+*.env
 node_modules/
 
 # Log files

--- a/README.md
+++ b/README.md
@@ -55,6 +55,16 @@ start-stack
 
 Given successful deployment, the frontend should be accessible at: `http://localhost/`. If you encounter any problems try looking at the logs `logs api` / `logs frontend`.
 
+To deploy the stack to a remote server, create another `.env` file and modify it accordingly:
+```bash
+cp env-local.env.sample env-dev.env
+```
+
+Use the name of the file (`dev` in the previous example) as an argument to the `deploy-stack` command to pass the `.env` file to the Docker command and the Docker compose file:
+```bash
+deploy-stack dev
+```
+
 ## Description of helper commands
 
 * To bootstrap the project: `build-stack`

--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ start-stack
 
 Given successful deployment, the frontend should be accessible at: `http://localhost/`. If you encounter any problems try looking at the logs `logs api` / `logs frontend`.
 
-To deploy the stack to a remote server, create another `.env` file and modify it accordingly:
+To deploy the stack to a remote server, create another `ENV` file, e.g. `env-dev.env`, and modify it accordingly:
 ```bash
 cp env-local.env.sample env-dev.env
 ```
 
-Use the name of the file (`dev` in the previous example) as an argument to the `deploy-stack` command to pass the `.env` file to the Docker command and the Docker compose file:
+Use the tag of the file (`dev` in the previous example) as an argument to the `deploy-stack` command to pass the `ENV` file to the Docker command and the Docker compose file:
 ```bash
 deploy-stack dev
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ In the folder `MetabolicAtlas` that has been cloned, add a `env-local.env` file 
 ```bash
 cp env-local.env.sample env-local.env
 ```
-and modify this `.env` file.
+and modify this `env-local.env` file.
 
 Make sure the paths for `DATA_FILES_PATH` and `DATA_GENERATOR_PATH` are correct for your setup, eg. the paths to where you have downloaded the repositories `data-files` and `data-generation`.
 

--- a/README.md
+++ b/README.md
@@ -28,38 +28,15 @@ Clone the three required repositories by
     git clone https://github.com/MetabolicAtlas/data-files && pushd data-files; git lfs pull; popd
 
 
-Go to the repository `data-generation` and follow the
-[instructions](https://github.com/MetabolicAtlas/data-generation#readme) on how to generate the data files required by MetabolicAtlas.
+Go to the repository `data-generation` and follow the [instructions](https://github.com/MetabolicAtlas/data-generation#readme) on how to generate the data files required by Metabolic Atlas.
 
-In the folder `MetabolicAtlas` that has been cloned, add a `.env` file based on the `.env.sample` file:
+In the folder `MetabolicAtlas` that has been cloned, add a `env-local.env` file based on the `env-local.env.sample` file:
 ```bash
-cp .env.sample .env
+cp env-local.env.sample env-local.env
 ```
 and modify this `.env` file.
 
-The content of the file `.env` that has just been copied from `.env.sample` is shown below. Make sure the paths for `DATA_FILES_PATH` and `DATA_GENERATOR_PATH` are correct for your setup,
-eg. the paths to where you have downloaded the repositories `data-files` and `data-generation`.
-
-
-```
-CERTBOT_EMAIL=
-SERVER_NAME=localhost
-DATA_FILES_PATH=../data-files
-DATA_GENERATOR_PATH=../data-generation
-
-NEO4J_USERNAME=neo4j
-NEO4J_PASSWORD=password-unhackable
-
-FTP_MIN_PORT=30000
-FTP_MAX_PORT=31000
-
-PORT_NGINX=80
-PORT_FRONTEND=81
-PORT_NEO4J_1=7474
-PORT_NEO4J_2=7687
-
-IP_FILTER=""
-```
+Make sure the paths for `DATA_FILES_PATH` and `DATA_GENERATOR_PATH` are correct for your setup, eg. the paths to where you have downloaded the repositories `data-files` and `data-generation`.
 
 To load the list of helper commands run:
 ```bash
@@ -94,9 +71,7 @@ When rebuilding the stack, you might have to change the ownership of the directo
 ```
 sudo chown -R <user> neo4j
 ```
-Replace `<user>` with your user name.
-The ownership will be automatically reset when running the project, so you will
-have to repeat this step for every rebuild.
+Replace `<user>` with your user name. The ownership will be automatically reset when running the project, so you will have to repeat this step for every rebuild.
 
 
 ## Licenses

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -36,8 +36,6 @@ services:
       - "127.0.0.1:${PORT_NEO4J_2:-7687}:7687"
 
   api:
-    environment:
-      - NODE_ENV=develop
     volumes:
       - ./api/src:/project/src
       - ./api/svg:/project/svg

--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -25,8 +25,6 @@ services:
           memory: 3G
 
   api:
-    environment:
-      - NODE_ENV=production
     command: yarn start
     restart: unless-stopped
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,6 @@ services:
   api:
     container_name: api
     build: api
-    env_file: .env
     depends_on: 
       - neo4j
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
   api:
     container_name: api
     build: api
+    env_file: ${CHOSEN_ENV}
     depends_on: 
       - neo4j
     networks:

--- a/env-local.env.sample
+++ b/env-local.env.sample
@@ -1,6 +1,9 @@
 ## The variables below are required for the production enviroment.
 ## Some might be also required for the local environment.
 
+# Assign this to the adequate Docker context
+export DOCKER_CONTEXT=default
+
 # These paths are needed to use code and files from other
 # repositories (dependencies).
 DATA_FILES_PATH=../data-files

--- a/env-local.env.sample
+++ b/env-local.env.sample
@@ -1,8 +1,11 @@
 ## The variables below are required for the production enviroment.
 ## Some might be also required for the local environment.
 
-# Assign this to the adequate Docker context
+# Assign this to the adequate Docker context.
 export DOCKER_CONTEXT=default
+
+# Set if Node.js should run in develop or production mode.
+NODE_ENV=develop
 
 # These paths are needed to use code and files from other
 # repositories (dependencies).

--- a/env-local.env.sample
+++ b/env-local.env.sample
@@ -2,9 +2,16 @@
 ## Some might be also required for the local environment.
 
 # Assign this to the adequate Docker context.
+# This will be used in the `docker context` command.
+# To read more about how to create and use a Docker context, visit
+# https://docs.docker.com/engine/reference/commandline/context/
+# The default value for a Docker setup is that the local context
+# is called `default`.
+# When deploying to a remote server, first create a Docker context
+# manually, and then reference it here.
 export DOCKER_CONTEXT=default
 
-# Set if Node.js should run in develop or production mode.
+# Set if Node.js should run in `develop` or `production` mode.
 NODE_ENV=develop
 
 # These paths are needed to use code and files from other
@@ -13,6 +20,9 @@ DATA_FILES_PATH=../data-files
 DATA_GENERATOR_PATH=../data-generation
 
 # These variables are needed to obtain the SSL certificate from Let's Encrypt.
+# The first is the email address to be associated with the SSL certificate.
+# The second is the domain name of the server where the deployment is made.
+# For local deployments use `localhost`
 CERTBOT_EMAIL=
 SERVER_NAME=localhost
 

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -163,7 +163,7 @@ export default {
       if (this.avail2D) {
         return `Switch to ${this.dimensionalState(!this.showing2D)}`;
       }
-      return 'This model only has 3D maps available';
+      return 'This model has only 3D maps available';
     },
   },
   watch: {

--- a/proj.sh
+++ b/proj.sh
@@ -44,6 +44,7 @@ function deploy-stack {
   CHOSEN_ENV="env-${1:=local}.env"
   generate-data
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
+  CHOSEN_ENV="env-local.env"
 }
 
 function import-db {

--- a/proj.sh
+++ b/proj.sh
@@ -1,11 +1,10 @@
 # To make sure docker-compose is in the path
 export PATH=$PATH:/usr/local/bin
-CHOSEN_ENV="env-${1:-local}.env"
+export CHOSEN_ENV="env-local.env"
 
 function generate-data {
   # enable flag "-q" to force overwritting existing data files
-  echo 'Data generation started.'
-  echo $CHOSEN_ENV
+  echo "Using $CHOSEN_ENV"
   source $CHOSEN_ENV && yarn --cwd $DATA_GENERATOR_PATH start $DATA_FILES_PATH "$@"
   /bin/cp -rf $DATA_GENERATOR_PATH/neo4j/* neo4j/import
   /bin/cp -rf $DATA_GENERATOR_PATH/dataOverlay api/
@@ -42,9 +41,9 @@ function logs {
 }
 
 function deploy-stack {
-  CHOSEN_ENV="env-${1:-local}.env"
+  CHOSEN_ENV="env-${1:=local}.env"
   generate-data
-  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-prod.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
+  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
 }
 
 function import-db {

--- a/proj.sh
+++ b/proj.sh
@@ -1,6 +1,7 @@
 # To make sure docker-compose is in the path
 export PATH=$PATH:/usr/local/bin
-export CHOSEN_ENV="env-local.env"
+LOCALENV="local"
+METATLAS_DEFAULT_ENV="env-${LOCALENV}.env"
 
 function generate-data {
   # enable flag "-q" to force overwritting existing data files
@@ -41,10 +42,10 @@ function logs {
 }
 
 function deploy-stack {
-  CHOSEN_ENV="env-${1:=local}.env"
+  CHOSEN_ENV="env-${1:-$LOCALENV}.env"
   generate-data
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
-  CHOSEN_ENV="env-local.env"
+  CHOSEN_ENV=$METATLAS_DEFAULT_ENV
 }
 
 function import-db {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #618 by implementing a way to use a user-provided short text to decide which environment file to use, relying on that environment file to also select the appropriate Docker context.
<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Instead of having to manually switch the `.env`, there are now multiple environment files that can be used, with the expected pattern `env-[NAME].env`. Before, the deployment command was expecting only a Docker context. Now, it is expecting the desired `[NAME]`, using it to identify the desired `.env` file, which now also specified the Docker context. I think this way of specifying the context might require a certain Docker version.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- A rebuild is needed due to new dependencies
- Instructions on how to test

**Further comments**  
After fetching the `.env` files, try building locally and also
```bash
deploy-stack dev
```

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] ~I have checked so that the same data as before is returned by the API~ n/a
