### PR TITLE
fix: remove padding to avoid code element overflow

### DIFF
--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -70,5 +70,7 @@ export default {
 <style lang="scss" scoped>
 code {
   font-size: 1em;
+  padding-top: 0px;
+  padding-bottom: 0px;
 }
 </style>


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #760.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Removed top and bottom padding to avoid overflow of code elements

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![image](https://user-images.githubusercontent.com/32480198/157476801-fd27d7c1-7e5a-4685-ae41-ccbc1a1a14c5.png)


**Testing**  
<!-- Please delete options that are not relevant -->
Visit for example `/explore/Fruitfly-GEM/map-viewer/phenylalanine_tyrosine_and_tryptophan_biosynthesisxxx?dim=2d` or `/explore/Fruitfly-GEM/map-viewer/phenylalanine_tyrosine_and_tryptophan_biosynthesisxkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkkxx?dim=2d`

**Further comments**  
<!-- Specify questions or related information -->
- I chose not to use bulma `py` since it would need to be added for two `<code>` elements + they already had a style section so to me it made sense. Feel free to have feedback on this though
- Should I add a comment in the code regarding why the padding is 0 or is that superfluous?

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code