### PR TITLE
feat: add support for returning all related reactions for a metabolite

### DIFF
--- a/api/src/endpoints/neo4j.js
+++ b/api/src/endpoints/neo4j.js
@@ -35,7 +35,7 @@ const fetchWith = async (req, res, queryHandler) => {
     full,
     searchTerm,
     componentTypes,
-    allCompartments,
+    isForAllCompartments,
   } = req.query;
 
   try {
@@ -52,8 +52,8 @@ const fetchWith = async (req, res, queryHandler) => {
       payload.componentTypes = JSON.parse(componentTypes);
     }
 
-    if (allCompartments) {
-      payload.allCompartments = JSON.parse(allCompartments);
+    if (isForAllCompartments) {
+      payload.isForAllCompartments = JSON.parse(isForAllCompartments);
     }
 
     const result = await queryHandler(payload);

--- a/api/src/endpoints/neo4j.js
+++ b/api/src/endpoints/neo4j.js
@@ -28,13 +28,32 @@ const neo4jRoutes = express.Router();
 
 const fetchWith = async (req, res, queryHandler) => {
   const { id } = req.params;
-  const { model, version, limit, full, searchTerm, componentTypes } = req.query;
+  const {
+    model,
+    version,
+    limit,
+    full,
+    searchTerm,
+    componentTypes,
+    allCompartments,
+  } = req.query;
 
   try {
-    const payload = { id, version, model, limit, full, searchTerm };
+    const payload = {
+      id,
+      version,
+      model,
+      limit,
+      full,
+      searchTerm,
+    };
 
     if (componentTypes) {
       payload.componentTypes = JSON.parse(componentTypes);
+    }
+
+    if (allCompartments) {
+      payload.allCompartments = JSON.parse(allCompartments);
     }
 
     const result = await queryHandler(payload);

--- a/api/src/neo4j/queries/relatedReactions.js
+++ b/api/src/neo4j/queries/relatedReactions.js
@@ -16,7 +16,7 @@ const getRelatedReactions = async ({
   model,
   version,
   limit,
-  allCompartments,
+  isForAllCompartments,
 }) => {
   const [m, v] = parseParams(model, version);
   let statement;
@@ -39,10 +39,10 @@ WHERE ccms1 = ccms3 and r1.id <> r.id`;
 MATCH (:Gene${m} {id: '${id}'})-[${v}]-(r:Reaction)`;
       break;
     case NODE_TYPES.metabolite:
-      // If `allCompartments` is true, all reactions associated with
+      // If `isForAllCompartments` is true, all reactions associated with
       // the metabolite are returned. Otherwise, only reactions associated
       // with the same compartmentalized metabolite are returned.
-      if (allCompartments) {
+      if (isForAllCompartments) {
         statement = `
 MATCH (:CompartmentalizedMetabolite${m} {id: '${id}'})-[${v}]-(m:Metabolite)
 WITH m
@@ -142,7 +142,7 @@ const getRelatedReactionsForMetabolite = ({
   model,
   version,
   limit,
-  allCompartments,
+  isForAllCompartments,
 }) =>
   getRelatedReactions({
     id,
@@ -150,7 +150,7 @@ const getRelatedReactionsForMetabolite = ({
     version,
     nodeType: NODE_TYPES.metabolite,
     limit,
-    allCompartments,
+    isForAllCompartments,
   });
 
 const getRelatedReactionsForSubsystem = ({ id, model, version, limit }) =>

--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -35,8 +35,8 @@ const fetchRelatedReactionsForReaction = async ({ id, model, version, limit }) =
     }));
 };
 
-const fetchRelatedReactions = async (resourceType, id, model, version, limit) => {
-  const params = { model, version, limit };
+const fetchRelatedReactions = async (resourceType, id, model, version, limit, allCompartments) => {
+  const params = { model, version, limit, allCompartments };
   const { data } = await axios.get(`/${resourceType}s/${id}/related-reactions`, { params });
   return data.map(r => ({
     ...r,
@@ -50,7 +50,7 @@ const fetchRelatedReactions = async (resourceType, id, model, version, limit) =>
 const fetchRelatedReactionsForGene = async ({ id, model, version, limit }) =>
   fetchRelatedReactions('gene', id, model, version, limit);
 
-const fetchRelatedReactionsForMetabolite = async ({ id, model, version, limit }, allCompartments) =>
+const fetchRelatedReactionsForMetabolite = async ({ id, model, version, limit, allCompartments }) =>
   fetchRelatedReactions('metabolite', id, model, version, limit, allCompartments);
 
 const fetchRelatedReactionsForSubsystem = async ({ id, model, version, limit }) =>

--- a/frontend/src/api/reactions.js
+++ b/frontend/src/api/reactions.js
@@ -35,8 +35,15 @@ const fetchRelatedReactionsForReaction = async ({ id, model, version, limit }) =
     }));
 };
 
-const fetchRelatedReactions = async (resourceType, id, model, version, limit, allCompartments) => {
-  const params = { model, version, limit, allCompartments };
+const fetchRelatedReactions = async (
+  resourceType,
+  id,
+  model,
+  version,
+  limit,
+  isForAllCompartments
+) => {
+  const params = { model, version, limit, isForAllCompartments };
   const { data } = await axios.get(`/${resourceType}s/${id}/related-reactions`, { params });
   return data.map(r => ({
     ...r,
@@ -50,8 +57,13 @@ const fetchRelatedReactions = async (resourceType, id, model, version, limit, al
 const fetchRelatedReactionsForGene = async ({ id, model, version, limit }) =>
   fetchRelatedReactions('gene', id, model, version, limit);
 
-const fetchRelatedReactionsForMetabolite = async ({ id, model, version, limit, allCompartments }) =>
-  fetchRelatedReactions('metabolite', id, model, version, limit, allCompartments);
+const fetchRelatedReactionsForMetabolite = async ({
+  id,
+  model,
+  version,
+  limit,
+  isForAllCompartments,
+}) => fetchRelatedReactions('metabolite', id, model, version, limit, isForAllCompartments);
 
 const fetchRelatedReactionsForSubsystem = async ({ id, model, version, limit }) =>
   fetchRelatedReactions('subsystem', id, model, version, limit);

--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -160,7 +160,7 @@
             display additional reactions involving the metabolite in any compartment, click the
             button to
             <i>See reactions from all compartments</i>
-            . Note that the number of retrieved reactions is limited to 200. It is recommended to
+            . Note that the number of retrieved reactions is limited to 1000. It is recommended to
             use the
             <a href="#API">API</a>
             to retrieve all reactions.
@@ -189,10 +189,7 @@
             page is also similar to the
             <a href="#GEM-Browser-Metabolite">Metabolite</a>
             page except that the top table shows information on the current selected metabolic
-            subsystem instead of metabolites. In addition, the maximum number of reactions shown in
-            the
-            <i>Reactions</i>
-            tables is limited to 1000 instead of 200.
+            subsystem instead of metabolites.
           </p>
           <p>
             Subsystems correspond to a set of reactions that share a similar metabolic function.

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -221,7 +221,7 @@ export default {
         const payload = {
           model: this.model,
           id: this.sourceName,
-          allCompartments: this.expandAllCompartment,
+          isForAllCompartments: this.expandAllCompartment,
         };
         await this.$store.dispatch(
           `reactions/getRelatedReactionsFor${this.type[0].toUpperCase()}${this.type.slice(1)}`,

--- a/frontend/src/store/modules/reactions.js
+++ b/frontend/src/store/modules/reactions.js
@@ -41,12 +41,13 @@ const actions = {
     commit('setRelatedReactions', reactions);
     // commit('setRelatedReactionsLimit', limit);
   },
-  async getRelatedReactionsForMetabolite({ commit, state }, { model, id }) {
+  async getRelatedReactionsForMetabolite({ commit, state }, { model, id, allCompartments }) {
     const payload = {
       id,
       model: model.apiName,
       version: model.apiVersion,
       limit: state.relatedReactionsLimit,
+      allCompartments,
     };
     const reactions = await reactionsApi.fetchRelatedReactionsForMetabolite(payload);
     commit('setRelatedReactions', reactions);

--- a/frontend/src/store/modules/reactions.js
+++ b/frontend/src/store/modules/reactions.js
@@ -41,13 +41,13 @@ const actions = {
     commit('setRelatedReactions', reactions);
     // commit('setRelatedReactionsLimit', limit);
   },
-  async getRelatedReactionsForMetabolite({ commit, state }, { model, id, allCompartments }) {
+  async getRelatedReactionsForMetabolite({ commit, state }, { model, id, isForAllCompartments }) {
     const payload = {
       id,
       model: model.apiName,
       version: model.apiVersion,
       limit: state.relatedReactionsLimit,
-      allCompartments,
+      isForAllCompartments,
     };
     const reactions = await reactionsApi.fetchRelatedReactionsForMetabolite(payload);
     commit('setRelatedReactions', reactions);

--- a/frontend/src/store/modules/reactions.js
+++ b/frontend/src/store/modules/reactions.js
@@ -4,7 +4,7 @@ const data = {
   reaction: {},
   referenceList: [],
   relatedReactions: [],
-  relatedReactionsLimit: 200,
+  relatedReactionsLimit: 1000,
 };
 
 const actions = {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #832 .

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- A new param called `allCompartments` is added to the related reactions for metabolite endpoint in The API.
- The frontend is adapted to send the new param, which results in different reactions.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

<img width="357" alt="image" src="https://user-images.githubusercontent.com/423498/152818443-8eaeacd4-094a-4fcd-a774-b716cd678986.png">

<img width="304" alt="image" src="https://user-images.githubusercontent.com/423498/152818523-65972c7c-2d3d-4036-b9be-3034b211ff4b.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test

1. Visit `/explore/Human-GEM/gem-browser/metabolite/MAM01450c`.
2. Verify that there are 25 related reactions (as shown in the first screenshot).
3. Click the "See reactions from all compartments" button.
4. Verify that the related reactions table reloads and shows 193 reactions afterwards (as shown in the second screenshot).
5. Click the "Restrict to current compartment" button.
6. Verify that the related reactions table reloads and shows 25 reactions again.


**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
