### PR TITLE
feat: remove GEM version prefix

### DIFF
--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -77,7 +77,7 @@
     {
       "date": "2020-02-07",
       "title": "Metabolic Atlas 1.5 updates both integrated models",
-      "text": "<b>Metabolic Atlas 1.5</b> is out. This release updates the layout of the <i>Home</i>, <i>Explore</i>, and <i>Interaction Partner</i> pages. A <i>News</i> section has also been added on the <i>About</i> page. Other features include suggestions on the <i>Search</i> page, a contact button in the <i>GEM Browser</i>, and a progress bar at the top indicating page loading status. The Human-GEM has also been updated to v1.3, and the Yeast-GEM to v8.3.4. More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/1.5' target='_blank'>on GitHub</a>."
+      "text": "<b>Metabolic Atlas 1.5</b> is out. This release updates the layout of the <i>Home</i>, <i>Explore</i>, and <i>Interaction Partner</i> pages. A <i>News</i> section has also been added on the <i>About</i> page. Other features include suggestions on the <i>Search</i> page, a contact button in the <i>GEM Browser</i>, and a progress bar at the top indicating page loading status. The Human-GEM has also been updated to 1.3, and the Yeast-GEM to 8.3.4. More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/1.5' target='_blank'>on GitHub</a>."
     }
   ],
   "2019": [
@@ -98,8 +98,8 @@
     },
     {
       "date": "2019-06-25",
-      "title": "Metabolic Atlas is upgraded to 1.2 with Human-GEM updated to v1.1",
-      "text": "<b>Metabolic Atlas 1.2</b> adds more interaction on the 3D <i>Map Viewer</i>, and improves the <i>GEM Comparison</i> tables. It also contains several bug fixes. More details can be found in <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/1.2' target='_blank'>on GitHub</a>. Moreover, <i>Human-GEM</i> was updated to v1.1."
+      "title": "Metabolic Atlas is upgraded to 1.2 with Human-GEM updated to 1.1",
+      "text": "<b>Metabolic Atlas 1.2</b> adds more interaction on the 3D <i>Map Viewer</i>, and improves the <i>GEM Comparison</i> tables. It also contains several bug fixes. More details can be found in <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/1.2' target='_blank'>on GitHub</a>. Moreover, <i>Human-GEM</i> was updated to 1.1."
     },
     {
       "date": "2019-05-29",


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #966.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Removed GEM version prefix for news section.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="628" alt="image" src="https://user-images.githubusercontent.com/423498/169041114-d89155af-d917-4205-a87b-581e7d71d9ee.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
  1. Visit `/about/news` and make sure there are no version prefixes (`v*`). 

**Further comments**  
<!-- Specify questions or related information -->
The only remaining instance of the version prefixes are found on the news page. I'm not 100% if they should even be removed here as they are not used directly after a model. I think #966  could be closed with or without this PR. Please let me know if you know of any other instances.

The [comment regarding dash between model and version number](https://github.com/MetabolicAtlas/MetabolicAtlas/issues/966#issuecomment-1122334283) has been moved to #976.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
