### PR TITLE
feat: update copyright year

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -142,7 +142,7 @@
       <div class="columns is-gapless">
         <div v-show="!showCompactFooter()" class="column has-text-centered mt-1">
           <p>
-            2021 ©
+            {{ currentYear }} ©
             <span class="is-hidden-touch">
               &nbsp;Department of Biology and Biological Engineering |
             </span>
@@ -150,7 +150,7 @@
           </p>
         </div>
         <div v-show="showCompactFooter()" class="column has-text-centered-mobile">
-          <p>2021 © &nbsp;Chalmers University of Technology</p>
+          <p>{{ currentYear }} © &nbsp;Chalmers University of Technology</p>
         </div>
       </div>
     </footer>
@@ -237,6 +237,7 @@ export default {
       showGemSearch: false,
       messages,
       errorMessage: '',
+      currentYear: new Date().getFullYear(),
     };
   },
   computed: {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #857.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] New feature (non-breaking change which adds functionality)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Updates the copyright year to the current one (as returned by javascript).

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![copyyear](https://user-images.githubusercontent.com/1029190/157219896-70fb13b0-00f4-4845-9e25-9a4e0119676d.png)

**Testing**  
<!-- Please delete options that are not relevant -->
Check the footer, the standard and the compact one.
Also please verify that there aren't unintended mentions of 2021 in the README.

**Further comments**  
<!-- Specify questions or related information -->
During last refinement, we discussed different solutions for this, eg having `2018-current` instead of a specified year.
The solution I went for in this PR sets the year to the current one, and does not have to be updated. We also don't have to figure out which starting year the copyright would have. 

**Checklist**  
<!-- Please delete options that are not relevant -->
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
