### PR TITLE
chore: eslint ignore images

### DIFF
--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,39 +1,78 @@
 #!/bin/bash
 
-# run_lint: runs prettier and eslint on all staged files inside docker
-# files will be reformatted by prettier and the script will fail if there are
-# any warnings from eslint
-#  $1: container name
-#  $2: file names as in container
-#  $3: local file names
-run_lint () {
 
-  if [[ ! -z "$2" ]]
-  then
-    # Prettify all selected files
-    echo "$2" | xargs docker compose -f docker-compose.yml -f docker-compose-local.yml exec $1 ./node_modules/.bin/prettier --ignore-unknown --write
 
-    # Exit if there are lint problems
-    if ! docker compose -f docker-compose.yml -f docker-compose-local.yml exec $1 yarn run eslint $2 --ext .js,.vue; then
-      exit 1
-    fi
+# docker_exec:	Helper function
+docker_exec () {
+	local container="$1"
+	shift	# We don't need $1 any longer.
 
-    # Add back the modified/prettified files to staging
-    echo "$3" | xargs git add
-
-  fi
-
+	docker compose \
+		-f docker-compose.yml \
+		-f docker-compose-local.yml \
+                --env-file env-local.env \
+		exec "$container" \
+		"$@"
 }
 
-# List all backend files
-A_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- api/src/ api/test/ | sed 's| |\\ |g')
-API_FILES=${A_FILES//api\/}
-F_FILES=$(git diff --cached --name-only --diff-filter=ACMR -- frontend/src/ | sed 's| |\\ |g')
-FRONTEND_FILES=${F_FILES//frontend\/}
+# run_lint:     Runs prettier and eslint on all staged files inside
+#               Docker. The files will be reformatted by prettier and the
+#               script will fail if there are any errors from eslint.
 
-echo "Running prettier and eslint on staged files"
-run_lint api $API_FILES $A_FILES
-run_lint frontend $FRONTEND_FILES $F_FILES
-echo "Files ok"
+# Arguments:
+#	$1:	Container name
+# 	$2 ...:	List of pathnames
+#
+# The pathnames will have their first pathname component stripped off to
+# generate the corresponding pathnames in the container.
 
-exit 0
+run_lint () {
+	local container="$1"
+	shift	# We don't need $1 any longer.
+
+	# "$@" is now the list of relative pathnames.
+
+        # "${@#*/}" is the list of pathnames with the first
+        # pathname component stripped off ("api/file" --> "file",
+        # "frontend/some/path" --> "some/path")
+
+	# Prettify all selected files in the container.
+	docker_exec "$container" ./node_modules/.bin/prettier \
+		--ignore-unknown \
+		--write \
+		"${@#*/}"
+
+        # Lint selected files in the container, and bail out if there
+        # are errors. Warnings are reported, but won't stop the commit
+	if ! docker_exec "$container" yarn run eslint "${@#*/}"
+	then
+		return 1
+	fi
+
+	# Add prettified files.
+	git add "$@"
+}
+
+for dir in api/src api/test frontend/src; do
+
+	# List changed staged files and add them to an array.
+	readarray -d '' -t list < <(
+		git diff -z --staged --name-only --diff-filter=ACMR -- "$dir"
+	)
+
+	# Skip directory if no changed files.
+	[ "${#list[@]}" -eq 0 ] && continue
+
+	# Lint files.
+        # The container name is taken from the first pathname component
+        # of the first entry in the list.
+	if ! run_lint "${list[0]%%/*}" "${list[@]}"; then
+		printf 'Aborted. Some files in "%s" failed linting\n.' "$dir" >&2
+		exit 1
+	fi
+
+	printf 'All files in "%s" ok\n' "$dir"
+
+done
+
+echo 'Done.'

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,19 +1,9 @@
 #!/bin/bash
 
+# import ma-exec, but don't print available commannds from proj.sh
+source proj.sh > /dev/null
+
 shopt -s globstar nullglob
-
-# docker_exec:	Helper function
-docker_exec () {
-	local container="$1"
-	shift	# We don't need $1 any longer.
-
-	docker compose \
-		-f docker-compose.yml \
-		-f docker-compose-local.yml \
-                --env-file env-local.env \
-		exec "$container" \
-		"$@"
-}
 
 # run_lint:     Runs prettier and eslint on all staged files inside
 #               Docker. The files will be reformatted by prettier and the
@@ -37,14 +27,14 @@ run_lint () {
         # "frontend/some/path" --> "some/path")
 
 	# Prettify all selected files in the container.
-	docker_exec "$container" ./node_modules/.bin/prettier \
+        ma-exec "$container" ./node_modules/.bin/prettier \
 		--ignore-unknown \
 		--write \
 		"${@#*/}"
 
         # Lint selected files in the container, and bail out if there
         # are errors. Warnings are reported, but won't stop the commit
-	if ! docker_exec "$container" yarn run eslint "${@#*/}"
+	if ! ma-exec "$container" yarn run eslint "${@#*/}"
 	then
 		return 1
 	fi

--- a/git_hooks/pre-commit
+++ b/git_hooks/pre-commit
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-
+shopt -s globstar nullglob
 
 # docker_exec:	Helper function
 docker_exec () {
@@ -55,9 +55,16 @@ run_lint () {
 
 for dir in api/src api/test frontend/src; do
 
+  	# Match all relevant file types under the given directory.
+	files=( "$dir"/**/*.{vue,js,html,css,ts,yaml} )
+
+	# Skip if no files.
+	[ "${#files[@]}" -eq 0 ] && continue
+
 	# List changed staged files and add them to an array.
 	readarray -d '' -t list < <(
-		git diff -z --staged --name-only --diff-filter=ACMR -- "$dir"
+		git diff -z --staged --name-only --diff-filter=ACMR -- \
+                  "${files[@]}"
 	)
 
 	# Skip directory if no changed files.


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #871.

Only files with any of the extensions `.{vue,js,html,css,ts,yaml}` will be formatted and linted.
<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Filter files in precommit hook by extension
- Refactor  `pre-commit`


**Testing**  
<!-- Please delete options that are not relevant -->
Try to add and commit a `png` file, or any other file which should not be linted. When committing, make sure eslint skips the file.
Also verify that eslint and prettier is still run as expected when committing. 

**Further comments**  
<!-- Specify questions or related information -->
[The documentation](https://eslint.org/docs/user-guide/configuring/ignoring-code#ignored-file-warnings) claims that files listed as ignored will be skipped, even if they are explicitly passed to eslint. For whatever reason, I can't get this to work. Instead the staged files are filtered by extension before given to the linters.

As a (free) bonus, we got a refactoring of the bash file. Feel free to have opinions about this too. Credit goes to @kusalananda for this.

**Definition of Done checklist**  
- [X] My code meets the Acceptance Criteria
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
