### PR TITLE
fix: search for metabolite names give score zero

### DIFF
--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -13,6 +13,7 @@ module.exports = {
     HUMAN_GEM_VERSION: 'writable',
     FRUITFLY_GEM_VERSION: 'writable',
     MOUSE_GEM_VERSION: 'writable',
+    WORM_GEM_VERSION: 'writable',
     RAT_GEM_VERSION: 'writable',
     YEAST_GEM_VERSION: 'writable',
     ZEBRAFISH_GEM_VERSION: 'writable',

--- a/api/.eslintrc.js
+++ b/api/.eslintrc.js
@@ -17,7 +17,7 @@ module.exports = {
     RAT_GEM_VERSION: 'writable',
     YEAST_GEM_VERSION: 'writable',
     ZEBRAFISH_GEM_VERSION: 'writable',
-    COMPARTMENTS: 'writable',
+    COMPONENTS: 'writable',
   },
   parserOptions: {
     ecmaVersion: 2018,

--- a/api/src/neo4j/queries/search/helper.js
+++ b/api/src/neo4j/queries/search/helper.js
@@ -16,4 +16,14 @@ const COMPONENT_TYPES = [
 
 const CHILD_LABELS = ['ExternalDb', 'PubmedReference'];
 
-export { MODELS, COMPONENT_TYPES, CHILD_LABELS };
+const getScore = (node, uniqueIds) => {
+  if (node.id in uniqueIds) {
+    return uniqueIds[node.id]['score'];
+  }
+  if (node.mid) {
+    return uniqueIds[node.mid]['score'];
+  }
+  return 0;
+};
+
+export { MODELS, COMPONENT_TYPES, CHILD_LABELS, getScore };

--- a/api/src/neo4j/queries/search/helper.js
+++ b/api/src/neo4j/queries/search/helper.js
@@ -21,5 +21,4 @@ const getScore = (node, uniqueIds) => {
   return id in uniqueIds ? uniqueIds[id]['score'] : 0;
 };
 
-
 export { MODELS, COMPONENT_TYPES, CHILD_LABELS, getScore };

--- a/api/src/neo4j/queries/search/helper.js
+++ b/api/src/neo4j/queries/search/helper.js
@@ -17,13 +17,9 @@ const COMPONENT_TYPES = [
 const CHILD_LABELS = ['ExternalDb', 'PubmedReference'];
 
 const getScore = (node, uniqueIds) => {
-  if (node.id in uniqueIds) {
-    return uniqueIds[node.id]['score'];
-  }
-  if (node.mid) {
-    return uniqueIds[node.mid]['score'];
-  }
-  return 0;
+  const id = node.mid || node.id;
+  return id in uniqueIds ? uniqueIds[id]['score'] : 0;
 };
+
 
 export { MODELS, COMPONENT_TYPES, CHILD_LABELS, getScore };

--- a/api/test/jest.setup.js
+++ b/api/test/jest.setup.js
@@ -1,12 +1,13 @@
 global.beforeAll(() => {
   global.API_BASE = 'http://localhost:8081/api/v2';
-  global.FRUITFLY_GEM_VERSION = '1_1_0';
-  global.HUMAN_GEM_VERSION = '1_10_0';
-  global.MOUSE_GEM_VERSION = '1_2_0';
-  global.RAT_GEM_VERSION = '1_2_0';
-  global.WORM_GEM_VERSION = '1_1_0';
-  global.YEAST_GEM_VERSION = '8_4_2';
-  global.ZEBRAFISH_GEM_VERSION = '1_1_0';
+  let model = readModelInfo();
+  global.FRUITFLY_GEM_VERSION = model['Fruitfly-GEM'];
+  global.HUMAN_GEM_VERSION = model['Human-GEM'];
+  global.MOUSE_GEM_VERSION = model['Mouse-GEM'];
+  global.RAT_GEM_VERSION = model['Rat-GEM'];
+  global.WORM_GEM_VERSION = model['Worm-GEM'];
+  global.YEAST_GEM_VERSION = model['Yeast-GEM'];
+  global.ZEBRAFISH_GEM_VERSION = model['Zebrafish-GEM'];
   global.COMPONENTS = [
     'metabolite',
     'gene',
@@ -15,3 +16,12 @@ global.beforeAll(() => {
     'compartment',
   ];
 });
+
+function readModelInfo() {
+  let json = require('../src/data/integratedModels.json');
+  let result = {};
+  for (const obj of json) {
+    result[obj.short_name] = obj.version.replace(/\./g, '_');
+  }
+  return result;
+}

--- a/api/test/jest.setup.js
+++ b/api/test/jest.setup.js
@@ -4,6 +4,7 @@ global.beforeAll(() => {
   global.HUMAN_GEM_VERSION = '1_10_0';
   global.MOUSE_GEM_VERSION = '1_2_0';
   global.RAT_GEM_VERSION = '1_2_0';
+  global.WORM_GEM_VERSION = '1_1_0';
   global.YEAST_GEM_VERSION = '8_4_2';
   global.ZEBRAFISH_GEM_VERSION = '1_1_0';
   global.COMPARTMENTS = [

--- a/api/test/jest.setup.js
+++ b/api/test/jest.setup.js
@@ -1,6 +1,10 @@
 global.beforeAll(() => {
   global.API_BASE = 'http://localhost:8081/api/v2';
+  global.FRUITFLY_GEM_VERSION = '1_1_0';
   global.HUMAN_GEM_VERSION = '1_10_0';
   global.MOUSE_GEM_VERSION = '1_2_0';
+  global.RAT_GEM_VERSION = '1_2_0';
+  global.FRUITFLY_GEM_VERSION = '1_1_0';
   global.YEAST_GEM_VERSION = '8_4_2';
+  global.ZEBRAFISH_GEM_VERSION = '1_1_0';
 });

--- a/api/test/jest.setup.js
+++ b/api/test/jest.setup.js
@@ -7,7 +7,7 @@ global.beforeAll(() => {
   global.WORM_GEM_VERSION = '1_1_0';
   global.YEAST_GEM_VERSION = '8_4_2';
   global.ZEBRAFISH_GEM_VERSION = '1_1_0';
-  global.COMPARTMENTS = [
+  global.COMPONENTS = [
     'metabolite',
     'gene',
     'reaction',

--- a/api/test/jest.setup.js
+++ b/api/test/jest.setup.js
@@ -18,8 +18,8 @@ global.beforeAll(() => {
 });
 
 function readModelInfo() {
-  let json = require('../src/data/integratedModels.json');
-  let result = {};
+  const json = require('../src/data/integratedModels.json');
+  const result = {};
   for (const obj of json) {
     result[obj.short_name] = obj.version.replace(/\./g, '_');
   }

--- a/api/test/jest.setup.js
+++ b/api/test/jest.setup.js
@@ -1,4 +1,6 @@
 global.beforeAll(() => {
   global.API_BASE = 'http://localhost:8081/api/v2';
   global.HUMAN_GEM_VERSION = '1_10_0';
+  global.MOUSE_GEM_VERSION = '1_2_0';
+  global.YEAST_GEM_VERSION = '8_4_2';
 });

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -17,7 +17,7 @@ describe('search', () => {
 
     const { metabolite } = data['Human-GEM'];
     expect(metabolite.length).toBeGreaterThan(0);
-    expect(metabolite.length).toBeLessThan(50);
+    expect(metabolite.length).toBeLessThan(51);
   });
 
   test('model search should receive sensible ranking scores', async () => {

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -75,4 +75,11 @@ describe('search', () => {
     expect(data['Fruitfly-GEM'].gene.length).toBeGreaterThan(0);
     expect(data['Zebrafish-GEM'].gene.length).toBeGreaterThan(0);
   });
+
+  test('search for metabolite name gives valid score for metabolites', async () => {
+    const data = await search({
+      searchTerm: 'pyridoxine',
+    });
+    expect(data['Human-GEM'].metabolite[0].score).toBeGreaterThan(0);
+  });
 });

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -79,7 +79,44 @@ describe('search', () => {
   test('search for metabolite name gives valid score for metabolites', async () => {
     const data = await search({
       searchTerm: 'pyridoxine',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
     });
-    expect(data['Human-GEM'].metabolite[0].score).toBeGreaterThan(0);
+    const [firstMetabolite] = data['Human-GEM'].metabolite.sort(
+      (a, b) => b.score - a.score
+    );
+    expect(firstMetabolite.score).toBeGreaterThan(0);
+  });
+
+  test('search for metabolite id gives matches', async () => {
+    const data = await search({
+      searchTerm: 'MAM01513s',
+    });
+    expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data['Mouse-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data['Rat-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data['Zebrafish-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data['Worm-GEM'].metabolite.length).toBeGreaterThan(0);
+  });
+
+  test('search by gene name or id both finds the gene', async () => {
+    const data = await search({
+      searchTerm: 'NEURL1B',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+    const data2 = await search({
+      searchTerm: 'ENSG00000214357',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+    const [firstGene] = data['Human-GEM'].gene.sort(
+      (a, b) => b.score - a.score
+    );
+    const [firstGene2] = data['Human-GEM'].gene.sort(
+      (a, b) => b.score - a.score
+    );
+    expect(firstGene.name).toEqual('NEURL1B');
+    expect(firstGene2.name).toEqual('NEURL1B');
   });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -42,7 +42,9 @@ describe('search', () => {
     const [firstMetabolite] = metabolite.sort((a, b) => b.score - a.score);
 
     expect(firstGene.name).toBe('POLR3F');
+    expect(firstGene.score).toBeGreaterThan(0);
     expect(firstMetabolite.name).toMatch(/Asparaginyl-Cysteinyl/);
+    expect(firstMetabolite.score).toBeGreaterThan(0);
   });
 
   test('gem search with special characters should not fail', async () => {

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -292,20 +292,20 @@ describe('gem search', () => {
       model: 'HumanGem',
       version: 'abcd',
     });
-    for (const compartment of COMPARTMENTS) {
-      expect(data['Human-GEM'][compartment].length).toEqual(0);
+    for (const component of COMPONENTS) {
+      expect(data['Human-GEM'][component].length).toEqual(0);
     }
   });
 
   test('search for subsystem id should give highest score to subsystems', async () => {
-    // test all compartments?
+    // test all components?
     const data = await search({
       searchTerm: 'Retinol metabolism',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
     });
 
-    const scores = COMPARTMENTS.map(c =>
+    const scores = COMPONENTS.map(c =>
       data['Human-GEM'][c][0] ? data['Human-GEM'][c][0].score : 0
     );
     const subsystemScore = data['Human-GEM']['subsystem'][0].score;
@@ -338,11 +338,11 @@ describe('gem search', () => {
         limit: 10,
       }),
     ]);
-    for (const compartment of COMPARTMENTS) {
-      expect(lim1['Human-GEM'][compartment].length).toBeLessThan(2);
+    for (const component of COMPONENTS) {
+      expect(lim1['Human-GEM'][component].length).toBeLessThan(2);
     }
-    for (const compartment of COMPARTMENTS) {
-      expect(lim10['Human-GEM'][compartment].length).toBeLessThan(11);
+    for (const component of COMPONENTS) {
+      expect(lim10['Human-GEM'][component].length).toBeLessThan(11);
     }
   });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -137,4 +137,36 @@ describe('search', () => {
     expect(firstGene2.name).toEqual('NEURL1B');
     expect(firstGene3.name).toEqual('NEURL1B');
   });
+
+  test('gem search by cross reference finds the gene', async () => {
+    const data = await search({
+      searchTerm: 'ENST00000415826',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+
+    const data2 = await search({
+      searchTerm: '11145',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+
+    const data3 = await search({
+      searchTerm: 'P53816',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+    const [firstGene] = data['Human-GEM'].gene.sort(
+      (a, b) => b.score - a.score
+    );
+    const [firstGene2] = data2['Human-GEM'].gene.sort(
+      (a, b) => b.score - a.score
+    );
+    const [firstGene3] = data3['Human-GEM'].gene.sort(
+      (a, b) => b.score - a.score
+    );
+    expect(firstGene.name).toEqual('PLAAT3');
+    expect(firstGene2.name).toEqual('PLAAT3');
+    expect(firstGene3.name).toEqual('PLAAT3');
+  });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -288,7 +288,7 @@ describe('gem search', () => {
 
   test('search for invalid version does not give results', async () => {
     const data = await search({
-      searchTerm: 'h20',
+      searchTerm: 'H2O',
       model: 'HumanGem',
       version: 'abcd',
     });
@@ -298,6 +298,7 @@ describe('gem search', () => {
   });
 
   test('search for subsystem id should give highest score to subsystems', async () => {
+    // test all compartments?
     const data = await search({
       searchTerm: 'Retinol metabolism',
       model: 'HumanGem',
@@ -312,8 +313,9 @@ describe('gem search', () => {
   });
 
   test('search in mouse gem should not give match in a other model', async () => {
+    // rewrite to: all models == MouseGem??
     const data = await search({
-      searchTerm: 'h20',
+      searchTerm: 'H2O',
       model: 'MouseGem',
       version: MOUSE_GEM_VERSION,
     });
@@ -323,14 +325,15 @@ describe('gem search', () => {
   });
 
   test('search results can be limited', async () => {
+    // TODO: behaves weirdly, test 2 vs 3 vs 5
     const [lim1, lim10] = await Promise.all([
       search({
-        searchTerm: 'h20',
+        searchTerm: 'H2O',
         model: 'HumanGem',
         limit: 1,
       }),
       search({
-        searchTerm: 'h20',
+        searchTerm: 'H2O',
         model: 'HumanGem',
         limit: 10,
       }),

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -95,10 +95,12 @@ describe('search', () => {
       search({
         searchTerm: 'MAM01513s',
         model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
       }),
       search({
         searchTerm: 'MAM00715c',
         model: 'FruitflyGem',
+        version: FRUITFLY_GEM_VERSION,
       }),
     ]);
     expect(data1['Human-GEM'].metabolite.length).toBeGreaterThan(0);
@@ -110,10 +112,12 @@ describe('search', () => {
     search({
       searchTerm: 'C21H44NO7P',
       model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
     }),
     search({
       searchTerm: 'C31H53NO4',
       model: 'ZebrafishGem',
+      version: ZEBRAFISH_GEM_VERSION,
     }),
     ]);
     expect(data1['Human-GEM'].metabolite.length).toBeGreaterThan(0);
@@ -267,6 +271,7 @@ describe('search', () => {
     const data = await search({
       searchTerm: 'Beta oxidation of even-chain fatty acids (peroxisomal)',
       model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
     });
     const [firstSubsystem] = data['Human-GEM'].subsystem;
     expect(firstSubsystem.name).toEqual(
@@ -279,6 +284,7 @@ describe('search', () => {
     const data = await search({
       searchTerm: 'Extracellular',
       model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
     });
     const [firstCompartment] = data['Human-GEM'].compartment;
     expect(firstCompartment.name).toEqual('Extracellular');

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -260,9 +260,7 @@ describe('gem search', () => {
     expect(firstSubsystem1.name).toEqual(
       'Beta oxidation of even-chain fatty acids (peroxisomal)'
     );
-    expect(firstSubsystem2.name).toEqual(
-      'Alkaloids biosynthesis'
-    );
+    expect(firstSubsystem2.name).toEqual('Alkaloids biosynthesis');
     expect(firstSubsystem1.score).toBeGreaterThan(0);
     expect(firstSubsystem2.score).toBeGreaterThan(0);
   });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -313,8 +313,18 @@ describe('gem search', () => {
     expect(subsystemScore).toEqual(Math.max(...scores));
   });
 
+  test('search in mouse gem should not give match in a other model', async () => {
+    const data = await search({
+      searchTerm: 'h20',
+      model: 'MouseGem',
+      version: MOUSE_GEM_VERSION,
+    });
+    for (const model of Object.keys(data)) {
+      expect(model).not.toEqual('Human-GEM');
+    }
+  });
+
   test('search results can be limited', async () => {
-    // TODO: behaves weirdly, test 2 vs 3 vs 5
     const [lim1, lim10] = await Promise.all([
       search({
         searchTerm: 'h20',

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -202,4 +202,61 @@ describe('search', () => {
     expect(firstReaction2.id).toEqual('MAR03893');
     expect(firstReaction3.id).toEqual('MAR00973');
   });
+
+  test('gem search by cross reference finds the reaction', async () => {
+    const [data1, data2, data3, data4, data5] = await Promise.all([
+      search({
+        searchTerm: 'RE3476C',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'HMR_0973',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'MNXR103919',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'RCR12105',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'RE3476C',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
+
+    const [firstReaction1] = data1['Human-GEM'].reaction;
+    expect(firstReaction1.id).toEqual('MAR00973');
+
+    const [firstReaction2] = data2['Human-GEM'].reaction;
+    expect(firstReaction2.id).toEqual('MAR00973');
+
+    // Multiple reactions share MetaNetX id
+    const [firstReaction3] = data3['Human-GEM'].reaction;
+    expect(firstReaction3.id).toEqual('MAR03896');
+
+    const [firstReaction4] = data4['Human-GEM'].reaction;
+    expect(firstReaction4.id).toEqual('MAR00973');
+
+    const [firstReaction5] = data5['Human-GEM'].reaction;
+    expect(firstReaction5.id).toEqual('MAR00973');
+  });
+  test('gem search on name should find subsystem', async () => {
+    const data = await search({
+      searchTerm: 'Beta oxidation of even-chain fatty acids (peroxisomal)',
+      model: 'HumanGem',
+    });
+    const [firstSubsystem] = data['Human-GEM'].subsystem;
+    expect(firstSubsystem.name).toEqual(
+      'Beta oxidation of even-chain fatty acids (peroxisomal)'
+    );
+    expect(firstSubsystem.score).toBeGreaterThan(0);
+  });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -118,23 +118,23 @@ describe('search', () => {
   });
 
   test('gem search by gene name, alternate name or id finds the gene', async () => {
-    const data1 = await search({
-      searchTerm: 'NEURL1B',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-
-    const data2 = await search({
-      searchTerm: 'neuralized E3 ubiquitin protein ligase 1B',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-
-    const data3 = await search({
-      searchTerm: 'ENSG00000214357',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
+    const [data1, data2, data3] = await Promise.all([
+      search({
+        searchTerm: 'NEURL1B',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'neuralized E3 ubiquitin protein ligase 1B',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'ENSG00000214357',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
     const [firstGene1] = data1['Human-GEM'].gene;
     const [firstGene2] = data2['Human-GEM'].gene;
     const [firstGene3] = data3['Human-GEM'].gene;
@@ -145,23 +145,24 @@ describe('search', () => {
   });
 
   test('gem search by cross reference finds the gene', async () => {
-    const data1 = await search({
-      searchTerm: 'ENST00000415826',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
+    const [data1, data2, data3] = await Promise.all([
+      search({
+        searchTerm: 'ENST00000415826',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: '11145',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'P53816',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
 
-    const data2 = await search({
-      searchTerm: '11145',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-
-    const data3 = await search({
-      searchTerm: 'P53816',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
     const [firstGene1] = data1['Human-GEM'].gene;
     const [firstGene2] = data2['Human-GEM'].gene;
     const [firstGene3] = data3['Human-GEM'].gene;
@@ -172,23 +173,23 @@ describe('search', () => {
   });
 
   test('gem search by id, EC code and PMID finds the reaction', async () => {
-    const data1 = await search({
-      searchTerm: 'MAR03893',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-
-    const data2 = await search({
-      searchTerm: '1.13.11.34',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-
-    const data3 = await search({
-      searchTerm: '7929234',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
+    const [data1, data2, data3] = await Promise.all([
+      search({
+        searchTerm: 'MAR03893',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: '1.13.11.34',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: '7929234',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
     const [firstReaction1] = data1['Human-GEM'].reaction;
     const [firstReaction2] = data2['Human-GEM'].reaction;
     const [firstReaction3] = data3['Human-GEM'].reaction;
@@ -228,19 +229,16 @@ describe('search', () => {
     ]);
 
     const [firstReaction1] = data1['Human-GEM'].reaction;
-    expect(firstReaction1.id).toEqual('MAR00973');
-
     const [firstReaction2] = data2['Human-GEM'].reaction;
-    expect(firstReaction2.id).toEqual('MAR00973');
-
     // Multiple reactions share MetaNetX id
     const [firstReaction3] = data3['Human-GEM'].reaction;
-    expect(firstReaction3.id).toEqual('MAR03896');
-
     const [firstReaction4] = data4['Human-GEM'].reaction;
-    expect(firstReaction4.id).toEqual('MAR00973');
-
     const [firstReaction5] = data5['Human-GEM'].reaction;
+
+    expect(firstReaction1.id).toEqual('MAR00973');
+    expect(firstReaction2.id).toEqual('MAR00973');
+    expect(firstReaction3.id).toEqual('MAR03896');
+    expect(firstReaction4.id).toEqual('MAR00973');
     expect(firstReaction5.id).toEqual('MAR00973');
   });
 

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -17,7 +17,7 @@ describe('gem search', () => {
 
     const { metabolite } = data['Human-GEM'];
     expect(metabolite.length).toBeGreaterThan(0);
-    expect(metabolite.length).toBeLessThan(51);
+    expect(metabolite.length).toBeLessThanOrEqual(50);
   });
 
   test('gem search should receive sensible ranking scores', async () => {
@@ -339,10 +339,10 @@ describe('gem search', () => {
       }),
     ]);
     for (const component of COMPONENTS) {
-      expect(lim1['Human-GEM'][component].length).toBeLessThan(2);
+      expect(lim1['Human-GEM'][component].length).toBeLessThanOrEqual(1);
     }
     for (const component of COMPONENTS) {
-      expect(lim10['Human-GEM'][component].length).toBeLessThan(11);
+      expect(lim10['Human-GEM'][component].length).toBeLessThanOrEqual(10);
     }
   });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -182,23 +182,22 @@ describe('gem search', () => {
         version: HUMAN_GEM_VERSION,
       }),
       search({
-        searchTerm: '1.13.11.34',
-        model: 'HumanGem',
-        version: HUMAN_GEM_VERSION,
+        searchTerm: '2.4.2.9',
+        model: 'WormGem',
+        version: WORM_GEM_VERSION,
       }),
       search({
-        searchTerm: '7929234',
-        model: 'HumanGem',
-        version: HUMAN_GEM_VERSION,
+        searchTerm: '17267599',
+        model: 'MouseGem',
+        version: MOUSE_GEM_VERSION,
       }),
     ]);
     const [firstReaction1] = data1['Human-GEM'].reaction;
-    const [firstReaction2] = data2['Human-GEM'].reaction;
-    const [firstReaction3] = data3['Human-GEM'].reaction;
+    const [firstReaction2] = data2['Worm-GEM'].reaction;
+    const [firstReaction3] = data3['Mouse-GEM'].reaction;
     expect(firstReaction1.id).toEqual('MAR03893');
-    // Multiple reactions share EC code and PMID
-    expect(firstReaction2.id).toEqual('MAR03893');
-    expect(firstReaction3.id).toEqual('MAR00973');
+    expect(firstReaction2.id).toEqual('MAR04343');
+    expect(firstReaction3.id).toMatch(/MAR03986|MAR09166|MAR03987/);
   });
 
   test('gem search by cross reference finds the reaction', async () => {

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -243,26 +243,48 @@ describe('gem search', () => {
   });
 
   test('gem search on name should find subsystem', async () => {
-    const data = await search({
-      searchTerm: 'Beta oxidation of even-chain fatty acids (peroxisomal)',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-    const [firstSubsystem] = data['Human-GEM'].subsystem;
-    expect(firstSubsystem.name).toEqual(
+    const [data1, data2] = await Promise.all([
+      search({
+        searchTerm: 'Beta oxidation of even-chain fatty acids (peroxisomal)',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'Alkaloids biosynthesis',
+        model: 'RatGem',
+        version: RAT_GEM_VERSION,
+      }),
+    ]);
+    const [firstSubsystem1] = data1['Human-GEM'].subsystem;
+    const [firstSubsystem2] = data2['Rat-GEM'].subsystem;
+    expect(firstSubsystem1.name).toEqual(
       'Beta oxidation of even-chain fatty acids (peroxisomal)'
     );
-    expect(firstSubsystem.score).toBeGreaterThan(0);
+    expect(firstSubsystem2.name).toEqual(
+      'Alkaloids biosynthesis'
+    );
+    expect(firstSubsystem1.score).toBeGreaterThan(0);
+    expect(firstSubsystem2.score).toBeGreaterThan(0);
   });
 
   test('gem search on name should find compartment', async () => {
-    const data = await search({
-      searchTerm: 'Extracellular',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-    const [firstCompartment] = data['Human-GEM'].compartment;
-    expect(firstCompartment.name).toEqual('Extracellular');
-    expect(firstCompartment.score).toBeGreaterThan(0);
+    const [data1, data2] = await Promise.all([
+      search({
+        searchTerm: 'Extracellular',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'Golgi apparatus',
+        model: 'WormGem',
+        version: WORM_GEM_VERSION,
+      }),
+    ]);
+    const [firstCompartment1] = data1['Human-GEM'].compartment;
+    const [firstCompartment2] = data2['Worm-GEM'].compartment;
+    expect(firstCompartment1.name).toEqual('Extracellular');
+    expect(firstCompartment2.name).toEqual('Golgi apparatus');
+    expect(firstCompartment1.score).toBeGreaterThan(0);
+    expect(firstCompartment2.score).toBeGreaterThan(0);
   });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -34,12 +34,8 @@ describe('search', () => {
       }),
     ]);
 
-    const { gene } = data1['Mouse-GEM'];
-
-    const { metabolite } = data2['Human-GEM'];
-
-    const [firstGene] = gene.sort((a, b) => b.score - a.score);
-    const [firstMetabolite] = metabolite.sort((a, b) => b.score - a.score);
+    const [firstGene] = data1['Mouse-GEM'].gene;
+    const [firstMetabolite] = data2['Human-GEM'].metabolite;
 
     expect(firstGene.id).toBe('Polr3f');
     expect(firstGene.score).toBeGreaterThan(0);
@@ -79,14 +75,10 @@ describe('search', () => {
         version: HUMAN_GEM_VERSION,
       }),
     ]);
-    const [data1Metabolite] = data1['Yeast-GEM'].metabolite.sort(
-      (a, b) => b.score - a.score
-    );
+    const [data1Metabolite] = data1['Yeast-GEM'].metabolite;
     expect(data1Metabolite.score).toBeGreaterThan(0);
 
-    const [data2Metabolite] = data2['Human-GEM'].metabolite.sort(
-      (a, b) => b.score - a.score
-    );
+    const [data2Metabolite] = data2['Human-GEM'].metabolite;
     expect(data2Metabolite.score).toBeGreaterThan(0);
   });
 
@@ -109,16 +101,16 @@ describe('search', () => {
 
   test('gem search for metabolite formula gives matches', async () => {
     const [data1, data2] = await Promise.all([
-    search({
-      searchTerm: 'C21H44NO7P',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    }),
-    search({
-      searchTerm: 'C31H53NO4',
-      model: 'ZebrafishGem',
-      version: ZEBRAFISH_GEM_VERSION,
-    }),
+      search({
+        searchTerm: 'C21H44NO7P',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: 'C31H53NO4',
+        model: 'ZebrafishGem',
+        version: ZEBRAFISH_GEM_VERSION,
+      }),
     ]);
     expect(data1['Human-GEM'].metabolite.length).toBeGreaterThan(0);
     expect(data2['Zebrafish-GEM'].metabolite.length).toBeGreaterThan(0);
@@ -126,7 +118,7 @@ describe('search', () => {
   });
 
   test('gem search by gene name, alternate name or id finds the gene', async () => {
-    const data = await search({
+    const data1 = await search({
       searchTerm: 'NEURL1B',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
@@ -143,22 +135,17 @@ describe('search', () => {
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
     });
-    const [firstGene] = data['Human-GEM'].gene.sort(
-      (a, b) => b.score - a.score
-    );
-    const [firstGene2] = data2['Human-GEM'].gene.sort(
-      (a, b) => b.score - a.score
-    );
-    const [firstGene3] = data3['Human-GEM'].gene.sort(
-      (a, b) => b.score - a.score
-    );
-    expect(firstGene.name).toEqual('NEURL1B');
+    const [firstGene1] = data1['Human-GEM'].gene;
+    const [firstGene2] = data2['Human-GEM'].gene;
+    const [firstGene3] = data3['Human-GEM'].gene;
+
+    expect(firstGene1.name).toEqual('NEURL1B');
     expect(firstGene2.name).toEqual('NEURL1B');
     expect(firstGene3.name).toEqual('NEURL1B');
   });
 
   test('gem search by cross reference finds the gene', async () => {
-    const data = await search({
+    const data1 = await search({
       searchTerm: 'ENST00000415826',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
@@ -175,22 +162,17 @@ describe('search', () => {
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
     });
-    const [firstGene] = data['Human-GEM'].gene.sort(
-      (a, b) => b.score - a.score
-    );
-    const [firstGene2] = data2['Human-GEM'].gene.sort(
-      (a, b) => b.score - a.score
-    );
-    const [firstGene3] = data3['Human-GEM'].gene.sort(
-      (a, b) => b.score - a.score
-    );
-    expect(firstGene.name).toEqual('PLAAT3');
+    const [firstGene1] = data1['Human-GEM'].gene;
+    const [firstGene2] = data2['Human-GEM'].gene;
+    const [firstGene3] = data3['Human-GEM'].gene;
+
+    expect(firstGene1.name).toEqual('PLAAT3');
     expect(firstGene2.name).toEqual('PLAAT3');
     expect(firstGene3.name).toEqual('PLAAT3');
   });
 
   test('gem search by id, EC code and PMID finds the reaction', async () => {
-    const data = await search({
+    const data1 = await search({
       searchTerm: 'MAR03893',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
@@ -207,16 +189,10 @@ describe('search', () => {
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
     });
-    const [firstReaction] = data['Human-GEM'].reaction.sort(
-      (a, b) => b.score - a.score
-    );
-    const [firstReaction2] = data2['Human-GEM'].reaction.sort(
-      (a, b) => b.score - a.score
-    );
-    const [firstReaction3] = data3['Human-GEM'].reaction.sort(
-      (a, b) => b.score - a.score
-    );
-    expect(firstReaction.id).toEqual('MAR03893');
+    const [firstReaction1] = data1['Human-GEM'].reaction;
+    const [firstReaction2] = data2['Human-GEM'].reaction;
+    const [firstReaction3] = data3['Human-GEM'].reaction;
+    expect(firstReaction1.id).toEqual('MAR03893');
     // Multiple reactions share EC code and PMID
     expect(firstReaction2.id).toEqual('MAR03893');
     expect(firstReaction3.id).toEqual('MAR00973');
@@ -267,6 +243,7 @@ describe('search', () => {
     const [firstReaction5] = data5['Human-GEM'].reaction;
     expect(firstReaction5.id).toEqual('MAR00973');
   });
+
   test('gem search on name should find subsystem', async () => {
     const data = await search({
       searchTerm: 'Beta oxidation of even-chain fatty acids (peroxisomal)',

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -1,7 +1,7 @@
 import driver from 'neo4j/driver';
 import { search } from 'neo4j/queries/search';
 
-describe('search', () => {
+describe('gem search', () => {
   afterAll(async () => {
     await driver.close();
   });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -23,9 +23,9 @@ describe('search', () => {
   test('gem search should receive sensible ranking scores', async () => {
     const [data1, data2] = await Promise.all([
       search({
-        searchTerm: 'POLR3F',
-        model: 'HumanGem',
-        version: HUMAN_GEM_VERSION,
+        searchTerm: 'Polr3f',
+        model: 'MouseGem',
+        version: MOUSE_GEM_VERSION,
       }),
       search({
         searchTerm: 'Asparaginyl-Cysteinyl',
@@ -34,14 +34,14 @@ describe('search', () => {
       }),
     ]);
 
-    const { gene } = data1['Human-GEM'];
+    const { gene } = data1['Mouse-GEM'];
 
     const { metabolite } = data2['Human-GEM'];
 
     const [firstGene] = gene.sort((a, b) => b.score - a.score);
     const [firstMetabolite] = metabolite.sort((a, b) => b.score - a.score);
 
-    expect(firstGene.name).toBe('POLR3F');
+    expect(firstGene.id).toBe('Polr3f');
     expect(firstGene.score).toBeGreaterThan(0);
     expect(firstMetabolite.name).toMatch(/Asparaginyl-Cysteinyl/);
     expect(firstMetabolite.score).toBeGreaterThan(0);
@@ -69,9 +69,9 @@ describe('search', () => {
   test('gem search for metabolite name gives valid score for metabolites', async () => {
     const [data1, data2] = await Promise.all([
       search({
-        searchTerm: 'pyridoxine',
-        model: 'HumanGem',
-        version: HUMAN_GEM_VERSION,
+        searchTerm: 'coenzyme A',
+        model: 'YeastGem',
+        version: YEAST_GEM_VERSION,
       }),
       search({
         searchTerm: '3(R)-hydroxy-(2S,6R,10)-trimethyl-hendecanoyl',
@@ -79,7 +79,7 @@ describe('search', () => {
         version: HUMAN_GEM_VERSION,
       }),
     ]);
-    const [data1Metabolite] = data1['Human-GEM'].metabolite.sort(
+    const [data1Metabolite] = data1['Yeast-GEM'].metabolite.sort(
       (a, b) => b.score - a.score
     );
     expect(data1Metabolite.score).toBeGreaterThan(0);
@@ -91,19 +91,34 @@ describe('search', () => {
   });
 
   test('gem search for metabolite id gives matches', async () => {
-    const data = await search({
-      searchTerm: 'MAM01513s',
-      model: 'HumanGem',
-    });
-    expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
+    const [data1, data2] = await Promise.all([
+      search({
+        searchTerm: 'MAM01513s',
+        model: 'HumanGem',
+      }),
+      search({
+        searchTerm: 'MAM00715c',
+        model: 'FruitflyGem',
+      }),
+    ]);
+    expect(data1['Human-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data2['Fruitfly-GEM'].metabolite.length).toBeGreaterThan(0);
   });
 
   test('gem search for metabolite formula gives matches', async () => {
-    const data = await search({
+    const [data1, data2] = await Promise.all([
+    search({
       searchTerm: 'C21H44NO7P',
       model: 'HumanGem',
-    });
-    expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
+    }),
+    search({
+      searchTerm: 'C31H53NO4',
+      model: 'ZebrafishGem',
+    }),
+    ]);
+    expect(data1['Human-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data2['Zebrafish-GEM'].metabolite.length).toBeGreaterThan(0);
+    expect(data2['Zebrafish-GEM'].metabolite[0].id).toEqual('MAM00130m');
   });
 
   test('gem search by gene name, alternate name or id finds the gene', async () => {

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -298,7 +298,6 @@ describe('gem search', () => {
   });
 
   test('search for subsystem id should give highest score to subsystems', async () => {
-    // test all components?
     const data = await search({
       searchTerm: 'Retinol metabolism',
       model: 'HumanGem',
@@ -313,7 +312,6 @@ describe('gem search', () => {
   });
 
   test('search in mouse gem should not give match in a other model', async () => {
-    // rewrite to: all models == MouseGem??
     const data = await search({
       searchTerm: 'H2O',
       model: 'MouseGem',
@@ -325,7 +323,6 @@ describe('gem search', () => {
   });
 
   test('search results can be limited', async () => {
-    // TODO: behaves weirdly, test 2 vs 3 vs 5
     const [lim1, lim10] = await Promise.all([
       search({
         searchTerm: 'H2O',

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -6,7 +6,7 @@ describe('search', () => {
     await driver.close();
   });
 
-  test('model search should have max 50 results per component type', async () => {
+  test('gem search should have max 50 results per component type', async () => {
     const data = await search({
       searchTerm: 'H2O',
       model: 'HumanGem',
@@ -20,7 +20,7 @@ describe('search', () => {
     expect(metabolite.length).toBeLessThan(51);
   });
 
-  test('model search should receive sensible ranking scores', async () => {
+  test('gem search should receive sensible ranking scores', async () => {
     const [data1, data2] = await Promise.all([
       search({
         searchTerm: 'POLR3F',
@@ -45,7 +45,7 @@ describe('search', () => {
     expect(firstMetabolite.name).toMatch(/Asparaginyl-Cysteinyl/);
   });
 
-  test('model search with special characters should not fail', async () => {
+  test('gem search with special characters should not fail', async () => {
     const [data1, data2] = await Promise.all([
       search({
         searchTerm: 'rna/dna: (met)',
@@ -64,19 +64,7 @@ describe('search', () => {
     }
   });
 
-  test('global search should return results for multiple models', async () => {
-    const data = await search({
-      searchTerm: 'POLR3F',
-    });
-
-    expect(data['Human-GEM'].gene.length).toBeGreaterThan(0);
-    expect(data['Mouse-GEM'].gene.length).toBeGreaterThan(0);
-    expect(data['Rat-GEM'].gene.length).toBeGreaterThan(0);
-    expect(data['Fruitfly-GEM'].gene.length).toBeGreaterThan(0);
-    expect(data['Zebrafish-GEM'].gene.length).toBeGreaterThan(0);
-  });
-
-  test('search for metabolite name gives valid score for metabolites', async () => {
+  test('gem search for metabolite name gives valid score for metabolites', async () => {
     const data = await search({
       searchTerm: 'pyridoxine',
       model: 'HumanGem',
@@ -88,18 +76,14 @@ describe('search', () => {
     expect(firstMetabolite.score).toBeGreaterThan(0);
   });
 
-  test('search for metabolite id gives matches', async () => {
+  test('gem search for metabolite id gives matches', async () => {
     const data = await search({
       searchTerm: 'MAM01513s',
     });
     expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
-    expect(data['Mouse-GEM'].metabolite.length).toBeGreaterThan(0);
-    expect(data['Rat-GEM'].metabolite.length).toBeGreaterThan(0);
-    expect(data['Zebrafish-GEM'].metabolite.length).toBeGreaterThan(0);
-    expect(data['Worm-GEM'].metabolite.length).toBeGreaterThan(0);
   });
 
-  test('search by gene name or id both finds the gene', async () => {
+  test('gem search by gene name or id both finds the gene', async () => {
     const data = await search({
       searchTerm: 'NEURL1B',
       model: 'HumanGem',

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -97,8 +97,7 @@ describe('search', () => {
     });
     expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
   });
-  
- 
+
   test('gem search for metabolite formula gives matches', async () => {
     const data = await search({
       searchTerm: 'C21H44NO7P',
@@ -107,13 +106,20 @@ describe('search', () => {
     expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
   });
 
-  test('gem search by gene name or id both finds the gene', async () => {
+  test('gem search by gene name, alternate name or id finds the gene', async () => {
     const data = await search({
       searchTerm: 'NEURL1B',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
     });
+
     const data2 = await search({
+      searchTerm: 'neuralized E3 ubiquitin protein ligase 1B',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+
+    const data3 = await search({
       searchTerm: 'ENSG00000214357',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
@@ -121,10 +127,14 @@ describe('search', () => {
     const [firstGene] = data['Human-GEM'].gene.sort(
       (a, b) => b.score - a.score
     );
-    const [firstGene2] = data['Human-GEM'].gene.sort(
+    const [firstGene2] = data2['Human-GEM'].gene.sort(
+      (a, b) => b.score - a.score
+    );
+    const [firstGene3] = data3['Human-GEM'].gene.sort(
       (a, b) => b.score - a.score
     );
     expect(firstGene.name).toEqual('NEURL1B');
     expect(firstGene2.name).toEqual('NEURL1B');
+    expect(firstGene3.name).toEqual('NEURL1B');
   });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -114,7 +114,9 @@ describe('gem search', () => {
     ]);
     expect(data1['Human-GEM'].metabolite.length).toBeGreaterThan(0);
     expect(data2['Zebrafish-GEM'].metabolite.length).toBeGreaterThan(0);
-    expect(data2['Zebrafish-GEM'].metabolite[0].id).toEqual('MAM00130m');
+    expect(data2['Zebrafish-GEM'].metabolite[0].id).toMatch(
+      /MAM00130|MAM00316/
+    );
   });
 
   test('gem search by gene name, alternate name or id finds the gene', async () => {

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -67,15 +67,27 @@ describe('search', () => {
   });
 
   test('gem search for metabolite name gives valid score for metabolites', async () => {
-    const data = await search({
-      searchTerm: 'pyridoxine',
-      model: 'HumanGem',
-      version: HUMAN_GEM_VERSION,
-    });
-    const [firstMetabolite] = data['Human-GEM'].metabolite.sort(
+    const [data1, data2] = await Promise.all([
+      search({
+        searchTerm: 'pyridoxine',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+      search({
+        searchTerm: '3(R)-hydroxy-(2S,6R,10)-trimethyl-hendecanoyl',
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      }),
+    ]);
+    const [data1Metabolite] = data1['Human-GEM'].metabolite.sort(
       (a, b) => b.score - a.score
     );
-    expect(firstMetabolite.score).toBeGreaterThan(0);
+    expect(data1Metabolite.score).toBeGreaterThan(0);
+
+    const [data2Metabolite] = data2['Human-GEM'].metabolite.sort(
+      (a, b) => b.score - a.score
+    );
+    expect(data2Metabolite.score).toBeGreaterThan(0);
   });
 
   test('gem search for metabolite id gives matches', async () => {

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -259,4 +259,14 @@ describe('search', () => {
     );
     expect(firstSubsystem.score).toBeGreaterThan(0);
   });
+
+  test('gem search on name should find compartment', async () => {
+    const data = await search({
+      searchTerm: 'Extracellular',
+      model: 'HumanGem',
+    });
+    const [firstCompartment] = data['Human-GEM'].compartment;
+    expect(firstCompartment.name).toEqual('Extracellular');
+    expect(firstCompartment.score).toBeGreaterThan(0);
+  });
 });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -93,6 +93,16 @@ describe('search', () => {
   test('gem search for metabolite id gives matches', async () => {
     const data = await search({
       searchTerm: 'MAM01513s',
+      model: 'HumanGem',
+    });
+    expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
+  });
+  
+ 
+  test('gem search for metabolite formula gives matches', async () => {
+    const data = await search({
+      searchTerm: 'C21H44NO7P',
+      model: 'HumanGem',
     });
     expect(data['Human-GEM'].metabolite.length).toBeGreaterThan(0);
   });

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -169,4 +169,37 @@ describe('search', () => {
     expect(firstGene2.name).toEqual('PLAAT3');
     expect(firstGene3.name).toEqual('PLAAT3');
   });
+
+  test('gem search by id, EC code and PMID finds the reaction', async () => {
+    const data = await search({
+      searchTerm: 'MAR03893',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+
+    const data2 = await search({
+      searchTerm: '1.13.11.34',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+
+    const data3 = await search({
+      searchTerm: '7929234',
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+    const [firstReaction] = data['Human-GEM'].reaction.sort(
+      (a, b) => b.score - a.score
+    );
+    const [firstReaction2] = data2['Human-GEM'].reaction.sort(
+      (a, b) => b.score - a.score
+    );
+    const [firstReaction3] = data3['Human-GEM'].reaction.sort(
+      (a, b) => b.score - a.score
+    );
+    expect(firstReaction.id).toEqual('MAR03893');
+    // Multiple reactions share EC code and PMID
+    expect(firstReaction2.id).toEqual('MAR03893');
+    expect(firstReaction3.id).toEqual('MAR00973');
+  });
 });

--- a/api/test/searchGlobal.test.js
+++ b/api/test/searchGlobal.test.js
@@ -1,0 +1,44 @@
+import driver from 'neo4j/driver';
+import { search } from 'neo4j/queries/search';
+
+describe('search', () => {
+  afterAll(async () => {
+    await driver.close();
+  });
+
+  test('global search should return results for multiple models', async () => {
+    const data = await search({
+      searchTerm: 'POLR3F',
+    });
+
+    expect(data['Human-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Mouse-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Rat-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Fruitfly-GEM'].gene.length).toBeGreaterThan(0);
+    expect(data['Zebrafish-GEM'].gene.length).toBeGreaterThan(0);
+  });
+
+  test('search for yeast reaction id should give highest score to yeast', async () => {
+    const data = await search({
+      searchTerm: 'r_2025',
+    });
+    let topscore = 0;
+
+    for (const model of [
+      'Human-GEM',
+      'Mouse-GEM',
+      'Rat-GEM',
+      'Fruitfly-GEM',
+      'Zebrafish-GEM',
+    ]) {
+      const scores = COMPONENTS.map(c =>
+        data[model][c][0] ? data[model][c][0].score : 0
+      );
+      topscore =
+        Math.max(...scores) > topscore ? Math.max(...scores) : topscore;
+    }
+
+    const yeastScore = data['Yeast-GEM']['reaction'][0].score;
+    expect(yeastScore).toBeGreaterThan(topscore);
+  });
+});

--- a/api/test/searchGlobal.test.js
+++ b/api/test/searchGlobal.test.js
@@ -41,4 +41,18 @@ describe('search', () => {
     const yeastScore = data['Yeast-GEM']['reaction'][0].score;
     expect(yeastScore).toBeGreaterThan(topscore);
   });
+
+  test('search for Nucleus should give same highest score in all models', async () => {
+    const data = await search({
+      searchTerm: 'Nucleus',
+    });
+    const scores = Object.values(data).map(m => {
+      return m.compartment[0].score;
+    });
+    const scoreSet = new Set(scores);
+
+    expect(scores.length).toEqual(7);
+    expect(scoreSet.size).toEqual(1);
+    expect(scoreSet.has(9.740471839904785)).toEqual(true);
+  });
 });

--- a/api/test/searchGlobal.test.js
+++ b/api/test/searchGlobal.test.js
@@ -46,9 +46,7 @@ describe('search', () => {
     const data = await search({
       searchTerm: 'Nucleus',
     });
-    const scores = Object.values(data).map(m => {
-      return m.compartment[0].score;
-    });
+    const scores = Object.values(data).map(m => m.compartment[0].score);
     const scoreSet = new Set(scores);
 
     expect(scores.length).toEqual(7);


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #896, created by @inghylt and @MalinAhlberg 

When searching for a metabolite name (eg "3(R)-hydroxy-(2S,6R,10)-trimethyl-hendecanoyl-CoA"), the score for the corresponding metabolite node (MAM00685p) will no longer be zero.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Keep the connection between metabolites and compartmentalized metabolites in the neo4j queries (global and model search), so that the score can be correctly set
- adds test for this bug fix 
- in commit 9257786, use `>=` when testing for `max 50`
 
**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![scorefix](https://user-images.githubusercontent.com/1029190/165318185-3627ebfe-ee14-4c2f-ba1c-7e31359957f2.png)

**Testing**  
<!-- Please delete options that are not relevant -->
Test searching for metabolite names and make sure they show up as first result.
Also verify that other searches work as expected, regarding both components and models.


**Further comments**  
<!-- Specify questions or related information -->
- This part of the issue description "When searching for fatty the top result should not be the gene FASTK as top result" is not solved. This problem turned out to be related only to the internal scoring of neo4j, and therefore ignored in this issue.

**Definition of Done checklist**  
- [X] My code meets the Acceptance Criteria
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
