### PR TITLE
feat: add PostgreSQL to the project for the enzyme database

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,6 @@ api/src/data/*.json
 
 # dataOverlay folder in API
 api/dataOverlay
+
+# PostgreSQL data
+pg/input_data/**/*.txt

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -53,3 +53,8 @@ services:
     environment:
       - FTP_IP=127.0.0.1
       - FLAGS=-Y 0 -d -d
+  pg:
+    volumes:
+      - ./pg/scripts:/scripts
+    ports:
+      - "127.0.0.1:5432:5432"

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -56,5 +56,6 @@ services:
   pg:
     volumes:
       - ./pg/scripts:/scripts
+      - ./pg/input_data:/input_data
     ports:
       - "127.0.0.1:5432:5432"

--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -71,5 +71,8 @@ services:
           cpus: '0.10'
           memory: 200M
 
+  pg:
+    restart: always
+
 volumes:
   letsencrypt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,13 @@ services:
     ports:
       - "21:21"
       - "${FTP_MIN_PORT}-${FTP_MAX_PORT}:${FTP_MIN_PORT}-${FTP_MAX_PORT}"
+  pg:
+    container_name: pg
+    image: postgres:14.3
+    environment:
+      - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+    networks:
+      - db-network
 
 networks:
   db-network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
       - "${FTP_MIN_PORT}-${FTP_MAX_PORT}:${FTP_MIN_PORT}-${FTP_MAX_PORT}"
   pg:
     container_name: pg
-    image: postgres:14.3
+    image: postgres:14.3-alpine
     environment:
       - POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
     networks:

--- a/env-local.env.sample
+++ b/env-local.env.sample
@@ -31,7 +31,7 @@ NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password-unhackable
 
 # These variables are used by PostgreSQL.
-POSTGRES_PASSWORD=DJSLpDdJHibHgX
+POSTGRES_PASSWORD=change-me
 
 # The variables below control the port range for the FTP connections.
 FTP_MIN_PORT=30000

--- a/env-local.env.sample
+++ b/env-local.env.sample
@@ -30,6 +30,9 @@ SERVER_NAME=localhost
 NEO4J_USERNAME=neo4j
 NEO4J_PASSWORD=password-unhackable
 
+# These variables are used by PostgreSQL.
+POSTGRES_PASSWORD=DJSLpDdJHibHgX
+
 # The variables below control the port range for the FTP connections.
 FTP_MIN_PORT=30000
 FTP_MAX_PORT=31000

--- a/pg/scripts/00-schema.sql
+++ b/pg/scripts/00-schema.sql
@@ -1,0 +1,41 @@
+-- ma-exec pg psql -f scripts/00-schema.sql -U postgres
+
+create table enzymes (
+    protein varchar(16) not null,
+    organism varchar(4) not null,
+    domain varchar(7),
+    ko char(6),
+    reaction_id char(6),
+    ec_number varchar(255) not null,
+    compound char(6),
+    kcat_values varchar(12),
+    km_values varchar(12)
+);
+
+create table compounds (
+    kegg char(6) not null,
+    name varchar(255),
+    formula varchar(50),
+    model_seed varchar(50),
+    bigg varchar(50),
+    chebi varchar(255),
+    metacyc varchar(255),
+    sabio_rk varchar(20),
+    reactome varchar(500)
+);
+
+create table ec (
+    ec varchar(50) not null,
+    name varchar(5000)
+);
+
+create table reactions (
+    kegg char(6) not null,
+    name varchar(255) not null,
+    equation varchar(255) not null,
+    rhea varchar(255) not null,
+    model_seed varchar(50),
+    bigg varchar(50),
+    metacyc varchar(255),
+    sabio_rk varchar(20)
+);

--- a/pg/scripts/01-seed-mock-data.sql
+++ b/pg/scripts/01-seed-mock-data.sql
@@ -1,0 +1,17 @@
+-- ma-exec pg psql -f scripts/01-seed-mock-data.sql -U postgres
+
+insert into enzymes
+select
+    'P' || a as protein,
+    'O' || b as organism,
+    'D' || c as domain,
+    'K' || a as ko,
+    'R' || d as reaction_id,
+    '1.1.1.' || d as ec_number,
+    'C' || c as compound,
+    round((random() * 50)::numeric, 4) as kcat_values,
+    round(random()::numeric, 4) as km_values
+from generate_series(1, 10) aa(a)
+cross join generate_series(1, 10) bb(b)
+cross join generate_series(1, 10) cc(c)
+cross join generate_series(1, 10) dd(d);

--- a/pg/scripts/01-seed-mock-data.sql
+++ b/pg/scripts/01-seed-mock-data.sql
@@ -7,7 +7,10 @@ select
     'D' || c as domain,
     'K' || a as ko,
     'R' || d as reaction_id,
-    '1.1.1.' || d as ec_number,
+    case when floor(random() + 0.5) = 1
+        then '1.1.1.' || 1
+        else '1.1.1.' || d || ';1.1.1.' || (d + 1 )
+    end as ec_number,
     'C' || c as compound,
     round((random() * 50)::numeric, 4) as kcat_values,
     round(random()::numeric, 4) as km_values

