### PR TITLE
feat: increase field width for enzymes table

### DIFF
--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div id="enzymes-table">
     <div class="field columns">
       <div class="column"></div>
       <div class="column is-narrow">
@@ -238,4 +238,8 @@ export default {
 };
 </script>
 
-<style lang="scss"></style>
+<style lang="scss">
+#enzymes-table .footer__navigation__page-info__current-entry {
+  width: 50px;
+}
+</style>


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1039.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Other

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Increases the width of the input field for page number for the enzymes table.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![2022-06-29-143639_378x96_scrot](https://user-images.githubusercontent.com/1029190/176437771-40ec6225-377b-4070-a94d-eca45cba61d2.png)


**Testing**  
<!-- Please delete options that are not relevant -->
- Go to for example `gotenzymes/compound/C00003` and look at the pagination for the table. Verify that you can input a sufficient number of digits.


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
