### PR TITLE
fix: make sure 404 is triggered when compartment or subsystem is not found

### DIFF
--- a/api/src/neo4j/queries/compartment.js
+++ b/api/src/neo4j/queries/compartment.js
@@ -39,7 +39,12 @@ CALL apoc.cypher.run("
   UNION
   
   MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(csvg:SvgMap)
-  WITH {compartmentId: '${id}', compartmentSVGs: COLLECT(DISTINCT(csvg {.*}))} as compartmentSVG
+  WITH  COLLECT(DISTINCT(csvg {.*})) as csvgs
+  WITH CASE
+    WHEN size(csvgs) > 0
+    THEN {compartmentId: '${id}', compartmentSVGs: csvgs}
+    ELSE null
+  END as compartmentSVG
   RETURN { compartmentSVGs: COLLECT(compartmentSVG) } as data
 ", {}) yield value
 RETURN apoc.map.mergeList(COLLECT(value.data)) as compartment

--- a/api/src/neo4j/queries/subsystem.js
+++ b/api/src/neo4j/queries/subsystem.js
@@ -41,7 +41,12 @@ CALL apoc.cypher.run("
   UNION
   
   MATCH (:Subsystem${m} {id: '${id}'})-[${v}]-(ssvg:SvgMap)
-  WITH {subsystemId: '${id}', subsystemSVGs: COLLECT(DISTINCT(ssvg {.*}))} as subsystemSVG
+  WITH COLLECT(DISTINCT(ssvg {.*})) as ssvgs
+  WITH CASE
+    WHEN size(ssvgs)> 0
+    THEN {subsystemId: '${id}', subsystemSVGs: ssvgs}
+    ELSE null
+  END as subsystemSVG
   RETURN { subsystemSVGs: COLLECT(subsystemSVG) } as data
 ", {}) yield value
 RETURN apoc.map.mergeList(COLLECT(value.data)) as subsystem


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #800.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->

We have [these lines](https://github.com/MetabolicAtlas/MetabolicAtlas/blob/2d061fd4ff58e093a8748829ecdaccc8452ddae2/api/src/neo4j/queryHandlers/single.js#L20-L25) that trigger a `404` for whenever an object is empty. The problem before was that object at this point is not empty according to our definition because it has the following shape. Specifically due to the `"compartmentId": "typo"` part.

```json
{
  "metabolitesCount": 0,
  "reactionsCount": 0,
  "genesCount": 0,
  "compartmentSVGs": [
    {
      "compartmentId": "typo",
      "compartmentSVGs": []
    }
  ],
  "subsystems": [],
  "externalDbs": []
}
```

This PR fixes the cypher queries so that the object would have the following shape instead, which fits our definition of an empty object.

```json
{
  "metabolitesCount": 0,
  "reactionsCount": 0,
  "genesCount": 0,
  "compartmentSVGs": [],
  "subsystems": [],
  "externalDbs": []
}
```



**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="1312" alt="image" src="https://user-images.githubusercontent.com/423498/160865142-c2f823a4-c49a-47ad-b6ce-331788f62a54.png">
<img width="1290" alt="image" src="https://user-images.githubusercontent.com/423498/160865312-ddc433f9-f25f-47c3-8677-e5dfd5719532.png">


**Testing**  
<!-- Please delete options that are not relevant -->
1. Make sure the appropriate error message triggers when an incorrect id is provided for example: 
  - `/explore/Human-GEM/gem-browser/compartment/typo`
  - `/explore/Human-GEM/gem-browser/subsystem/typo`
2. Make sure the page loads as normal when a correct id is provided for example: 
  - `/explore/Human-GEM/gem-browser/compartment/cytosol`
  - `/explore/Human-GEM/gem-browser/subsystem/acylglycerides_metabolism`

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
