### PR TITLE
fix: improve performance of GEM comparison query to avoid server timeout

### DIFF
--- a/api/src/neo4j/queries/compare.js
+++ b/api/src/neo4j/queries/compare.js
@@ -34,8 +34,8 @@ const compareThree = async ({ type, models }) => {
 
   const statement = `
 MATCH (a:${type}:${ma.model})-[:V${ma.version}]-(e:ExternalDb)-[:V${mb.version}]-(b:${type}:${mb.model})
+USING JOIN on e
 MATCH (a)-[:V${ma.version}]-(e)-[:V${mc.version}]-(c:${type}:${mc.model})
-MATCH (b)-[:V${mb.version}]-(e)-[:V${mc.version}]-(c)
 RETURN { ${ma.model}: COUNT(DISTINCT(a)), ${mb.model}: COUNT(DISTINCT(b)), ${mc.model}: COUNT(DISTINCT(c)) }
 `;
 
@@ -129,8 +129,8 @@ RETURN { own: COUNT(DISTINCT(a)) }
   if (mc) {
     commonStatement = `
 MATCH (a:${type}:${ma.model})-[:V${ma.version}]-(e:ExternalDb)-[:V${mb.version}]-(b:${type}:${mb.model})
+USING JOIN on e
 MATCH (a)-[:V${ma.version}]-(e)-[:V${mc.version}]-(c:${type}:${mc.model})
-MATCH (b)-[:V${mb.version}]-(e)-[:V${mc.version}]-(c)
 RETURN { common: COUNT(DISTINCT(a)) }
 `;
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #823.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Use `JOIN` to optimize cypher query and remove redundant part of the query. The time taken for query went from ~1.7min to ~20s on my machine.

In plain language, we are looking for all instances of model `A` where it shares a common `ExternalDb`(Cross Reference) with model `B` and model `C`. This is satisfied by the following two lines:

```graphql
MATCH (a:${type}:${ma.model})-[:V${ma.version}]-(e:ExternalDb)-[:V${mb.version}]-(b:${type}:${mb.model})
MATCH (a)-[:V${ma.version}]-(e)-[:V${mc.version}]-(c:${type}:${mc.model})
```

The next line, while technically correct, is completely unnecessary and slowed down the query:

```graphql
MATCH (b)-[:V${mb.version}]-(e)-[:V${mc.version}]-(c)
```

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
1. Visit the GEM Comparison page with three GEMs selected, for example: `/gems/comparison?models=FruitflyGem-1.2.0&models=HumanGem-1.11.0&models=MouseGem-1.3.0`.
2. Verify that the the comparison table loads faster (hopefully under 30s).
3. Click a comparison in the `others` row from the comparison table, for example as in screenshot below.
4. Verify that the comparison details, to the right of the comparison table, loads faster (hopefully under 30s).

![image](https://user-images.githubusercontent.com/423498/171145628-a91acf7a-9dfc-4a0c-a120-f517732f7763.png)


**Further comments**  
<!-- Specify questions or related information -->
While this is still not as fast as we would like, it's a significant improvement and should be within the current timeout limit of 30s. Please let me know if you have any ideas on how to further improve the performance.

This was a joint effort by @perjo and me.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
