### PR TITLE
refactor: formatting logic for Europe PMC results

### DIFF
--- a/frontend/src/api/europepmc.js
+++ b/frontend/src/api/europepmc.js
@@ -5,39 +5,7 @@ const searchReferences = async queryIds => {
     `https://www.ebi.ac.uk/europepmc/webservices/rest/search?query=${queryIds}&resultType=core&format=json`
   );
 
-  const refs = {};
-
-  data.resultList.result.forEach(details => {
-    try {
-      const refDetails = {};
-      if (!details.fullTextUrlList) {
-        refDetails.link = null;
-      } else {
-        refDetails.link = details.fullTextUrlList.fullTextUrl.filter(
-          e => e.documentStyle === 'html' && e.site === 'Europe_PMC'
-        );
-        if (refDetails.link.length === 0) {
-          refDetails.link = details.fullTextUrlList.fullTextUrl.filter(
-            e => e.documentStyle === 'doi' || e.documentStyle === 'abs'
-          )[0].url;
-        } else {
-          refDetails.link = refDetails.link[0].url;
-        }
-      }
-      if (details.pubYear) {
-        refDetails.year = details.pubYear;
-      }
-      refDetails.authors = details.authorList.author.map(e => e.fullName);
-      refDetails.journal = details.journalInfo.journal.title;
-      refDetails.title = details.title;
-      refDetails.formattedString = `${refDetails.authors.join(', ')}, ${refDetails.year}. <i>${
-        refDetails.title
-      }</i> ${refDetails.journal}`;
-      refs[details.id] = refDetails;
-    } catch {} // eslint-disable-line no-empty
-  });
-
-  return refs;
+  return data.resultList.result;
 };
 
 export default { searchReferences };

--- a/frontend/src/store/modules/europepmc.js
+++ b/frontend/src/store/modules/europepmc.js
@@ -6,7 +6,51 @@ const data = {
 
 const actions = {
   async searchReferences({ commit }, queryIds) {
-    const formattedRefs = await europepmcApi.searchReferences(queryIds);
+    const refs = await europepmcApi.searchReferences(queryIds);
+
+    // The `refs` returned from EuropePMC many fields that are not used
+    // in this project. The following `reduce` extracts and popoulates
+    // a small subset of fields: `authors`, `formattedString`, `journal`,
+    // `link`, `title` and optionally `year`.
+    const formattedRefs = refs.reduce((dict, details) => {
+      const { id, title } = details;
+      const authors = details.authorList?.author?.map(e => e.fullName);
+      const journal = details.journalInfo?.journal?.title;
+
+      let link = null;
+      if (details.fullTextUrlList) {
+        const fullTextUrl = details.fullTextUrlList?.fullTextUrl;
+
+        link = fullTextUrl?.filter(e => e.documentStyle === 'html' && e.site === 'Europe_PMC');
+
+        if (link.length === 0) {
+          link = fullTextUrl?.filter(e => e.documentStyle === 'doi' || e.documentStyle === 'abs')[0]
+            ?.url;
+        } else {
+          link = link[0].url;
+        }
+      }
+
+      if (!id || !authors || !journal || !title || !link) {
+        // if any of these are not found, go to the next reference
+        return dict;
+      }
+
+      const year = details.pubYear;
+
+      const formattedString = `${authors.join(', ')}, ${year}. <i>${title}</i> ${journal}`;
+
+      const refDetails = { authors, formattedString, journal, link, title };
+      if (year) {
+        refDetails.year = year;
+      }
+
+      return {
+        ...dict,
+        [id]: refDetails,
+      };
+    }, {});
+
     commit('setFormattedRefs', formattedRefs);
   },
 };


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #996.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Move data formatting logic from `./frontend/src/api/europepmc.js` to `./frontend/src/store/modules/europepmc.js`.
- Use `reduce` + [optional chaining](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Optional_chaining) instead of `forEach` + `try/catch` to process data.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
Visit a page that contains reference details from Europe PMC, for example: `/explore/Human-GEM/gem-browser/reaction/MAR03372`, and verify that the section looks and works the same as before.

**Further comments**  
<!-- Specify questions or related information -->
It would have been helpful to identify certain components that would have thrown errors in the original `try/catch` implementation to fully verify that this refactor is correct. I was however unable to find any such examples.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
