### PR TITLE
fix: fix disappearing letters in search field

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -27,7 +27,6 @@
           type="text"
           class="input"
           :placeholder="placeholder"
-          :value="searchTermString"
           @keyup.esc="handleClear()"
           @focus="showResults = true"
           @blur="blur()"
@@ -189,16 +188,16 @@ export default {
       }
     },
     async searchDebounce(searchTerm) {
+      this.$store.dispatch('search/setSearchTermString', searchTerm);
       this.noResult = false;
       this.showSearchCharAlert = searchTerm.length === 1;
-      this.$store.dispatch('search/setSearchTermString', searchTerm);
 
       const canSearch = searchTerm.length > 1;
 
       this.showLoader = canSearch;
       this.showResults = canSearch;
       if (canSearch) {
-        await this.search(searchTerm);
+        await this.search();
       }
     },
     async search() {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #771 .

<!-- Include below a description of the changes proposed in the pull request -->
The fix consists of removing the `:value="searchTermString"` of the input field, and instead relying on  `searchDebounce()` to set that variable.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Start typing, eg "ge", in the quick search field
- Wait until the search has started and then continue typing
- Note that all letters are still there when the search finishes

Also please verify that all other interactions with the input field works as expected. Eg, that moving to the global search works.

**Further comments**  
<!-- Specify questions or related information -->

**Checklist**  
<!-- Please delete options that are not relevant -->
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
