### PR TITLE
fix: split subsystem links

### DIFF
--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -41,7 +41,7 @@ const fetchRelatedReactions = async (resourceType, id, model, version, limit) =>
   return data.map(r => ({
     ...r,
     compartment_str: constructCompartmentStr(r),
-    subsystem_str: r.subsystems.map(s => s.name).join(', '),
+    subsystem_str: r.subsystems.map(s => s.name).join('; '),
     reactants: r.metabolites.filter(m => m.outgoing),
     products: r.metabolites.filter(m => !m.outgoing),
   }));


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #741.

Fixes the problem with broken links to subsystems from the reaction table in the gem browser.
<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Names in  `subsystem_str` are consistently separated by `;`.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Check the subsystem links in the reaction table here `explore/Yeast-GEM/gem-browser/gene/YJL167W`
- Also verify that subsystem names with `,` still work, eg here `explore/Human-GEM/gem-browser/gene/ENSG00000121691` (`Phenylalanine, tyrosine and tryptophan biosynthesis`)

**Further comments**  
<!-- Specify questions or related information -->
As far as I can tell, the `subsystem_str` are not used outside of `ReactionTable.vue`.

**Checklist**  
<!-- Please delete options that are not relevant -->
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have checked so that the same data as before is returned by the API
