### PR TITLE
fix: set default title tag

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -13,7 +13,6 @@
   <meta name="application-name" content="Metabolic Atlas" />
   <meta name="msapplication-TileColor" content="#FFFFFF" />
   <meta name="msapplication-TileImage" content="mstile-144x144.png" />
-  <title>Metabolic Atlas</title>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <%= process.env.VUE_APP_HOTJAR %>

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -244,6 +244,11 @@ export default {
       model: state => state.models.model,
     }),
   },
+  metaInfo() {
+    return {
+      title: 'Metabolic Atlas',
+    };
+  },
   watch: {
     showGemSearch(show) {
       if (show) {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #775 .

<!-- Include below a description of the changes proposed in the pull request -->
The title tag will default to `Metabolic Atlas`.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

**List of changes made**  
<!-- Specify what changes have been made and why -->
Add a default title value to `App.vue`


**Testing**  
Navigate to the GEM Browser.
Click on any reaction, metabolite, gene or subsytem.
Note that the title tag updates.
Navigate to any other part of the web page (eg `About`)
Note that the title is `Metabolic Atlas` again.

**Further comments**  
<!-- Specify questions or related information -->

**Checklist**  
<!-- Please delete options that are not relevant -->
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
