### PR TITLE
fix: remove only project specific docker items

### DIFF
--- a/proj.sh
+++ b/proj.sh
@@ -34,9 +34,7 @@ function stop-stack {
 }
 
 function clean-stack {
-  docker stop $(docker ps -a -q) || true
-  docker rm $(docker ps -a -q) || true
-  docker volume prune --force || true
+  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-local.yml down --rmi all --remove-orphans -v
 }
 
 function logs {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #816.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Removes only Metabolic Atlas specific docker items (containers, images, and volumes) instead of all docker items for the entire system.

**Testing**  
<!-- Please delete options that are not relevant -->
- A rebuild is needed ~~due to new dependencies~~ if you currently don't have the project stack built
- Instructions on how to test
  1. Use the latest `proj.sh` file: `source proj.sh`.
  2. (Optional) Build and start the project if necessary: `build-stack && start-stack`.
  3. (Optional) If you don't have any other docker related items, add one to help the verification step. For example: `docker pull hello-world && docker run hello-world`.
  4. Clean the stack: `clean-stack`.
  5. Verify that the project stops running and all of the related docker items are removed and all of the non-related items are not removed: `docker image ls -a && docker ps -a`.

<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
