### PR TITLE
feat: separate model search and global search implementation and reduce model search response content

### DIFF
--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -1,0 +1,400 @@
+import queryListResult from 'neo4j/queryHandlers/list';
+import { sanitizeSearchString, intersect } from 'utils/utils';
+import { MODELS, COMPONENT_TYPES } from 'neo4j/queries/search/helper';
+
+const fetchCompartmentalizedMetabolites = async ({
+  ids,
+  model,
+  version,
+  limit,
+  viaMetabolties,
+}) => {
+  if (!ids) {
+    return null;
+  }
+
+  let statement = ``;
+
+  if (viaMetabolties) {
+    statement += `
+WITH ${JSON.stringify(ids)} as mids
+UNWIND mids as mid
+MATCH (:Metabolite:${model} {id:mid})-[${version}]-(cm:CompartmentalizedMetabolite)
+WITH DISTINCT(cm.id) as cmid
+`;
+  } else {
+    statement += `
+WITH ${JSON.stringify(ids)} as cmids
+UNWIND cmids as cmid
+`;
+  }
+
+  statement += `
+CALL apoc.cypher.run('
+  MATCH (ms:MetaboliteState)-[${version}]-(:Metabolite)-[${version}]-(:CompartmentalizedMetabolite:${model} {id: $cmid})
+  RETURN ms { id: $cmid, .* } as data
+  
+  UNION
+  
+  MATCH (:CompartmentalizedMetabolite:${model} {id: $cmid})-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
+  RETURN { id: $cmid, compartment: cs { id: c.id, .* } } as data
+  
+  UNION
+  
+  MATCH (:CompartmentalizedMetabolite:${model} {id: $cmid})-[${version}]-(:Reaction)-[${version}]-(s:Subsystem)
+  WITH DISTINCT s
+  MATCH (s)-[${version}]-(ss:SubsystemState)
+  RETURN { id: $cmid, subsystem: COLLECT({id: s.id, name: ss.name}) } as data
+', {cmid:cmid}) yield value
+RETURN apoc.map.mergeList(apoc.coll.flatten(
+	apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])
+)) as metabolites
+`;
+
+  if (limit) {
+    statement += `
+LIMIT ${limit}
+`;
+  }
+
+  return queryListResult(statement);
+};
+
+const fetchGenes = async ({ ids, model, version }) => {
+  if (!ids) {
+    return null;
+  }
+
+  const statement = `
+WITH ${JSON.stringify(ids)} as gids
+UNWIND gids as gid
+CALL apoc.cypher.run("
+  MATCH (gs:GeneState)-[${version}]-(:Gene:${model} {id: $gid})
+  RETURN { id: $gid, name: gs.name } as data
+  
+  UNION
+  
+  MATCH (:Gene:${model} {id: $gid})-[${version}]-(r:Reaction)
+  WITH DISTINCT r
+  MATCH (r)-[${version}]-(s:Subsystem)
+  WITH DISTINCT s
+  MATCH (s)-[${version}]-(ss:SubsystemState)
+  RETURN { id: $gid, subsystem: COLLECT({ id: s.id, name: ss.name }) } as data
+  
+  UNION
+  
+  MATCH (:Gene:${model} {id: $gid})-[${version}]-(:Reaction)-[${version}]-(cm:CompartmentalizedMetabolite)
+  WITH DISTINCT cm
+  MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
+  USING JOIN on c
+  RETURN { id: $gid, compartment: COLLECT(DISTINCT({ id: c.id, name: cs.name })) } as data
+", {gid:gid}) yield value
+RETURN apoc.map.mergeList(apoc.coll.flatten(
+	apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])
+)) as gene
+`;
+
+  return queryListResult(statement);
+};
+
+const fetchReactions = async ({ ids, model, version, includeMetabolites }) => {
+  if (!ids) {
+    return null;
+  }
+
+  let statement = `
+WITH ${JSON.stringify(ids)} as rids
+UNWIND rids as rid
+CALL apoc.cypher.run("
+  MATCH (rs:ReactionState)-[${version}]-(:Reaction:${model} {id: $rid})
+  RETURN rs { id: $rid, .* } as data
+`;
+
+  if (includeMetabolites) {
+    statement += `
+  UNION
+  
+  MATCH (r:Reaction:${model} {id: $rid})-[cmE${version}]-(cm:CompartmentalizedMetabolite)-[${version}]-(:Metabolite)-[${version}]-(ms:MetaboliteState)
+  MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
+  USING JOIN on c
+  RETURN { id: $rid, metabolites: COLLECT(DISTINCT(ms {id: cm.id, compartment: cs.name, fullName: COALESCE(ms.name, '') + ' [' + COALESCE(cs.letterCode, '') + ']', stoichiometry: cmE.stoichiometry, outgoing: startnode(cmE)=cm, .*})) } as data
+`;
+  }
+
+  statement += `
+  UNION
+  
+  MATCH (:Reaction:${model} {id: $rid})-[${version}]-(s:Subsystem)-[${version}]-(ss:SubsystemState)
+  USING JOIN on s
+  RETURN { id: $rid, subsystem: COLLECT(DISTINCT({ id: s.id, name: ss.name })) } as data
+  
+  UNION
+  
+  MATCH (:Reaction:${model} {id: $rid})-[${version}]-(cm:CompartmentalizedMetabolite)
+  WITH DISTINCT cm
+  MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
+  USING JOIN on c
+  RETURN { id: $rid, compartment: COLLECT(DISTINCT({ id: c.id, name: cs.name })) } as data
+", {rid:rid}) yield value
+RETURN apoc.map.mergeList(apoc.coll.flatten(
+	apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])
+)) as reaction
+`;
+
+  return queryListResult(statement);
+};
+
+const fetchSubsystems = async ({ ids, model, version, includeCounts }) => {
+  if (!ids) {
+    return null;
+  }
+
+  let statement = `
+WITH ${JSON.stringify(ids)} as sids
+UNWIND sids as sid
+CALL apoc.cypher.run("
+  MATCH (ss:SubsystemState)-[${version}]-(:Subsystem:${model} {id: $sid})
+  RETURN { id: $sid, name: ss.name } as data
+`;
+
+  if (includeCounts) {
+    statement += ` 
+  UNION
+  
+  MATCH (:Subsystem:${model} {id: $sid})-[${version}]-(r:Reaction)
+  RETURN { id: $sid, reactionCount: COUNT(DISTINCT(r)) } as data
+  
+  UNION
+  
+  MATCH (:Subsystem:${model} {id: $sid})-[${version}]-(r:Reaction)
+  WITH DISTINCT r
+  MATCH (r)-[${version}]-(cm:CompartmentalizedMetabolite)
+  RETURN { id: $sid, compartmentalizedMetaboliteCount: COUNT(DISTINCT cm) } as data
+  
+  UNION
+  
+  MATCH (:Subsystem:${model} {id: $sid})-[${version}]-(r:Reaction)
+  WITH DISTINCT r
+  MATCH (r)-[${version}]-(g:Gene)
+  RETURN { id: $sid, geneCount: COUNT(DISTINCT g) } as data
+`;
+  }
+
+  statement += ` 
+  UNION
+  
+  MATCH (:Subsystem:${model} {id: $sid})-[${version}]-(:Reaction)-[${version}]-(cm:CompartmentalizedMetabolite)
+  WITH DISTINCT cm
+  MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
+  USING JOIN on c
+  RETURN { id: $sid, compartment: COLLECT(DISTINCT({ id: c.id, name: cs.name })) } as data
+", {sid:sid}) yield value
+RETURN apoc.map.mergeList(apoc.coll.flatten(
+	apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])
+)) as subsystem
+`;
+
+  return queryListResult(statement);
+};
+
+const fetchCompartments = async ({ ids, model, version, includeCounts }) => {
+  if (!ids) {
+    return null;
+  }
+
+  let statement = `
+WITH ${JSON.stringify(ids)} as cids
+UNWIND cids as cid
+CALL apoc.cypher.run("
+  MATCH (cs:CompartmentState)-[${version}]-(:Compartment:${model} {id: $cid})
+  RETURN cs { id: $cid, .* } as data
+`;
+
+  if (includeCounts) {
+    statement += ` 
+  UNION
+  
+  MATCH (:Compartment:${model} {id: $cid})-[${version}]-(:CompartmentalizedMetabolite)-[${version}]-(r:Reaction)
+  RETURN { id: $cid, reactionCount: COUNT(DISTINCT(r)) } as data
+  
+  UNION
+  
+  MATCH (:Compartment:${model} {id: $cid})-[${version}]-(cm:CompartmentalizedMetabolite)
+  RETURN { id: $cid, compartmentalizedMetaboliteCount: COUNT(DISTINCT cm) } as data
+  
+  UNION
+  
+  MATCH (:Compartment:${model} {id: $cid})-[${version}]-(:CompartmentalizedMetabolite)-[${version}]-(r:Reaction)
+  WITH DISTINCT r
+  MATCH (r)-[${version}]-(g:Gene)
+  RETURN { id: $cid, geneCount: COUNT(DISTINCT g) } as data
+  
+  UNION
+  
+  MATCH (:Compartment:${model} {id: $cid})-[${version}]-(:CompartmentalizedMetabolite)-[${version}]-(r:Reaction)
+  WITH DISTINCT r
+  MATCH (r)-[${version}]-(s:Subsystem)
+  RETURN { id: $cid, subsystemCount: COUNT(DISTINCT s) } as data
+`;
+  }
+
+  statement += ` 
+", {cid:cid}) yield value
+RETURN apoc.map.mergeList(apoc.coll.flatten(
+	apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])
+)) as compartment
+`;
+
+  return queryListResult(statement);
+};
+
+const globalSearch = async ({ searchTerm, version, limit }) => {
+  const results = await Promise.all(
+    MODELS.map(m =>
+      search({
+        searchTerm,
+        version,
+        model: m.label,
+        limit,
+        includeCounts: true,
+      })
+    )
+  );
+
+  return MODELS.reduce((obj, m, i) => {
+    obj[m.name] = {
+      ...results[i],
+      name: m.name,
+    };
+    return obj;
+  }, {});
+};
+
+/*
+ * The search consists of two steps
+ * 1. Do a fuzzy search over all nodes covered by full-text search index
+ * 2. Fetch results for each component type (parallelly) and return result
+ */
+const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
+  const v = version ? `:V${version}` : '';
+
+  const term = sanitizeSearchString(searchTerm, true);
+
+  // Metabolites are not included as it would mess with the limit and
+  // relevant metabolites should be matched through CompartmentalizedMetabolites
+  // The search term is used twice, once with exact match and once with
+  // fuzzy match. This seems to produce optimal results.
+  let statement = `
+CALL db.index.fulltext.queryNodes("fulltext", "${term} ${term}~")
+YIELD node, score
+WITH node, score, LABELS(node) as labelList
+OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
+WHERE node:${model} OR parentNode:${model}
+WITH DISTINCT(
+	CASE
+		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) THEN { id: node.id, labels: labelList, score: score }
+		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
+	END
+) as r 
+WHERE any(r IN r.labels WHERE r="${model}")
+RETURN r
+`;
+  if (limit) {
+    statement += `
+LIMIT ${limit}
+`;
+  }
+
+  const results = await queryListResult(statement);
+
+  const idsToScore = {};
+  const uniqueIds = results.reduce((o, r) => {
+    const c = intersect(COMPONENT_TYPES, r.labels);
+    if (!o[c]) {
+      o[c] = new Set();
+    }
+    o[c].add(r.id);
+    idsToScore[r.id] = r.score;
+    return o;
+  }, {});
+
+  const ids = Object.assign(
+    {},
+    ...Object.keys(uniqueIds).map(c => ({ [c]: Array.from(uniqueIds[c]) }))
+  );
+  const [
+    compartmentalizedMetabolites,
+    metabolites,
+    genes,
+    reactions,
+    subsystems,
+    compartments,
+  ] = await Promise.all([
+    fetchCompartmentalizedMetabolites({
+      ids: ids['CompartmentalizedMetabolite'],
+      model,
+      version: v,
+      limit,
+    }),
+    fetchCompartmentalizedMetabolites({
+      ids: ids['Metabolite'],
+      model,
+      version: v,
+      limit,
+      viaMetabolties: true,
+    }),
+    fetchGenes({ ids: ids['Gene'], model, version: v }),
+    fetchReactions({
+      ids: ids['Reaction'],
+      model,
+      version: v,
+      includeMetabolites: !!limit,
+    }),
+    fetchSubsystems({
+      ids: ids['Subsystem'],
+      model,
+      version: v,
+      includeCounts: true,
+    }),
+    fetchCompartments({
+      ids: ids['Compartment'],
+      model,
+      version: v,
+      includeCounts: true,
+    }),
+  ]);
+
+  const resObj = {
+    compartmentalizedMetabolites,
+    metabolites,
+    genes,
+    reactions,
+    subsystems,
+    compartments,
+  };
+
+  const resWithScore = {};
+  for (const [component, result] of Object.entries(resObj)) {
+    if (result) {
+      resWithScore[component] = result.map(obj => ({
+        ...obj,
+        score: idsToScore[obj.id],
+      }));
+    } else {
+      resWithScore[component] = [];
+    }
+  }
+
+  return {
+    metabolite: [
+      ...resWithScore.compartmentalizedMetabolites,
+      ...resWithScore.metabolites,
+    ],
+    gene: resWithScore.genes,
+    reaction: resWithScore.reactions,
+    subsystem: resWithScore.subsystems,
+    compartment: resWithScore.compartments,
+  };
+};
+
+export { globalSearch };

