### PR TITLE
fix: clean search term and escape bad characters for neo4j

### DIFF
--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -328,9 +328,7 @@ const _search = async ({
   let term = sanitizeSearchString(searchTerm, true);
   // the EC field for reaction could contain ":", which is a special character
   // in this case th search term is modified to be escape and perform an exact match
-  term = term.includes('EC\\:')
-    ? `\\"${term}~\\"`
-    : `${term}~`;
+  term = term.includes('EC\\:') ? `\\"${term}~\\"` : `${term}~`;
 
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -326,9 +326,17 @@ const _search = async ({
 
   // the EC field for reaction could contain ":", which is a special character
   // in this case th search term is modified to be escape and perform an exact match
-  const term = searchTerm.includes('EC:')
+  let term = searchTerm.includes('EC:')
     ? `\\"${searchTerm}~\\"`
     : `${searchTerm}~`;
+
+  // clean the search term and excape special characters that may cause errors
+  // in neo4j querying
+  term = term
+    .replace(/\s\s+/g, ' ')
+    .replace(/^\s|\s$/g, '')
+    .replace(/([\"])/g, '')
+    .replace(/([:/^!\"\(\)\[\]])/g, '\\$1');
 
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -1,4 +1,5 @@
 import queryListResult from 'neo4j/queryHandlers/list';
+import { sanitizeSearchString } from 'utils/utils';
 const INTEGRATED_MODELS = require('data/integratedModels');
 
 const componentTypes = [
@@ -324,11 +325,12 @@ const _search = async ({
 }) => {
   const v = version ? `:V${version}` : '';
 
+  let term = sanitizeSearchString(searchTerm, true);
   // the EC field for reaction could contain ":", which is a special character
   // in this case th search term is modified to be escape and perform an exact match
-  let term = searchTerm.includes('EC\\:')
-    ? `\\"${searchTerm}~\\"`
-    : `${searchTerm}~`;
+  term = term.includes('EC\\:')
+    ? `\\"${term}~\\"`
+    : `${term}~`;
 
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -330,7 +330,6 @@ const _search = async ({
     ? `\\"${searchTerm}~\\"`
     : `${searchTerm}~`;
 
-  console.log(`term: ${term}`); //eslint-disable-line
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites
   let statement = `

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -325,15 +325,12 @@ const _search = async ({
 }) => {
   const v = version ? `:V${version}` : '';
 
-  let term = sanitizeSearchString(searchTerm, true);
-  // the EC field for reaction could contain ":", which is a special character
-  // in this case th search term is modified to be escape and perform an exact match
-  term = term.includes('EC\\:') ? `\\"${term}~\\"` : `${term}~`;
+  const term = sanitizeSearchString(searchTerm, true);
 
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites
   let statement = `
-CALL db.index.fulltext.queryNodes("fulltext", "${term}")
+CALL db.index.fulltext.queryNodes("fulltext", "${term} ${term}~")
 YIELD node, score
 WITH node, score, LABELS(node) as labelList
 OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -335,7 +335,7 @@ const _search = async ({
   term = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
-    .replace(/([\"])/g, '')
+    .replace(/([\"\\])/g, '')
     .replace(/([:/^!\"\(\)\[\]])/g, '\\$1');
 
   // Metabolites are not included as it would mess with the limit and

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -326,18 +326,11 @@ const _search = async ({
 
   // the EC field for reaction could contain ":", which is a special character
   // in this case th search term is modified to be escape and perform an exact match
-  let term = searchTerm.includes('EC:')
+  let term = searchTerm.includes('EC\\:')
     ? `\\"${searchTerm}~\\"`
     : `${searchTerm}~`;
 
-  // clean the search term and excape special characters that may cause errors
-  // in neo4j querying
-  term = term
-    .replace(/\s\s+/g, ' ')
-    .replace(/^\s|\s$/g, '')
-    .replace(/([\"\\])/g, '')
-    .replace(/([:/^!\"\(\)\[\]])/g, '\\$1');
-
+  console.log(`term: ${term}`); //eslint-disable-line
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites
   let statement = `

--- a/api/src/utils/utils.js
+++ b/api/src/utils/utils.js
@@ -2,7 +2,7 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
   let newTerm = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
-    .replace(/["]/g, '');
+    .replace(/["\\]/g, '');
   if (isAddBackSlash === true) {
     newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }

--- a/api/src/utils/utils.js
+++ b/api/src/utils/utils.js
@@ -1,0 +1,10 @@
+export function sanitizeSearchString(term, isAddBackSlash = true) {
+  let newTerm = term
+    .replace(/\s\s+/g, ' ')
+    .replace(/^\s|\s$/g, '')
+    .replace(/["]/g, '');
+  if (isAddBackSlash === true) {
+    newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
+  }
+  return newTerm;
+}

--- a/api/src/utils/utils.js
+++ b/api/src/utils/utils.js
@@ -4,7 +4,7 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
     .replace(/^\s|\s$/g, '')
     .replace(/["\\]/g, '');
   if (isAddBackSlash === true) {
-    newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
+    newTerm = newTerm.replace(/[~^!\-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
   return newTerm;
 }

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -18,4 +18,23 @@ describe('search', () => {
     const { metabolite } = data['Human-GEM'];
     expect(metabolite.length).toBe(50);
   });
+
+  test('model search with special characters should not fail', async () => {
+    const [data1, data2] = await Promise.all([
+      search({
+        searchTerm: 'rna/dna: (met)',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'cy\\|+ {zinc}! glyco/mg',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
+    for (const data of [data1, data2]) {
+      const { name } = data['Human-GEM'];
+      expect(name).toEqual('Human-GEM');
+    }
+  });
 });

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -43,7 +43,7 @@ describe('search', () => {
     expect(firstGene.name).toBe('POLR3F');
     expect(firstMetabolite.name).toMatch(/Asparaginyl-Cysteinyl/);
   });
-  
+
   test('model search with special characters should not fail', async () => {
     const [data1, data2] = await Promise.all([
       search({

--- a/frontend/src/api/search.js
+++ b/frontend/src/api/search.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { reformatChemicalReactionHTML } from '@/helpers/utils';
+import { reformatChemicalReactionHTML, sanitizeSearchString } from '@/helpers/utils';
 
 const search = async ({ searchTerm, model, version, limit }) => {
-  const params = { searchTerm, model, version, limit };
+  const params = { searchTerm: sanitizeSearchString(searchTerm), model, version, limit };
   const { data } = await axios.get('/search', { params });
 
   // the metabolites are returned ONLY if limit is provided

--- a/frontend/src/api/search.js
+++ b/frontend/src/api/search.js
@@ -1,8 +1,8 @@
 import axios from 'axios';
-import { reformatChemicalReactionHTML, sanitizeSearchString } from '@/helpers/utils';
+import { reformatChemicalReactionHTML } from '@/helpers/utils';
 
 const search = async ({ searchTerm, model, version, limit }) => {
-  const params = { searchTerm: sanitizeSearchString(searchTerm), model, version, limit };
+  const params = { searchTerm, model, version, limit };
   const { data } = await axios.get('/search', { params });
 
   // the metabolites are returned ONLY if limit is provided

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -202,6 +202,8 @@ export default {
     },
     async search() {
       document.getElementById('search').focus();
+      // sanitize the searchTerm without adding backslashes when doing minimal
+      // length checking, so that backslashes are not counted
       if (sanitizeSearchString(this.searchTermString, false).length < 2) {
         return;
       }

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -117,6 +117,7 @@
 import { mapGetters, mapState } from 'vuex';
 import $ from 'jquery';
 import { default as messages } from '@/content/messages';
+import { sanitizeSearchString } from '@/helpers/utils';
 
 export default {
   name: 'GemSearch',
@@ -203,7 +204,7 @@ export default {
     },
     async search() {
       $('#search').focus();
-      if (this.searchTermString.length < 2) {
+      if (sanitizeSearchString(this.searchTermString, false).length < 2) {
         return;
       }
 
@@ -241,7 +242,7 @@ export default {
       this.$router.push({ name: 'search', query: { term: this.searchTermString } });
     },
     formatSearchResultLabel(type, element, searchTerm) {
-      const re = new RegExp(`(${searchTerm})`, 'ig');
+      const re = new RegExp(`(${sanitizeSearchString(searchTerm)})`, 'ig');
       let s = '';
       this.itemKeys[type]
         .filter(key => element[key])

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -208,7 +208,7 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
   let newTerm = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
-    .replace(/["]/g, '');
+    .replace(/["\\]/g, '');
   if (isAddBackSlash === true) {
     newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -208,9 +208,9 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
   let newTerm = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
-    .replace(/([~^!"\\])/g, '');
+    .replace(/["\\]/g, '');
   if (isAddBackSlash === true) {
-    newTerm = newTerm.replace(/([:/()?$*[\]{}])/g, '\\$1');
+    newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
   return newTerm;
 }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -210,7 +210,7 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
     .replace(/^\s|\s$/g, '')
     .replace(/["\\]/g, '');
   if (isAddBackSlash === true) {
-    newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
+    newTerm = newTerm.replace(/[~^!\-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
   return newTerm;
 }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -208,9 +208,9 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
   let newTerm = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
-    .replace(/([~^*!"\\])/g, '');
+    .replace(/([~^!"\\])/g, '');
   if (isAddBackSlash === true) {
-    newTerm = newTerm.replace(/([:/()[\]{}])/g, '\\$1');
+    newTerm = newTerm.replace(/([:/()?$*[\]{}])/g, '\\$1');
   }
   return newTerm;
 }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -208,7 +208,7 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
   let newTerm = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
-    .replace(/["\\]/g, '');
+    .replace(/["]/g, '');
   if (isAddBackSlash === true) {
     newTerm = newTerm.replace(/[~^!-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -203,3 +203,14 @@ export const generateSocialMetaTags = ({ title, description }) => [
   { property: 'twitter:title', vmid: 'twitter:title', content: title },
   { property: 'twitter:description', vmid: 'twitter:description', content: description },
 ];
+
+export function sanitizeSearchString(term, isAddBackSlash = true) {
+  let newTerm = term
+    .replace(/\s\s+/g, ' ')
+    .replace(/^\s|\s$/g, '')
+    .replace(/([~^*!"\\])/g, '');
+  if (isAddBackSlash === true) {
+    newTerm = newTerm.replace(/([:/()[\]{}])/g, '\\$1');
+  }
+  return newTerm;
+}


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #764 and (probably) #884

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
The search term for the quick search is cleaned to avoid unexpected neo4j querying error.
1. Special characters are escaped by adding `\ `
2. The character `"` and `\` are removed since it may cause errors even after escaping- 
3. Multiple white spaces are replaced with a single space
4. the trailing white spaces are removed 

Besides, a test is added for searching of terms with special characters.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
Test in the quick search with searching terms e.g.  
1. `Node: rna`, 
2. `Tricarboxylic acid cycle and glyoxylate/dicarboxylate ` 
3. `°!#€€#€%&&///(/(())())=?``^ÅPOIUUYYTTRRE EWW_:;M:*ÄÖ*^ÄÖLKK;:;M_:;>ZXZXCVV°!"©@££$∞§ ∞§|[]]≈± ø–‘›‹ç≈÷≈çç‹›‘›‘ ‘’ ’ –ßß∂ƒƒ¸ ƒ¸˛˛√√ªﬁøæıüµ•Ωé®†µµüıı©@£$∞§§§||[ []] []≈±´`  😄  

**Further comments**  
<!-- Specify questions or related information -->

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
