### PR TITLE
fix: display data overlay level on mouse hover

### DIFF
--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -116,6 +116,9 @@ export default {
     async mapData() {
       await this.init();
     },
+    componentClassName() {
+      this.setupHoverEventHandlers();
+    },
     dataSet() {
       this.applyLevelsOnMap();
     },
@@ -133,23 +136,6 @@ export default {
       $('#svg-wrapper').on('click', aClass, async function f() {
         await self.selectElement($(this));
       });
-    });
-    $('#svg-wrapper').on('mouseover', `.${self.componentClassName}`, function f(e) {
-      const id = $(this).attr('class').split(' ')[1].trim();
-      if (id in self.computedLevels) {
-        self.$refs.tooltip.innerHTML = self.computedLevels[id][1]; // eslint-disable-line prefer-destructuring
-      } else if (Object.keys(self.computedLevels).length !== 0) {
-        self.$refs.tooltip.innerHTML = self.computedLevels['n/a'][1]; // eslint-disable-line prefer-destructuring
-      } else {
-        return;
-      }
-      self.$refs.tooltip.style.top = `${e.pageY - $('.svgbox').first().offset().top + 15}px`;
-      self.$refs.tooltip.style.left = `${e.pageX - $('.svgbox').first().offset().left + 15}px`;
-      self.$refs.tooltip.style.display = 'block';
-    });
-    $('#svg-wrapper').on('mouseout', `.${self.componentClassName}`, () => {
-      self.$refs.tooltip.innerHTML = '';
-      self.$refs.tooltip.style.display = 'none';
     });
     $('.svgbox').on(
       'webkitfullscreenchange mozfullscreenchange fullscreenchange mozFullScreen MSFullscreenChange',
@@ -175,6 +161,26 @@ export default {
       const payload = { model: this.model.short_name, svgName: this.mapData.svgs[0].filename };
       await this.$store.dispatch('maps/getSvgMap', payload);
       this.bindKeyboardShortcuts();
+    },
+    setupHoverEventHandlers() {
+      const self = this;
+      $('#svg-wrapper').on('mouseover', `.${self.componentClassName}`, function f(e) {
+        const id = $(this).attr('class').split(' ')[1].trim();
+        if (id in self.computedLevels) {
+          self.$refs.tooltip.innerHTML = self.computedLevels[id][1]; // eslint-disable-line prefer-destructuring
+        } else if (Object.keys(self.computedLevels).length !== 0) {
+          self.$refs.tooltip.innerHTML = self.computedLevels['n/a'][1]; // eslint-disable-line prefer-destructuring
+        } else {
+          return;
+        }
+        self.$refs.tooltip.style.top = `${e.pageY - $('.svgbox').first().offset().top + 15}px`;
+        self.$refs.tooltip.style.left = `${e.pageX - $('.svgbox').first().offset().left + 15}px`;
+        self.$refs.tooltip.style.display = 'block';
+      });
+      $('#svg-wrapper').on('mouseout', `.${self.componentClassName}`, () => {
+        self.$refs.tooltip.innerHTML = '';
+        self.$refs.tooltip.style.display = 'none';
+      });
     },
     bindKeyboardShortcuts() {
       document.addEventListener('keydown', event => {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes https://github.com/MetabolicAtlas/private-issues/issues/141.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
The data overlay level used to be displayed on mouse hover but was then broken. This PR re-enables it.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="311" alt="image" src="https://user-images.githubusercontent.com/423498/150181530-19c7b5b3-1c6f-4a18-ac86-50c36caeb000.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test

1. Visit `/explore/Human-GEM/map-viewer/acylglycerides_metabolism?dim=2d&panel=1`.
2. Select a data set, for example 'adipose tissue'.
3. Mouse over genes (rectangles) on the SVG map and verify that a number is displayed.

**Further comments**  
<!-- Specify questions or related information -->
The mouse event initialization was previously done in the `mounted` function. In this function the `componentClassName` may still not be initialized so the mouse events are not setup.

The fix moves the mouse event initialization into a separate function which is called inside a watch handler for `componentClassName` to ensure it's done correctly.

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