--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -280,8 +280,6 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
 
   const term = sanitizeSearchString(searchTerm, true);
 
-  // Metabolites are not included as it would mess with the limit and
-  // relevant metabolites should be matched through CompartmentalizedMetabolites
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.
   let statement = `

--- a/api/src/neo4j/queries/search/helper.js
+++ b/api/src/neo4j/queries/search/helper.js
@@ -1,0 +1,17 @@
+const INTEGRATED_MODELS = require('data/integratedModels');
+
+const MODELS = INTEGRATED_MODELS.map(m => ({
+  label: m.short_name.replace('-GEM', 'Gem'),
+  name: m.short_name,
+}));
+
+const COMPONENT_TYPES = [
+  'CompartmentalizedMetabolite',
+  'Metabolite',
+  'Gene',
+  'Reaction',
+  'Subsystem',
+  'Compartment',
+];
+
+export { MODELS, COMPONENT_TYPES };

--- a/api/src/neo4j/queries/search/index.js
+++ b/api/src/neo4j/queries/search/index.js
@@ -1,0 +1,7 @@
+import { modelSearch } from 'neo4j/queries/search/modelSearch';
+import { globalSearch } from 'neo4j/queries/search/globalSearch';
+
+const search = async params =>
+  params.model ? modelSearch(params) : globalSearch(params);
+
+export { search };

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -166,8 +166,6 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
 
   const term = sanitizeSearchString(searchTerm, true);
 
-  // Metabolites are not included as it would mess with the limit and
-  // relevant metabolites should be matched through CompartmentalizedMetabolites
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.
   let statement = `

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -77,7 +77,7 @@ CALL apoc.cypher.run("
   MATCH (r:Reaction:${model} {id: $rid})-[cmE${version}]-(cm:CompartmentalizedMetabolite)-[${version}]-(:Metabolite)-[${version}]-(ms:MetaboliteState)
   MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
   USING JOIN on c
-  RETURN { id: $rid, metabolites: COLLECT(DISTINCT({id: cm.id, name: ms.name, fullName: COALESCE(ms.name, '') + ' [' + COALESCE(cs.letterCode, '') + ']', stoichiometry: cmE.stoichiometry, outgoing: startnode(cmE)=cm})) } as data
+  RETURN { id: $rid, metabolites: COLLECT(DISTINCT({name: ms.name, fullName: COALESCE(ms.name, '') + ' [' + COALESCE(cs.letterCode, '') + ']', stoichiometry: cmE.stoichiometry, outgoing: startnode(cmE)=cm})) } as data
 
   UNION
   

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -77,7 +77,7 @@ CALL apoc.cypher.run("
   MATCH (r:Reaction:${model} {id: $rid})-[cmE${version}]-(cm:CompartmentalizedMetabolite)-[${version}]-(:Metabolite)-[${version}]-(ms:MetaboliteState)
   MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
   USING JOIN on c
-  RETURN { id: $rid, metabolites: COLLECT(DISTINCT(ms {id: cm.id, compartment: cs.name, fullName: COALESCE(ms.name, '') + ' [' + COALESCE(cs.letterCode, '') + ']', stoichiometry: cmE.stoichiometry, outgoing: startnode(cmE)=cm, .*})) } as data
+  RETURN { id: $rid, metabolites: COLLECT(DISTINCT({id: cm.id, name: ms.name, fullName: COALESCE(ms.name, '') + ' [' + COALESCE(cs.letterCode, '') + ']', stoichiometry: cmE.stoichiometry, outgoing: startnode(cmE)=cm})) } as data
 
   UNION
   

--- a/api/src/utils/utils.js
+++ b/api/src/utils/utils.js
@@ -1,4 +1,4 @@
-export function sanitizeSearchString(term, isAddBackSlash = true) {
+const sanitizeSearchString = (term, isAddBackSlash = true) => {
   let newTerm = term
     .replace(/\s\s+/g, ' ')
     .replace(/^\s|\s$/g, '')
@@ -7,4 +7,7 @@ export function sanitizeSearchString(term, isAddBackSlash = true) {
     newTerm = newTerm.replace(/[~^!\-:/\\^$*+?.()|[\]{}]/g, '\\$&');
   }
   return newTerm;
-}
+};
+const intersect = (a, b) => [...new Set(a)].filter(x => new Set(b).has(x));
+
+export { sanitizeSearchString, intersect };

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -6,7 +6,7 @@ describe('search', () => {
     await driver.close();
   });
 
-  test('model search to have 50 results per component type if it exceeds the limit 50', async () => {
+  test('model search should have max 50 results per component type', async () => {
     const data = await search({
       searchTerm: 'H2O',
       model: 'HumanGem',
@@ -16,7 +16,8 @@ describe('search', () => {
     expect(Object.keys(data)).toContain('Human-GEM');
 
     const { metabolite } = data['Human-GEM'];
-    expect(metabolite.length).toBe(50);
+    expect(metabolite.length).toBeGreaterThan(0);
+    expect(metabolite.length).toBeLessThan(50);
   });
 
   test('model search should receive sensible ranking scores', async () => {

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -62,4 +62,16 @@ describe('search', () => {
       expect(name).toEqual('Human-GEM');
     }
   });
+
+  test('global search should return 50 results for multiple models', async () => {
+    const data = await search({
+      searchTerm: 'POLR3F',
+    });
+
+    expect(data['Human-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Mouse-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Rat-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Fruitfly-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Zebrafish-GEM'].gene.length).toBeGreaterThan(0);
+  });
 });

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -64,7 +64,7 @@ describe('search', () => {
     }
   });
 
-  test('global search should return 50 results for multiple models', async () => {
+  test('global search should return results for multiple models', async () => {
     const data = await search({
       searchTerm: 'POLR3F',
     });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #705.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Separate model search and global search code.
- Reduce response content for model search.
- Fix bug where too many metabolites may be returned, as mentioned [here](https://github.com/MetabolicAtlas/private-issues/issues/101#issuecomment-1047937655).

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test

1. Click the search icon in the nav bar and select `Human-GEM`.
2. Search for `h2o` and make sure results for `Metabolite`, `Gene`, and `Reaction` look correct.
3. Search for `peroxisom` and make sure results for `Subsystem`, and `Compartment` look correct.

**Further comments**  
<!-- Specify questions or related information -->
- If it helps, you can use the dev or prod server to compare the search results.
- The search results for metabolites may be slightly different as before due to [the bug fix](https://github.com/MetabolicAtlas/MetabolicAtlas/commit/3b3b01e5388e2fce301f841f824e350a2ddc32f9).

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [ ] I have checked so that the same data as before is returned by the API (leaving this unchecked this time as the data is different but more correct now)