--- a/pg/scripts/init-schema.sql
+++ b/pg/scripts/init-schema.sql
@@ -1,4 +1,4 @@
--- ma-exec pg psql -f scripts/00-schema.sql -U postgres
+-- ma-exec pg psql -f scripts/init-schema.sql -U postgres
 
 create table enzymes (
     protein varchar(16) not null,
@@ -16,6 +16,7 @@ create table compounds (
     kegg char(6) not null,
     name varchar(255),
     formula varchar(50),
+    meta_net_x varchar(12),
     model_seed varchar(50),
     bigg varchar(50),
     chebi varchar(255),
@@ -31,11 +32,12 @@ create table ec (
 
 create table reactions (
     kegg char(6) not null,
-    name varchar(255) not null,
-    equation varchar(255) not null,
-    rhea varchar(255) not null,
-    model_seed varchar(50),
-    bigg varchar(50),
-    metacyc varchar(255),
+    name text,
+    equation text,
+    meta_net_x text,
+    rhea text,
+    model_seed text,
+    bigg text,
+    metacyc text,
     sabio_rk varchar(20)
 );

--- a/pg/scripts/seed-data.sql
+++ b/pg/scripts/seed-data.sql
@@ -1,0 +1,11 @@
+-- ma-exec pg psql -f scripts/seed-data.sql -U postgres
+
+copy enzymes from '/input_data/enzymes/abac.txt' delimiter E'\t';
+copy enzymes from '/input_data/enzymes/eco.txt' delimiter E'\t';
+copy enzymes from '/input_data/enzymes/hsa.txt' delimiter E'\t';
+copy enzymes from '/input_data/enzymes/neq.txt' delimiter E'\t';
+copy enzymes from '/input_data/enzymes/sce.txt' delimiter E'\t';
+
+copy compounds from '/input_data/supplementary/compound.txt' delimiter E'\t' CSV HEADER;
+copy ec from '/input_data/supplementary/ec.txt' quote E'\u0007' delimiter E'\t' CSV HEADER;
+copy reactions from '/input_data/supplementary/reaction.txt' delimiter E'\t' CSV HEADER;

--- a/pg/scripts/seed-mock-data.sql
+++ b/pg/scripts/seed-mock-data.sql
@@ -1,4 +1,4 @@
--- ma-exec pg psql -f scripts/01-seed-mock-data.sql -U postgres
+-- ma-exec pg psql -f scripts/seed-mock-data.sql -U postgres
 
 insert into enzymes
 select

--- a/proj.sh
+++ b/proj.sh
@@ -42,7 +42,7 @@ function logs {
 }
 
 function ma-exec {
-  docker compose --env-file $CHOSEN_ENV  -f docker-compose.yml -f docker-compose-local.yml exec $@
+  docker compose --env-file "$CHOSEN_ENV"  -f docker-compose.yml -f docker-compose-local.yml exec "$@"
 }
 
 function deploy-stack {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1008.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Add PostgreSQL to the project using docker.
- For the enzyme database, ddd scripts to initialize and seed the data.

**Testing**  
<!-- Please delete options that are not relevant -->
- A ~~rebuild~~restart (`start-stack`) is needed due to new dependencies
- Instructions on how to test
1. Update the `env-local.env` file and add the `POSTGRES_PASSWORD` environment variable. An example can be found in `env-local.env.sample`.
2. (Re)start the stack: `start-stack`. This should set up the new `pg` container
3. Verify that the PostgresQL container is up and running: `ma-exec pg psql -U postgres -c '\list'`.
4. Initialize the DB schema: `ma-exec pg psql -f scripts/init-schema.sql -U postgres`.
5. Add the input data files (currently incomplete). They were first posted [here](https://github.com/MetabolicAtlas/MetabolicAtlas/issues/1008#issuecomment-1144904853) and then [here](https://github.com/MetabolicAtlas/MetabolicAtlas/issues/1008#issuecomment-1148622936). Please use the `MainData` from the first link and the `supplOutput` data from the second link.
  i. Copy the contents of `MainData`, except for `README.txt`, into the `./pg/input_data/enzymes/` directory.
  ii. Copy the contents of `supplOutput` into the `./pg/input_data/supplementary/` directory. 
6. Seed the database using the input data: `ma-exec pg psql -f scripts/seed-data.sql -U postgres`. Edit: if this doesn't work please see [this comment](https://github.com/MetabolicAtlas/MetabolicAtlas/pull/1016#issuecomment-1149785950).
7. Verify that the database is setup correctly: `ma-exec pg psql -U postgres -c 'select * from enzymes limit 1'`. You can replace `enzymes` with `compounds`, `ec`, or `reactions` to test the other tables.

**Further comments**  
<!-- Specify questions or related information -->
- A third script to generate random data for the `enzymes` table is available at `./pg/scripts/seed-mock-data.sql`. I used this to help test the performance of the database for larger dataset. More info can be found [here](https://github.com/MetabolicAtlas/MetabolicAtlas/issues/1008#issuecomment-1148729227).
- The input data currently available is a small subset of what the complete data should be. I think the following things would make more sense to include once the complete data is available.
  - Decide on if the database creation should be done every time during `build-stack`, or optionally unless specified for example `build-stack --seed-pg`. The option could be useful if it takes a long time to seed the database.
  - Add instructions in the `README` about how to setup and deploy the new `pg` container.

This is a joint effort by @perjo and @e0, with the assistance of @feiranl and @Yu-sysbio providing the input data files. Please let me know if you have any questions or feedback.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
