### PR TITLE
feat: UI and UX improvements for Table of Contents

### DIFF
--- a/frontend/src/components/shared/TableOfContents.vue
+++ b/frontend/src/components/shared/TableOfContents.vue
@@ -6,7 +6,8 @@
         <li v-for="l in links" :key="l.name">
           <router-link
             :to="l.routeName ? { name: l.routeName } : l.link"
-            active-class="has-background-white-ter"
+            :class="{ 'has-background-white-ter': hasActiveSubsection(l) }"
+            active-class="has-background-link-light"
             @click.native="isMobileMenu = false"
           >
             <span v-if="l.icon" class="icon pr-5 has-text-info">
@@ -18,7 +19,7 @@
             <li v-for="sub in l.subsections" :key="sub.name">
               <router-link
                 :to="sub.routeName ? { name: sub.routeName } : sub.link"
-                active-class="has-background-white-ter"
+                active-class="has-background-link-light"
                 @click.native="isMobileMenu = false"
               >
                 {{ sub.name }}
@@ -37,6 +38,11 @@ export default {
     links: {
       type: Array,
       default: () => [],
+    },
+  },
+  methods: {
+    hasActiveSubsection({ subsections }) {
+      return (subsections ?? []).map(s => s.link).includes(this.$route.hash);
     },
   },
 };

--- a/frontend/src/components/shared/TableOfContents.vue
+++ b/frontend/src/components/shared/TableOfContents.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="column is-narrow">
+  <div id="table-of-contents" class="column is-narrow">
     <aside class="menu">
       <p class="menu-label">Table of Contents</p>
       <ul class="menu-list">
@@ -43,6 +43,16 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@media screen and (min-width: $tablet) {
+  #table-of-contents {
+    position: sticky;
+    top: 0;
+    align-self: flex-start;
+    max-height: 100vh;
+    overflow: auto;
+  }
+}
+
 .menu-list {
   ul {
     margin-top: 0;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #864.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Changes for the ToC are made according to the issue description, including:
- Sticks to the top after scrolling the page down.
- Has max visible height of screen height and gets its own scroll section if it's longer than the screen height.
- Does not become sticky for mobile (smaller than `$tablet`) devices.
- Adds nested visualization for active link. The active color before `white-ter` is now used for the active parent link. The actual active link color is now `link-light`, which seems to work well with the look and feel of the rest of the ToC, for example the icon color.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="1684" alt="image" src="https://user-images.githubusercontent.com/423498/158615305-56bd5453-4ef4-4009-b586-b70bcc7c070a.png">
<img width="1684" alt="image" src="https://user-images.githubusercontent.com/423498/158615429-350b886d-6df5-41d7-a121-d9c4a4a97f40.png">
<img width="1684" alt="image" src="https://user-images.githubusercontent.com/423498/158615574-2a88bba1-dc1e-4607-93bb-cacf2c5e9e7d.png">
<img width="381" alt="image" src="https://user-images.githubusercontent.com/423498/158615795-3873f0d0-a070-4c37-a83a-2ad306e423a9.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test

Try clicking the ToC links as well as scrolling the `/documentation` and `/about/*` pages.

**Further comments**  
<!-- Specify questions or related information -->
- Please let me know if you have any suggestions on the design choices made in this PR.
- I have tested using different screen sizes on Chrome, Firefox, and Safari on macOS.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
