### PR TITLE
fix: make sure that the PostgreSQL password is reset after deployment

### DIFF
--- a/proj.sh
+++ b/proj.sh
@@ -49,7 +49,7 @@ function deploy-stack {
   CHOSEN_ENV="env-${1:-$LOCALENV}.env"
   generate-data
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
-  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml exec -it pg psql -U postgres -c "alter user postgres with password '${POSTGRES_PASSWORD}';"
+  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml exec -d pg psql -U postgres -c "alter user postgres with password '${POSTGRES_PASSWORD}';"
   CHOSEN_ENV=$METATLAS_DEFAULT_ENV
 }
 

--- a/proj.sh
+++ b/proj.sh
@@ -49,6 +49,7 @@ function deploy-stack {
   CHOSEN_ENV="env-${1:-$LOCALENV}.env"
   generate-data
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
+  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml exec -it pg psql -U postgres -c "alter user postgres with password '${POSTGRES_PASSWORD}';"
   CHOSEN_ENV=$METATLAS_DEFAULT_ENV
 }
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1041 and is related to #1023.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Adds a command to the `deploy-stack` function that makes sure the password specified in the given `*.env` file is set.

**Testing**  
<!-- Please delete options that are not relevant -->
- A rebuild is needed due to new dependencies
- Instructions on how to test
1. Change the value of `POSTGRES_PASSWORD` in your `env-dev.env` file to something else.
2. Deploy to the dev server `deploy-stack dev`.
3. Verify that the `GotEnzymes` pages are working. For example `/gotenzymes/reaction/R01234`.

**Further comments**  
<!-- Specify questions or related information -->
The way things are setup now. The command to set the password runs after the command to deploy the stack. For this to happen the `pg` container must be up and running before the password command is run. This doesn't seem to be problem since the `ftp` container takes a while to setup properly and the `pg` container sets up before that. Maybe something good to keep in mind though.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
