### PR TITLE
feat: display compartments as links for interaction partners

### DIFF
--- a/api/src/neo4j/queries/interactionPartners.js
+++ b/api/src/neo4j/queries/interactionPartners.js
@@ -40,7 +40,9 @@ CALL apoc.cypher.mapParallel2("
  MATCH (reaction)-[cmE${v}]-(cm:CompartmentalizedMetabolite)
  WITH DISTINCT cm, cmE, reaction, compartments, subsystem, genes
  MATCH (c:Compartment)-[${v}]-(cm)-[${v}]-(:Metabolite)-[${v}]-(ms:MetaboliteState)
- RETURN {id: reaction.id, subsystem: subsystem, compartments: compartments, genes: genes, metabolites: COLLECT(DISTINCT({id: cm.id, name: ms.name,  compartmentId: c.id, outgoing: startnode(cmE)=cm})) } as data", {}, reactions, 50) YIELD value
+ WITH DISTINCT cm, cmE, reaction, compartments, subsystem, genes, c, ms
+ MATCH (reaction)-[${v}]-(rs:ReactionState)
+ RETURN {id: reaction.id, reversible: rs.reversible, subsystem: subsystem, compartments: compartments, genes: genes, metabolites: COLLECT(DISTINCT({id: cm.id, name: ms.name,  compartmentId: c.id, outgoing: startnode(cmE)=cm})) } as data", {}, reactions, 50) YIELD value
 
 WITH apoc.map.mergeList(apoc.coll.flatten(
   apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])

--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -104,19 +104,10 @@
                 <!-- eslint-enable vue/valid-v-for vue/require-v-for-key max-len -->
               </td>
               <td>
-                <template v-for="(w, i) in r.compartment_str.split(/⇔|⇒/)">
-                  <template v-if="i !== 0">{{ r.reversible ? ' ⇔ ' : ' ⇒ ' }}</template>
-                  <template v-for="(comp, j) in w.split(' + ')">
-                    <template v-if="j != 0">+</template>
-                    <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
-                    <a
-                      :href="`/explore/${model.short_name}/gem-browser/compartment/${idfy(comp)}`"
-                      @click="handleRouterClick"
-                    >
-                      {{ comp }}
-                    </a>
-                  </template>
-                </template>
+                <compartment-links
+                  :compartment-string="r.compartment_str"
+                  :is-reversible="r.reversible"
+                />
               </td>
             </tr>
           </tbody>
@@ -132,12 +123,14 @@ import Loader from '@/components/Loader';
 import { default as compare } from '@/helpers/compare';
 import ExportTSV from '@/components/shared/ExportTSV';
 import { idfy, reformatChemicalReactionHTML } from '@/helpers/utils';
+import CompartmentLinks from '@/components/shared/CompartmentLinks';
 
 export default {
   name: 'ReactionTable',
   components: {
     ExportTSV,
     Loader,
+    CompartmentLinks,
   },
   props: {
     sourceName: { type: String, required: true },

--- a/frontend/src/components/shared/CompartmentLinks.vue
+++ b/frontend/src/components/shared/CompartmentLinks.vue
@@ -1,0 +1,38 @@
+<template>
+  <span>
+    <template v-for="(w, i) in compartmentString.split(/⇔|⇒/)">
+      <template v-if="i !== 0">{{ isReversible ? ' ⇔ ' : ' ⇒ ' }}</template>
+      <template v-for="(c, j) in w.split(' + ')">
+        <template v-if="j != 0">+</template>
+        <!-- eslint-disable-next-line vue/valid-v-for vue/require-v-for-key max-len -->
+        <a
+          :href="`/explore/${model.short_name}/gem-browser/compartment/${idfy(c)}`"
+          @click="handleRouterClick"
+        >
+          {{ c }}
+        </a>
+      </template>
+    </template>
+  </span>
+</template>
+
+<script>
+import { mapState } from 'vuex';
+import { idfy } from '@/helpers/utils';
+
+export default {
+  name: 'CompartmentLinks',
+  props: {
+    compartmentString: { type: String, required: true },
+    isReversible: { type: Boolean, required: true },
+  },
+  computed: {
+    ...mapState({
+      model: state => state.models.model,
+    }),
+  },
+  methods: {
+    idfy,
+  },
+};
+</script>


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes https://github.com/MetabolicAtlas/private-issues/issues/109.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Refactor: extract out a component for rendering compartment links
- New functionality: display compartments as links for interaction partners table

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="1503" alt="image" src="https://user-images.githubusercontent.com/423498/170241560-cbac775d-4b60-41cf-a058-d573c19d6cdf.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
  1. Visit an interaction partners page that contains a table of reactions at the bottom. For example: `/explore/Human-GEM/interaction-partners/MAM03177s`.
  2. Verify that the individual compartments are displayed as links and the links are working correctly.

**Further comments**  
<!-- Specify questions or related information -->
The issue description states the following: "_As part of this work, it is expected that the final string gets constructed correctly from the beginning, instead of being fixed later. See https://github.com/MetabolicAtlas/MetabolicAtlas/pull/644 for more details._" I reviewed the comments from that issue and I'm not sure what this is referring to. Please let me know if anyone remembers and if anything should be changed.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
