### PR TITLE
fix: add full=true to compartment swagger api

### DIFF
--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -58,7 +58,7 @@ paths:
           description: 'Successful query'
         '404':
           description: 'Invalid input'
-  /compartments/{id}?model={model}:
+  /compartments/{id}?model={model}&full=true:
     get:
       tags:
         - 'Compartments'


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR is a patch to the issue #759 

<!-- Include below a description of the changes proposed in the pull request -->
Add the param `full=true` to the compartment API endpoint in swagger so that it retrieves all metabolites, genes, reactions and subsystems contained by the given compartment as claimed in the description.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**Testing**  
<!-- Please delete options that are not relevant -->
http://localhost/api/v2/#/Compartments

**Further comments**  
<!-- Specify questions or related information -->

**Checklist**  
<!-- Please delete options that are not relevant -->
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
