### PR TITLE
fix: increase timeout to fix error for time-consuming global searches

### DIFF
--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -40,7 +40,7 @@ services:
 
   neo4j:
     environment:
-      - NEO4J_dbms_transaction_timeout=15s
+      - NEO4J_dbms_transaction_timeout=40s
       - NEO4J_dbms_memory_heap_initial__size=5G
       - NEO4J_dbms_memory_off__heap_max__size=8G
     restart: unless-stopped


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #765

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Limit for neo4j transaction timeout increased to make sure that time consuming global searches does not lead to 400 Bad Request.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
This has been tested, i.e. deployed,  on the dev machine. Following links cause error with a lower limit but work with 40 sek:
`https://dev-metatlas.csbi.chalmers.se/search?term=citric%20acid`
`https://dev-metatlas.csbi.chalmers.se/search?term=C5-branched%20dibasic%20acid%20metabolism`
But please experiment more with global search and see if everything is working correctly

**Further comments**  
<!-- Specify questions or related information -->
A limit of the previously suggested 30 sek continued to cause 400 Bad Request for the example links above, but 40 sek seems to do the trick.

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x My changes generate no new warnings
- [x] I have checked so that the same data as before is returned by the API
