### PR TITLE
fix: use matching id for internal links

### DIFF
--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -129,7 +129,7 @@
             pages in which this reaction is involved.
           </p>
 
-          <h5 id="metabolite-page" class="is-size-5">Metabolite page</h5>
+          <h5 id="GEM-Browser-Metabolite" class="is-size-5">Metabolite page</h5>
           <p>
             The
             <i>Metabolite</i>


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #833.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Changed the target id to the correct one so the internal links pointing to it would work.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="571" alt="image" src="https://user-images.githubusercontent.com/423498/150139599-b7c359b5-a071-40f9-9891-16d259516c2d.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test

1. Go to the `/documentation` page.
2. Click on the 'Metabolite page' from the Table of Contents (sidebar).
3. Verify that the page jumps to the 'Metabolite page' section.

**Further comments**  
<!-- Specify questions or related information -->
Initially I changed the link in the ToC to `#metabolite-page`. Then I realized that it's the id that should be changed as the links pointing to it have previously been updated elsewhere in the project: https://github.com/MetabolicAtlas/MetabolicAtlas/commit/c19b42425372caebc52d036aa467173b5ae12879#diff-af365a2d85050d7c234a70eac8ba9fac19526d81e3b3fc8c8421b600ab6a8273

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
