### PR TITLE
refactor: move formatting logic to module and simplify format

### DIFF
--- a/frontend/src/api/gems.js
+++ b/frontend/src/api/gems.js
@@ -2,33 +2,7 @@ import axios from 'axios';
 
 const fetchGems = async () => {
   const { data } = await axios.get('repository/models/');
-
-  return data.reduce((dict, g) => {
-    const gem = {
-      ...g,
-      ...g.sample,
-      description: g.description || g.gemodelset.description,
-      set_name: g.gemodelset.name,
-      tissue:
-        [g.sample.tissue, g.sample.cell_type, g.sample.cell_line].filter(e => e).join(' ‒ ') || '-',
-      stats: `<p>reactions:&nbsp;${
-        g.reaction_count === null ? '-' : g.reaction_count
-      }</p><p>metabolites:&nbsp;${
-        g.metabolite_count === null ? '-' : g.metabolite_count
-      }</p><p>genes:&nbsp;${g.gene_count === null ? '-' : g.gene_count}</p>`,
-      maintained: g.maintained ? 'Yes' : 'No',
-      organ_system: g.sample.organ_system || '-',
-      condition: g.condition || '-',
-      ref: g.ref.length > 0 ? g.ref : g.gemodelset.reference,
-    };
-
-    // eslint-disable-next-line
-    const { gemodelset, sample, cell_type, reference, ...strippedGem } = gem;
-    return {
-      ...dict,
-      [strippedGem.id]: strippedGem,
-    };
-  }, {});
+  return data;
 };
 
 export default { fetchGems };

--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -327,13 +327,13 @@ export default {
   computed: {
     ...mapState({
       gem: state => state.gems.gem,
+      gems: state => state.gems.gems,
     }),
     ...mapGetters({
       integratedModels: 'models/integratedModels',
       setFilterOptions: 'gems/setFilterOptions',
       systemFilterOptions: 'gems/systemFilterOptions',
       conditionFilterOptions: 'gems/conditionFilterOptions',
-      gems: 'gems/gemList',
     }),
   },
   watch: {

--- a/frontend/src/store/modules/gems.js
+++ b/frontend/src/store/modules/gems.js
@@ -6,24 +6,46 @@ const data = {
 };
 
 const getters = {
-  /* eslint-disable no-unused-vars */
-  gemList: state => Object.values(state.gems),
-  setFilterOptions: (state, _getters) => [...new Set(_getters.gemList.map(g => g.set_name))].sort(),
-  systemFilterOptions: (state, _getters) =>
-    [...new Set(_getters.gemList.map(g => g.organ_system))].sort(),
-  conditionFilterOptions: (state, _getters) =>
-    [...new Set(_getters.gemList.map(g => g.condition))].sort(),
-  /* eslint-enable no-unused-vars */
+  setFilterOptions: state => [...new Set(state.gems.map(g => g.set_name))].sort(),
+  systemFilterOptions: state => [...new Set(state.gems.map(g => g.organ_system))].sort(),
+  conditionFilterOptions: state => [...new Set(state.gems.map(g => g.condition))].sort(),
 };
 
 const actions = {
   async getGems({ commit }) {
     const gems = await gemsApi.fetchGems();
-    commit('setGems', gems);
+
+    const formattedGems = gems.map(g => {
+      const gem = {
+        ...g,
+        ...g.sample,
+        description: g.description || g.gemodelset.description,
+        set_name: g.gemodelset.name,
+        tissue:
+          [g.sample.tissue, g.sample.cell_type, g.sample.cell_line].filter(e => e).join(' ‒ ') ||
+          '-',
+        stats: `<p>reactions:&nbsp;${
+          g.reaction_count === null ? '-' : g.reaction_count
+        }</p><p>metabolites:&nbsp;${
+          g.metabolite_count === null ? '-' : g.metabolite_count
+        }</p><p>genes:&nbsp;${g.gene_count === null ? '-' : g.gene_count}</p>`,
+        maintained: g.maintained ? 'Yes' : 'No',
+        organ_system: g.sample.organ_system || '-',
+        condition: g.condition || '-',
+        ref: g.ref.length > 0 ? g.ref : g.gemodelset.reference,
+      };
+
+      // eslint-disable-next-line
+      const { gemodelset, sample, cell_type, reference, ...strippedGem } = gem;
+      return strippedGem;
+    });
+
+    commit('setGems', formattedGems);
   },
   getGemData({ commit, state }, id) {
-    if (state.gems[id]) {
-      commit('setGem', state.gems[id]);
+    const gem = state.gems.find(g => g.id === id);
+    if (gem) {
+      commit('setGem', gem);
       return true;
     }
     return false;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #991.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Move data formatting logic from `./frontend/src/api/gems.js` to `./frontend/src/store/modules/gem.js`.
- Change the `gems/gems` store state from a dictionary to a list and remove obsoleted `gems/gemList` store getter.

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
Visit `/gems/repository#GEM-repository` and verify that the GEM Repository section works the same as before. 

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
