### PR TITLE
fix: redirect api/ to api/v2

### DIFF
--- a/nginx/prod.nginx.conf
+++ b/nginx/prod.nginx.conf
@@ -65,7 +65,7 @@ server {
     try_files $uri @proxy;
   }
 
-  location /api/ {
+  location /api/v2 {
     limit_req zone=api_limit burst=20 nodelay;
     try_files $uri @proxy_cached;
   }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #911.

<!-- Include below a description of the changes proposed in the pull request -->
Both `/api/` and `/api` now redirects to `/api/v2/`.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
   Set these configs under `api/v2` instead of `api/`
```
 limit_req zone=api_limit burst=20 nodelay;
 try_files $uri @proxy_cached;
```
 so that the code block doesn't block redirection from `api` (in the block below).


**Testing**  
<!-- Please delete options that are not relevant -->
This branch is deployed to the dev server.
Test `/api/` and `/api`.

**Further comments**  
<!-- Specify questions or related information -->
I'm far from an nginx expert, so please verify that this does not break any intended behaviour.

**Definition of Done checklist**  
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] My changes generate no new warnings
