### PR TITLE
fix: run GH Actions workflows on all branches except main

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,11 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ develop ]
+    branches-ignore: 
+      - 'main'
   pull_request:
-    branches: [ develop ]
+    branches-ignore: 
+      - 'main'
 
 jobs:
   analyze:

--- a/.github/workflows/prettier.yml
+++ b/.github/workflows/prettier.yml
@@ -2,7 +2,8 @@ name: "Prettier"
 
 on:
   pull_request:
-    branches: [develop]
+    branches-ignore: 
+      - 'main'
 
 jobs:
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR changes workflows to run on all branches except `main`, so that bugs don't squeeze through PRs between branches which are not `develop`. Here is the relevant [documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-excluding-branches-and-tags).
