### PR TITLE
fix: make consistent url when switching between 2D/3D Map Viewer for SVG maps with sub maps 

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -285,7 +285,7 @@ export default {
         let urlPath = `${this.$route.path}`;
         if (this.currentMap.mapReactionIdSet.length > 1) {
           if (newQuery.dim === '2d') {
-            urlPath = urlPath.replace(new RegExp(this.currentMap.id), `${this.currentMap.id}_1`);
+            urlPath = urlPath.replace(new RegExp(this.currentMap.id), this.currentMap.svgs[0].id);
           } else {
             urlPath = urlPath.replace(new RegExp(this.$route.params.map_id), this.currentMap.id);
           }

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -279,11 +279,17 @@ export default {
         .join('&');
 
       if (newQuery.dim === this.$route.query.dim || (newQuery.dim && !this.$route.query.dim)) {
+        // if Map viewer (2D or 3D) is not changed, keep the url path
         const payload = [{}, null, `${this.$route.path}?${queryString}`];
         history.replaceState(...payload); // eslint-disable-line no-restricted-globals
       } else {
         let urlPath = `${this.$route.path}`;
         if (this.currentMap.mapReactionIdSet.length > 1) {
+          // if Map Viewer (2D or 3D) is changed, for the 2D Compartment maps with
+          // sub maps, e.g. Cytosol, replace the map id to the name of submap when
+          // switching to the 2D Map viewer, and replace the map id of the
+          // submap back to the compartment name when switching to the 3D Map
+          // viewer
           if (newQuery.dim === '2d') {
             urlPath = urlPath.replace(new RegExp(this.currentMap.id), this.currentMap.svgs[0].id);
           } else {

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -277,10 +277,20 @@ export default {
       const queryString = Object.entries(newQuery)
         .map(e => e.join('='))
         .join('&');
-      const payload = [{}, null, `${this.$route.path}?${queryString}`];
+
       if (newQuery.dim === this.$route.query.dim || (newQuery.dim && !this.$route.query.dim)) {
+        const payload = [{}, null, `${this.$route.path}?${queryString}`];
         history.replaceState(...payload); // eslint-disable-line no-restricted-globals
       } else {
+        let urlPath = `${this.$route.path}`;
+        if (this.currentMap.mapReactionIdSet.length > 1) {
+          if (newQuery.dim === '2d') {
+            urlPath = urlPath.replace(new RegExp(this.currentMap.id), `${this.currentMap.id}_1`);
+          } else {
+            urlPath = urlPath.replace(new RegExp(this.$route.params.map_id), this.currentMap.id);
+          }
+        }
+        const payload = [{}, null, `${urlPath}?${queryString}`];
         history.pushState(...payload); // eslint-disable-line no-restricted-globals
       }
     },


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #745 
<!-- Include below a description of the changes proposed in the pull request -->
The URL in the address bar is reset to reflect the actual map shows in the Map Viewer, so that a hard refresh (ctrl-r) will not show `map not found` error
**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
Follow the steps described in the issue  #745, the buggy behavior will disappear. 
Moreover, when switching to the 2D map viewer, select e.g. `Part 4`, and then switch to 3D and then switch back to 2D, the original 2D map for `Part 4` will be restored.  

**Further comments**  
<!-- Specify questions or related information -->
When switching to the 2D map for the first time from the 3D map viewer, the SVG map `Part 2`, which is the first element of the array `this.currentMap.svgs`,  is selected. This might be discussed if it is reasonable. 

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
