### PR TITLE
3.0 release

### DIFF
--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -2,7 +2,7 @@
   "2022": [
     {
       "date": "2022-08-12",
-      "title": "Metabolic Atlas 3.0",
+      "title": "Metabolic Atlas 3.0 presents GotEnzymes",
       "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information about the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
     },
     {

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -3,7 +3,7 @@
     {
       "date": "2022-08-12",
       "title": "Metabolic Atlas 3.0 presents GotEnzymes",
-      "text": "We are delighted to announce the official release of <b>Metabolic Atlas 3.0</b> 🎉 In this major release we provide access to the newly created database <i>GotEnzymes</i> (article under consideration). GotEnzymes contains over 25.7 million predicted enzyme turnover numbers (k<sub>cat</sub>) for +5.8 million unique sequences and 4147 compounds, across 8099 species. The values are predicted by cutting-edge artificial intelligence tools. In addition, Metabolic Atlas has obtained an _Identifiers.org_ profile and has improved the _About_ pages. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
+      "text": "We are delighted to announce the official release of <b>Metabolic Atlas 3.0</b> 🎉 In this major release we provide access to the newly created database <i>GotEnzymes</i> (article under consideration). GotEnzymes contains over 25.7 million predicted enzyme turnover numbers (k<sub>cat</sub>) for +5.8 million unique sequences and 4147 compounds, across 8099 species. The values are predicted by cutting-edge artificial intelligence tools. In addition, Metabolic Atlas has obtained an <i>Identifiers.org</i> profile and has improved the <i>About</i> pages. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
     },
     {
       "date": "2022-06-01",

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -3,7 +3,7 @@
     {
       "date": "2022-06-30",
       "title": "Metabolic Atlas 3.0",
-      "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 million predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
+      "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 million predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information about the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
     },
     {
       "date": "2022-06-01",

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -1,6 +1,11 @@
 {
   "2022": [
     {
+      "date": "2022-06-30",
+      "title": "Metabolic Atlas 3.0",
+      "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 million predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
+    },
+    {
       "date": "2022-06-01",
       "title": "Metabolic Atlas 2.6 adds a feature to visualise model updates",
       "text": "<b>Metabolic Atlas 2.6</b> is out. In this minor release we have added a new feature for visualizing the history and development of the integrated GEMs, updated the model versions, improved the GEM comparison and the search functionality and fixed a number of bugs. Improvements of the readability and ease of navigation of the web page have been added as well. More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/2.6' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/record/6627419' target='_blank'>on Zenodo</a>."

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -3,7 +3,9 @@
     {
       "date": "2022-08-12",
       "title": "Metabolic Atlas 3.0 presents GotEnzymes",
-      "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information about the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
+      "text": "We are delighted to announce the official release of <b>Metabolic Atlas 3.0</b> 🎉 In this major release we provide access to the newly created database <i>GotEnzymes</i> (article under consideration). GotEnzymes contains over 25.7 million predicted enzyme turnover numbers (k<sub>cat</sub>) for +5.8 million unique sequences and 4147 compounds, across 8099 species. The values are predicted by cutting-edge artificial intelligence tools. In addition, Metabolic Atlas has obtained an _Identifiers.org_ profile and has improved the _About_ pages.
+<br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>.
+."
     },
     {
       "date": "2022-06-01",

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -3,9 +3,7 @@
     {
       "date": "2022-08-12",
       "title": "Metabolic Atlas 3.0 presents GotEnzymes",
-      "text": "We are delighted to announce the official release of <b>Metabolic Atlas 3.0</b> 🎉 In this major release we provide access to the newly created database <i>GotEnzymes</i> (article under consideration). GotEnzymes contains over 25.7 million predicted enzyme turnover numbers (k<sub>cat</sub>) for +5.8 million unique sequences and 4147 compounds, across 8099 species. The values are predicted by cutting-edge artificial intelligence tools. In addition, Metabolic Atlas has obtained an _Identifiers.org_ profile and has improved the _About_ pages.
-<br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>.
-."
+      "text": "We are delighted to announce the official release of <b>Metabolic Atlas 3.0</b> 🎉 In this major release we provide access to the newly created database <i>GotEnzymes</i> (article under consideration). GotEnzymes contains over 25.7 million predicted enzyme turnover numbers (k<sub>cat</sub>) for +5.8 million unique sequences and 4147 compounds, across 8099 species. The values are predicted by cutting-edge artificial intelligence tools. In addition, Metabolic Atlas has obtained an _Identifiers.org_ profile and has improved the _About_ pages. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
     },
     {
       "date": "2022-06-01",

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -3,7 +3,7 @@
     {
       "date": "2022-06-30",
       "title": "Metabolic Atlas 3.0",
-      "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 million predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information about the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
+      "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information about the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
     },
     {
       "date": "2022-06-01",

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -3,7 +3,7 @@
     {
       "date": "2022-06-01",
       "title": "Metabolic Atlas 2.6 adds a feature to visualise model updates",
-      "text": "<b>Metabolic Atlas 2.6</b> is out. In this minor release we have added a new feature for visualizing the history and development of the integrated GEMs, updated the model versions, improved the GEM comparison and the search functionality and fixed a number of bugs. Improvements of the readability and ease of navigation of the web page have been added as well. More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/2.6' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
+      "text": "<b>Metabolic Atlas 2.6</b> is out. In this minor release we have added a new feature for visualizing the history and development of the integrated GEMs, updated the model versions, improved the GEM comparison and the search functionality and fixed a number of bugs. Improvements of the readability and ease of navigation of the web page have been added as well. More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/2.6' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/record/6627419' target='_blank'>on Zenodo</a>."
     },
     {
       "date": "2022-04-04",

--- a/frontend/src/content/news.json
+++ b/frontend/src/content/news.json
@@ -1,7 +1,7 @@
 {
   "2022": [
     {
-      "date": "2022-06-30",
+      "date": "2022-08-12",
       "title": "Metabolic Atlas 3.0",
       "text": "<b>Metabolic Atlas 3.0</b> is out! In this major release we provide access to the newly created database <i>GotEnzymes</i>. This contains over 25,794,195 predicted k<sub>cat</sub> from 8,099 species. The values are predicted by cutting-edge artificial intelligence tools. For more information about the prediction methods, please have a look at <a href='https://doi.org/10.1038/s41929-022-00798-z'><i>Deep learning-based k<sub>cat</sub> prediction enables improved enzyme-constrained model reconstruction</i></a>. <br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>."
     },


### PR DESCRIPTION
In this major release we provide access to the newly created database <i>GotEnzymes</i> (article under consideration). GotEnzymes contains over 25.7 million predicted enzyme turnover numbers (k<sub>cat</sub>) for +5.8 million unique sequences and 4147 compounds, across 8099 species. The values are predicted by cutting-edge artificial intelligence tools. These new data are stored in a newly-added Postgres database that is seamlessly integrated into the software stack. In addition, Metabolic Atlas has obtained an _Identifiers.org_ profile and has improved the _About_ pages.
<br> More details can be found <a href='https://github.com/MetabolicAtlas/MetabolicAtlas/releases/tag/3.0' target='_blank'>on GitHub</a> or <a href='https://zenodo.org/badge/latestdoi/53664497' target='_blank'>on Zenodo</a>.

**The work on GotEnzymes has been divided across the following issues:**
- #1023
- #1015
- #1014
- #1041 
- #1024
- #1032
- #1026
- #1039
- #1034
- #1027
- #1060
- #1065
- #1061
- #1086

**Other Metabolic Atlas:**
-  Issue: obtain profile on [identifiers.org](https://identifiers.org)
- #907
- #916
- #1035
- #1063

**Project maintenance**
- #1022
- #963
- #1049
- [Improve documentation about 3D network viewer](https://github.com/MetabolicAtlas/3d-network-viewer/issues/38)

