### PR TITLE
fix: remove HPA version from Data Overlay documentation

### DIFF
--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -367,7 +367,7 @@
                 Viewer. The gene expression levels used are obtained from the file
                 <a href="https://www.proteinatlas.org/about/download" target="_blank">
                   rna_tissue_hpa.tsv
-                </a>
+                </a>.
               </p>
               <p>
                 The

--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -365,9 +365,12 @@
                 <i>None</i>
                 option in the drop down list. RNA levels are available for both 2D and 3D Map
                 Viewer. The gene expression levels used are obtained from the file
+                <b>rna_tissue_hpa.tsv.zip</b>
+                in the
                 <a href="https://www.proteinatlas.org/about/download" target="_blank">
-                  rna_tissue_hpa.tsv
-                </a>.
+                  download page
+                </a>
+                of the Human Protein Atlas.
               </p>
               <p>
                 The

--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -354,12 +354,8 @@
                 . By clicking the
                 <i>Data overlay</i>
                 button on the right side of the page, one can toggle the hidden/display of this
-                panel. On the
-                <i>Data overlay</i>
-                panel, gene expression levels for genes from
-                <a href="https://www.proteinatlas.org/about/releases#18" target="_blank">
-                  The Human Protein Atlas v18
-                </a>
+                panel. For Human-GEM, the gene expression levels for genes from
+                <a href="https://www.proteinatlas.org/" target="_blank">The Human Protein Atlas</a>
                 can be loaded by selecting one of the tissues in the drop down list. Once selected,
                 the RNA levels corresponding to the chosen tissue will be used to color each gene on
                 the respective map, according to the color legend (an example of the color legend is
@@ -368,10 +364,10 @@
                 ). To clear the RNA levels, select the
                 <i>None</i>
                 option in the drop down list. RNA levels are available for both 2D and 3D Map
-                Viewer. The data is obtained from version 18 of the Protein Atlas with the units in
-                log
-                <sub>2</sub>
-                (TPM+1) associated with a gradient colorbar.
+                Viewer. The gene expression levels used are obtained from the file
+                <a href="https://www.proteinatlas.org/about/download" target="_blank">
+                  rna_tissue_hpa.tsv
+                </a>
               </p>
               <p>
                 The


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #738

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other, improve documentation
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Data Overlay documentation is rewritten to not reference a specific HPA version as this easily can go out of date

Note that [this comment](https://github.com/MetabolicAtlas/MetabolicAtlas/issues/738#issuecomment-966336807) was fixed in #807

**Testing**  
<!-- Please delete options that are not relevant -->
Look at `/documentation#Data-overlay` and see if it looks good

**Further comments**  
<!-- Specify questions or related information -->

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
