### PR TITLE
fix: overlay disappears on collapsing bar

### DIFF
--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -160,7 +160,7 @@
 </template>
 
 <script>
-import { mapGetters, mapState } from 'vuex';
+import { mapGetters, mapState, mapActions } from 'vuex';
 import { debounce } from 'vue-debounce';
 import DataOverlay from '@/components/explorer/mapViewer/DataOverlay.vue';
 import ErrorPanel from '@/components/shared/ErrorPanel';
@@ -249,6 +249,9 @@ export default {
     this.loadMapFromParams();
   },
   methods: {
+    ...mapActions({
+      resetOverlay: 'dataOverlay/resetValues',
+    }),
     handleSidebarScroll() {
       if (this.$refs.mapSidebar.scrollTop > 0) {
         this.sidebarLayoutReset = false;
@@ -301,6 +304,7 @@ export default {
       }
     },
     loadMapFromParams() {
+      this.resetOverlay();
       const id = this.$route.params.map_id;
       if (id) {
         const categories = Object.keys(this.mapsListing);

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -160,7 +160,7 @@
 </template>
 
 <script>
-import { mapGetters, mapState, mapActions } from 'vuex';
+import { mapGetters, mapState } from 'vuex';
 import { debounce } from 'vue-debounce';
 import DataOverlay from '@/components/explorer/mapViewer/DataOverlay.vue';
 import ErrorPanel from '@/components/shared/ErrorPanel';
@@ -249,9 +249,6 @@ export default {
     this.loadMapFromParams();
   },
   methods: {
-    ...mapActions({
-      resetOverlay: 'dataOverlay/resetValues',
-    }),
     handleSidebarScroll() {
       if (this.$refs.mapSidebar.scrollTop > 0) {
         this.sidebarLayoutReset = false;
@@ -304,7 +301,6 @@ export default {
       }
     },
     loadMapFromParams() {
-      this.resetOverlay();
       const id = this.$route.params.map_id;
       if (id) {
         const categories = Object.keys(this.mapsListing);

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -195,7 +195,7 @@ export default {
       filename: datasource,
       propagate: false,
     });
-    const dataSet = this.validDataSourceDataSetInQuery() ? this.$route.query.dataSet : 'None';
+    const dataSet = this.validDataSourceDataSetInQuery() ? this.dataSet : 'None';
     await this.setDataSet(dataSet);
   },
   methods: {
@@ -273,9 +273,9 @@ export default {
     },
     validDataSourceDataSetInQuery() {
       return (
-        this.$route.query.dataSet && // eslint-disable-line operator-linebreak
+        this.dataSet && // eslint-disable-line operator-linebreak
         this.dataSource && // eslint-disable-line operator-linebreak
-        this.dataSource.dataSets.indexOf(this.$route.query.dataSet) > -1
+        this.dataSource.dataSets.indexOf(this.dataSet) > -1
       );
     },
   },

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -198,9 +198,6 @@ export default {
     const dataSet = this.validDataSourceDataSetInQuery() ? this.$route.query.dataSet : 'None';
     await this.setDataSet(dataSet);
   },
-  destroyed() {
-    this.resetDataValues();
-  },
   methods: {
     ...mapActions({
       getDataSourcesIndex: 'dataOverlay/getIndex',

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -195,7 +195,7 @@ export default {
       filename: datasource,
       propagate: false,
     });
-    const dataSet = this.validDataSourceDataSetInQuery() ? this.dataSet : 'None';
+    const dataSet = this.validDataSourceDataSetInQuery() ? this.currentDataSet() : 'None';
     await this.setDataSet(dataSet);
   },
   methods: {
@@ -271,11 +271,14 @@ export default {
     modelHasOverlayData() {
       return Object.keys(this.dataSourcesIndex).length > 0;
     },
+    currentDataSet() {
+      return this.dataSet !== 'None' ? this.dataSet : this.$route.query.dataSet;
+    },
     validDataSourceDataSetInQuery() {
       return (
-        this.dataSet && // eslint-disable-line operator-linebreak
+        this.currentDataSet() && // eslint-disable-line operator-linebreak
         this.dataSource && // eslint-disable-line operator-linebreak
-        this.dataSource.dataSets.indexOf(this.dataSet) > -1
+        this.dataSource.dataSets.indexOf(this.currentDataSet()) > -1
       );
     },
   },

--- a/frontend/src/components/explorer/mapViewer/DataOverlay.vue
+++ b/frontend/src/components/explorer/mapViewer/DataOverlay.vue
@@ -206,7 +206,6 @@ export default {
       setDataSet: 'dataOverlay/setDataSet',
       setCustomDataSource: 'dataOverlay/setCustomDataSource',
       setCustomDataSet: 'dataOverlay/setCustomDataSet',
-      resetDataValues: 'dataOverlay/resetValues',
     }),
     async handleDataTypeSelect(e) {
       const payload = {

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -161,6 +161,7 @@ export default {
       const payload = { model: this.model.short_name, svgName: this.mapData.svgs[0].filename };
       await this.$store.dispatch('maps/getSvgMap', payload);
       this.bindKeyboardShortcuts();
+      this.applyLevelsOnMap();
     },
     setupHoverEventHandlers() {
       const self = this;

--- a/frontend/src/store/modules/dataOverlay.js
+++ b/frontend/src/store/modules/dataOverlay.js
@@ -104,10 +104,6 @@ const actions = {
     }
     commit('setCustomDataSet', dataSet);
   },
-  resetValues({ commit }) {
-    // Used to reset overlay values when switching maps
-    commit('setDataSet', 'None');
-  },
 };
 
 const mutations = {

--- a/frontend/src/store/modules/dataOverlay.js
+++ b/frontend/src/store/modules/dataOverlay.js
@@ -105,9 +105,7 @@ const actions = {
     commit('setCustomDataSet', dataSet);
   },
   resetValues({ commit }) {
-    commit('setIndex', {});
-    commit('setCurrentDataType', null);
-    commit('setCurrentDataSource', null);
+    // Used to reset overlay values when switching maps
     commit('setDataSet', 'None');
   },
 };


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #935 and #789.

Changes of the overlay is kept even if the overlay bar is collapsed.
The levels / overlay is kept when switching between 2D/3D, when a new map is chosen, or if leaving the Maps and then returning.
<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- [X] overlay data is not reset when collapsing the sidebar
- [X] overlay data is kept when reopening the sidebar
- [X] overlay is always applied when a 2D map is drawn (already present for 3D)
- [X] keep the values when (re-)entering the Map Viewer / switching maps.

As a consequence, issue #789 was solved.


**Testing**  
<!-- Please delete options that are not relevant -->
Navigate to the map viewer, open any map and then open the `Data Overlay` side bar. Add a Level.
Verify that the overlay is kept (on the map, in the dropdown, in the url) when collapsing and reopening the overlay side bar. 2D and 3D  should work the same way.
Also test that the overlay works as expected when moving around on the page.

**Further comments**  
<!-- Specify questions or related information -->
I did not implement the optional acceptance criterion (adding some sort of indicator for when overlay is added), but I think it would make much sense to add it, especially since the overlay is kept when you leave and re-enter the map viewer. I will open a new issue for this.


**Definition of Done checklist**  
- [X] My code meets the Acceptance Criteria
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
