### PR TITLE
fix: add delay for blur event

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -115,7 +115,6 @@
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import $ from 'jquery';
 import { default as messages } from '@/content/messages';
 
 export default {
@@ -202,7 +201,7 @@ export default {
       }
     },
     async search() {
-      $('#search').focus();
+      document.getElementById('search').focus();
       if (this.searchTermString.length < 2) {
         return;
       }
@@ -277,9 +276,9 @@ export default {
         } else if (
           document.getElementById('model-select').contains(document.activeElement) === false
         ) {
-          $('#search').focus();
+          document.getElementById('search').focus();
         }
-      });
+      }, 100);
     },
   },
 };


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #729.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Add small delay (100ms) to the blur event for the gem search. Please note that this does not delay the global search request.
- Removed usages of jQuery in this file with plain JavaScript. Not needed for this issue but I saw some related error output in Safari.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![safari_search](https://user-images.githubusercontent.com/423498/154300833-31397921-3ede-4b4a-9646-cd07ba7a48fc.gif)

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
1. Click the GemSearch and input `ENSG00000002587` with model as `Fruitfly-GEM`.
2. Click the "Search all integrated GEMs" button.
3. Verify that the global page loads and performs a search on `ENSG00000002587` and the gem search hides.

**Further comments**  
<!-- Specify questions or related information -->
Please let me know if you think the jQuery stuff should not be included here.

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
