### PR TITLE
docs: rename operation ID for interaction partners

### DIFF
--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -352,7 +352,7 @@ paths:
       description:
         'This query retrieves all first order interaction partners for
         a given gene or metabolite.'
-      operationId: 'geneInteractionPartners'
+      operationId: 'interactionPartners'
       produces:
         - 'application/json'
       parameters:


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #948.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Rename Swagger operation ID for interaction partners from `geneInteractionPartners` to `interactionPartners`.

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
  1. Visit `/api/v2/#/Interaction%20Partners/interactionPartners`.
  2. Verify that the page scrolls to the specified endpoint/operation.

**Further comments**  
<!-- Specify questions or related information -->
Camel case (`interactionPartners`) is used instead of pascal case (`InteractionPartners`) as specified in the issue's acceptance criteria. This is to be consistent with the rest of the page.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
