### PR TITLE
feat: improve search scoring

### DIFF
--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -332,6 +332,8 @@ const _search = async ({
 
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites
+  // The search term is used twice, once with exact match and once with
+  // fuzzy match. This seems to produce optimal results.
   let statement = `
 CALL db.index.fulltext.queryNodes("fulltext", "${term} ${term}~")
 YIELD node, score

--- a/api/src/neo4j/queries/search.js
+++ b/api/src/neo4j/queries/search.js
@@ -327,13 +327,13 @@ const _search = async ({
   // the EC field for reaction could contain ":", which is a special character
   // in this case th search term is modified to be escape and perform an exact match
   const term = searchTerm.includes('EC:')
-    ? `\\"${searchTerm}~\\"`
-    : `${searchTerm}~`;
+    ? `\\"${searchTerm}\\"`
+    : `${searchTerm}`;
 
   // Metabolites are not included as it would mess with the limit and
   // relevant metabolites should be matched through CompartmentalizedMetabolites
   let statement = `
-CALL db.index.fulltext.queryNodes("fulltext", "${term}")
+CALL db.index.fulltext.queryNodes("fulltext", "${term} ${term}~")
 YIELD node, score
 WITH node, score, LABELS(node) as labelList
 OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -18,4 +18,29 @@ describe('search', () => {
     const { metabolite } = data['Human-GEM'];
     expect(metabolite.length).toBe(50);
   });
+
+  test('model search should receive sensible ranking scores', async () => {
+    const [data1, data2] = await Promise.all([
+      search({
+        searchTerm: 'POLR3F',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'Asparaginyl-Cysteinyl',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
+
+    const { gene } = data1['Human-GEM'];
+
+    const { metabolite } = data2['Human-GEM'];
+
+    const [firstGene] = gene.sort((a, b) => b.score - a.score);
+    const [firstMetabolite] = metabolite.sort((a, b) => b.score - a.score);
+
+    expect(firstGene.name).toBe('POLR3F');
+    expect(firstMetabolite.name).toMatch(/Asparaginyl-Cysteinyl/);
+  });
 });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #707 and #686.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Use a combination of exact match and fuzzy match when searching.

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test

Use the quick search and see if the results are sensible. Specifically the following search terms caused problems before. You can use the web inspector to check the scoring of the search results.

1. `POLR3F`: This should have an exact match on the gene name but it was ranked 2nd. It should be ranked 1st now.
2. `Asparaginyl-Cysteinyl`: Unsure exactly what the problem is but this does not return any matches when using fuzzy match. Using exact match does return sensible results and you should see some results returned with the top ranking results having partial matches with the metabolite name.

**Further comments**  
<!-- Specify questions or related information -->
There is a new test case added that verifies the above two keywords. You can verify this locally with `ma-exec api yarn test` and the test named `model search should receive sensible ranking scores` should pass.

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
