### PR TITLE
fix: improve ec search

### DIFF
--- a/api/src/gotEnzymes/index.js
+++ b/api/src/gotEnzymes/index.js
@@ -7,4 +7,13 @@ import getOrganism from 'gotEnzymes/organism';
 import getReaction from 'gotEnzymes/reaction';
 import search from 'gotEnzymes/search';
 
-export { getCompound, getDomain, getEc, getEnzymes, getGene, getReaction, getOrganism, search };
+export {
+  getCompound,
+  getDomain,
+  getEc,
+  getEnzymes,
+  getGene,
+  getReaction,
+  getOrganism,
+  search,
+};

--- a/api/src/gotEnzymes/search.js
+++ b/api/src/gotEnzymes/search.js
@@ -16,13 +16,20 @@ const search = async searchTerm => {
     where kegg = ${searchTerm}
   `;
 
+  const ecMatchQuery = sql`
+    select 'ec' as type, ec as id, ec as match, ${sql`similarity(ec, ${searchTerm})`} as score
+    from ec
+    where ec LIKE ${searchTerm} || '%'
+  `;
+
   await sql`set pg_trgm.similarity_threshold = 0.25`; // this allows more matches, default is 0.3
-  const [fuzzyResults, geneResults] = await Promise.all([
+  const [fuzzyResults, geneResults, ecResults] = await Promise.all([
     fuzzyQuery,
     geneMatchQuery,
+    ecMatchQuery,
   ]);
 
-  return [...geneResults, ...fuzzyResults].slice(0, 10);
+  return [...geneResults, ...ecResults, ...fuzzyResults].slice(0, 10);
 };
 
 export default search;

--- a/api/src/gotEnzymes/search.js
+++ b/api/src/gotEnzymes/search.js
@@ -3,7 +3,14 @@ import sql from 'gotEnzymes/db';
 const search = async searchTerm => {
   const term = searchTerm.toLowerCase();
   const fuzzyQuery = sql`
-    select type, id, match, ${sql`similarity(match, ${term})`} as score
+    select
+      type,
+      id,
+      match,
+      ${sql`similarity(
+        ${sql`replace(match, '.', 'a')`},
+        ${sql`replace(${term}, '.', 'a')`}
+      )`} as score
     from multi_search
     where match % ${term}
     order by score desc
@@ -16,20 +23,13 @@ const search = async searchTerm => {
     where kegg = ${searchTerm}
   `;
 
-  const ecMatchQuery = sql`
-    select 'ec' as type, ec as id, ec as match, ${sql`similarity(ec, ${searchTerm})`} as score
-    from ec
-    where ec LIKE ${searchTerm} || '%'
-  `;
-
   await sql`set pg_trgm.similarity_threshold = 0.25`; // this allows more matches, default is 0.3
-  const [fuzzyResults, geneResults, ecResults] = await Promise.all([
+  const [fuzzyResults, geneResults] = await Promise.all([
     fuzzyQuery,
     geneMatchQuery,
-    ecMatchQuery,
   ]);
 
-  return [...geneResults, ...ecResults, ...fuzzyResults].slice(0, 10);
+  return [...geneResults, ...fuzzyResults].slice(0, 10);
 };
 
 export default search;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1060. Joint work with @e0.

The `.` in the EC codes are replaced by a standard character (`a`) in the psql search, so that the standard similarity score works as expected.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [X] Bug fix (non-breaking change which fixes an issue)

**List of changes made**  
<!-- Specify what changes have been made and why -->
- Use replacement of special character to improve search results for ECs.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![2022-08-10-174151_973x509_scrot](https://user-images.githubusercontent.com/1029190/183948144-0648edc0-8874-4615-9dcc-b65609969a88.png)



**Testing**  
<!-- Please delete options that are not relevant -->
- Try searching for example `7.1.1.1` and make sure the first hit is the exact match
- Search for `1.1.3` and see that the results are relevant
- Also try other types of searches to make sure the work as expected and that performance is not affected.


**Definition of Done checklist**  
- [X] My code meets the Acceptance Criteria
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
