### PR TITLE
fix: broken link to the API in the resource page 

### DIFF
--- a/frontend/src/components/about/Resources.vue
+++ b/frontend/src/components/about/Resources.vue
@@ -195,9 +195,9 @@ export default {
         APIs: [
           {
             name: 'Metabolic Atlas API',
-            link: 'api/',
+            link: '/api/v2/',
             img: '/img/logo.png',
-            title: 'Access Metabolic Atlas programatically',
+            title: 'Access Metabolic Atlas programmatically',
             description:
               'The API is a set of URL requests that will respond to the query parameters with JSON formatted text. Our implementation gives the possibility of trying out different queries to see what the results would look like.',
           },
@@ -205,7 +205,7 @@ export default {
             name: 'Protein Atlas Programmatic data access',
             link: 'https://www.proteinatlas.org/about/help/dataaccess',
             img: require('../../assets/logos/hpa.png'),
-            title: 'Access Protein Atlas programatically',
+            title: 'Access Protein Atlas programmatically',
             description:
               'Download a subset of the data provided in XML, RDF or TSV format, either as individual queries or search queries. ',
           },

--- a/frontend/src/components/about/Resources.vue
+++ b/frontend/src/components/about/Resources.vue
@@ -195,7 +195,7 @@ export default {
         APIs: [
           {
             name: 'Metabolic Atlas API',
-            link: '/api/v2/',
+            link: '/api',
             img: '/img/logo.png',
             title: 'Access Metabolic Atlas programmatically',
             description:


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #893 

<!-- Include below a description of the changes proposed in the pull request -->
Fix the link to the API in the `about/resources` page and fixed typos

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 

**Testing**  
<!-- Please delete options that are not relevant -->
Click `Access Metabolic Atlas programmatically` in the page http://localhost/about/resources and it should direct you to the API page.

**Further comments**  
<!-- Specify questions or related information -->
The comment https://github.com/MetabolicAtlas/MetabolicAtlas/issues/893#issuecomment-1057747239 @mihai-sysbio mentioned is not related to this issue. I think it might be caused by the configuration in the `prod.nginx.conf`. As I tested, the behaviors are the same for the `prod` and `dev`

https://metabolicatlas.org/api/   not-working 
https://metabolicatlas.org/api    working 
https://dev-metatlas.csbi.chalmers.se/api/    not-working
https://dev-metatlas.csbi.chalmers.se/api     working
http://localhost/api   working
http://localhost/api/  working


**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
