### PR TITLE
fix: use parent node of pubmedreference

### DIFF
--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -279,6 +279,7 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
   const v = version ? `:V${version}` : '';
 
   const term = sanitizeSearchString(searchTerm, true);
+  const childLabels = "['ExternalDb', 'PubmedReference']"
 
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.
@@ -290,7 +291,7 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) AND NOT 'PubmedReference' in LABELS(node)
+                WHEN EXISTS(node.id) AND NOT apoc.coll.intersection(${childLabels}, LABELS(node))
                 THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END

--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -1,6 +1,10 @@
 import queryListResult from 'neo4j/queryHandlers/list';
 import { sanitizeSearchString, intersect } from 'utils/utils';
-import { MODELS, COMPONENT_TYPES } from 'neo4j/queries/search/helper';
+import {
+  MODELS,
+  COMPONENT_TYPES,
+  CHILD_LABELS,
+} from 'neo4j/queries/search/helper';
 
 const fetchCompartmentalizedMetabolites = async ({
   ids,
@@ -279,7 +283,6 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
   const v = version ? `:V${version}` : '';
 
   const term = sanitizeSearchString(searchTerm, true);
-  const childLabels = "['ExternalDb', 'PubmedReference']";
 
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.
@@ -291,7 +294,9 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-                WHEN EXISTS(node.id) AND NOT apoc.coll.intersection(${childLabels}, LABELS(node))
+                WHEN EXISTS(node.id) AND NOT apoc.coll.intersection(${JSON.stringify(
+                  CHILD_LABELS
+                )}, LABELS(node))
                 THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END

--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -290,7 +290,8 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) THEN { id: node.id, labels: labelList, score: score }
+		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) AND NOT 'PubmedReference' in LABELS(node)
+                THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END
 ) as r 

--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -279,7 +279,7 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
   const v = version ? `:V${version}` : '';
 
   const term = sanitizeSearchString(searchTerm, true);
-  const childLabels = "['ExternalDb', 'PubmedReference']"
+  const childLabels = "['ExternalDb', 'PubmedReference']";
 
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.

--- a/api/src/neo4j/queries/search/helper.js
+++ b/api/src/neo4j/queries/search/helper.js
@@ -14,4 +14,6 @@ const COMPONENT_TYPES = [
   'Compartment',
 ];
 
-export { MODELS, COMPONENT_TYPES };
+const CHILD_LABELS = ['ExternalDb', 'PubmedReference'];
+
+export { MODELS, COMPONENT_TYPES, CHILD_LABELS };

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -1,6 +1,10 @@
 import queryListResult from 'neo4j/queryHandlers/list';
 import { sanitizeSearchString, intersect } from 'utils/utils';
-import { MODELS, COMPONENT_TYPES } from 'neo4j/queries/search/helper';
+import {
+  MODELS,
+  COMPONENT_TYPES,
+  CHILD_LABELS,
+} from 'neo4j/queries/search/helper';
 
 const fetchCompartmentalizedMetabolites = async ({
   ids,
@@ -165,7 +169,6 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
   const v = version ? `:V${version}` : '';
 
   const term = sanitizeSearchString(searchTerm, true);
-  const childLabels = "['ExternalDb', 'PubmedReference']";
 
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.
@@ -177,7 +180,9 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-                WHEN EXISTS(node.id) AND NOT apoc.coll.intersection(${childLabels}, LABELS(node))
+                WHEN EXISTS(node.id) AND NOT apoc.coll.intersection(${JSON.stringify(
+                  CHILD_LABELS
+                )}, LABELS(node))
                 THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -165,6 +165,7 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
   const v = version ? `:V${version}` : '';
 
   const term = sanitizeSearchString(searchTerm, true);
+  const childLabels = "['ExternalDb', 'PubmedReference']"
 
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.
@@ -176,7 +177,7 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) AND NOT 'PubmedReference' in LABELS(node)
+                WHEN EXISTS(node.id) AND NOT apoc.coll.intersection(${childLabels}, LABELS(node))
                 THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -165,7 +165,7 @@ const search = async ({ searchTerm, model, version, limit, includeCounts }) => {
   const v = version ? `:V${version}` : '';
 
   const term = sanitizeSearchString(searchTerm, true);
-  const childLabels = "['ExternalDb', 'PubmedReference']"
+  const childLabels = "['ExternalDb', 'PubmedReference']";
 
   // The search term is used twice, once with exact match and once with
   // fuzzy match. This seems to produce optimal results.

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -176,7 +176,8 @@ OPTIONAL MATCH (node)-[${v}]-(parentNode:${model})
 WHERE node:${model} OR parentNode:${model}
 WITH DISTINCT(
 	CASE
-		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) THEN { id: node.id, labels: labelList, score: score }
+		WHEN EXISTS(node.id) AND NOT EXISTS(node.externalId) AND NOT 'PubmedReference' in LABELS(node)
+                THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END
 ) as r 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #889.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Adapt case statement in neo4j query to use the parent node when encountering a PubmedReference node.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![pmid](https://user-images.githubusercontent.com/1029190/160421078-0672c40d-0f30-414a-9c70-151b5a999a65.png)

**Testing**  
<!-- Please delete options that are not relevant -->
Try searching for PMIDs, eg `11579996`, `16111821`, `18406340`, `11368003`. The result should contain Reactions, where the PMIDs can be seen in th References table at the bottom of the page.

Also please verify that the results for other types of queries haven't changed.


**Definition of Done checklist**  
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
