### PR TITLE
feat: gotenzymes loader

### DIFF
--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -16,11 +16,17 @@
       :rows="enzymes"
       :sort-options="{ enabled: true }"
       :pagination-options="tablePaginationOptions"
+      :is-loading="showEnzymesLoader"
       :total-rows="totalRows"
       @on-page-change="onPageChange"
       @on-sort-change="onSortChange"
       @on-column-filter="onColumnFilter"
     >
+      <div slot="emptystate">No enzymes found</div>
+      <template slot="loadingContent">
+        <div>
+          <loader /></div
+      ></template>
       <template slot="table-row" slot-scope="props">
         <template v-if="linkableFields.includes(props.column.field)">
           <template v-if="props.column.field === 'ec_number'">
@@ -55,6 +61,7 @@
 
 <script>
 import { mapState } from 'vuex';
+import Loader from '@/components/Loader';
 import { VueGoodTable } from 'vue-good-table';
 import ExportTSV from '@/components/shared/ExportTSV';
 import RangeFilter from '@/components/shared/RangeFilter';
@@ -65,6 +72,7 @@ export default {
     VueGoodTable,
     ExportTSV,
     RangeFilter,
+    Loader,
   },
   props: {
     initialFilter: { type: Object, default: () => {} },
@@ -74,6 +82,7 @@ export default {
   data() {
     return {
       linkableFields: ['compound', 'domain', 'ec_number', 'gene', 'organism', 'reaction_id'],
+      showEnzymesLoader: true,
       columns: [
         {
           label: 'Gene',
@@ -152,6 +161,7 @@ export default {
   },
   methods: {
     async setup() {
+      this.showEnzymesLoader = true;
       this.serverPaginationOptions = {
         ...this.serverPaginationOptions,
         filters: {
@@ -161,6 +171,7 @@ export default {
       };
 
       await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      this.showEnzymesLoader = false;
     },
     async onPageChange({ currentPage }) {
       this.serverPaginationOptions = {
@@ -186,6 +197,7 @@ export default {
       await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
     },
     async onColumnFilter({ columnFilters }) {
+      this.showEnzymesLoader = true;
       this.serverPaginationOptions = {
         ...this.serverPaginationOptions,
         filters: {
@@ -195,6 +207,7 @@ export default {
       };
 
       await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      this.showEnzymesLoader = false;
     },
     formatToTSV() {
       let tsvContent = `${this.columns.map(e => e.label).join('\t')}\n`;
@@ -212,6 +225,7 @@ export default {
     async handleRangeFilterUpdate({ field, remove, ...payload }) {
       // payload can look like { min: 0, max: 1 }
 
+      this.showEnzymesLoader = true;
       const filters = { ...this.serverPaginationOptions.filters };
       if (remove) {
         delete filters[field];
@@ -225,6 +239,7 @@ export default {
       };
 
       await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      this.showEnzymesLoader = false;
     },
   },
 };

--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -6,6 +6,7 @@
         <ExportTSV
           :filename="`Enzymes for ${componentType} ${componentId}.tsv`"
           :format-function="formatToTSV"
+          :disabled="showEnzymesLoader"
         ></ExportTSV>
       </div>
     </div>

--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -174,6 +174,7 @@ export default {
       this.showEnzymesLoader = false;
     },
     async onPageChange({ currentPage }) {
+      this.showEnzymesLoader = true;
       this.serverPaginationOptions = {
         ...this.serverPaginationOptions,
         pagination: {
@@ -183,8 +184,10 @@ export default {
       };
 
       await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      this.showEnzymesLoader = false;
     },
     async onSortChange([{ field, type }]) {
+      this.showEnzymesLoader = true;
       this.serverPaginationOptions = {
         ...this.serverPaginationOptions,
         pagination: {
@@ -195,6 +198,7 @@ export default {
       };
 
       await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      this.showEnzymesLoader = false;
     },
     async onColumnFilter({ columnFilters }) {
       this.showEnzymesLoader = true;

--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -23,7 +23,9 @@
       @on-sort-change="onSortChange"
       @on-column-filter="onColumnFilter"
     >
-      <div slot="emptystate">No enzymes found</div>
+      <div slot="emptystate">
+        <div class="vgt-center-align vgt-text-disabled">No data found</div>
+      </div>
       <template slot="loadingContent">
         <div>
           <loader /></div

--- a/frontend/src/components/shared/ExportTSV.vue
+++ b/frontend/src/components/shared/ExportTSV.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <a class="button is-primary is-outlined" @click="exportToTSV">
+    <a :disabled="disabled" class="button is-primary is-outlined" @click="exportToTSV">
       <span class="icon is-large"><i class="fa fa-download"></i></span>
       <span>Export to TSV</span>
     </a>
@@ -22,6 +22,7 @@ export default {
     arg: [Number, String, Object, Array],
     filename: String,
     formatFunction: Function,
+    disabled: Boolean,
   },
   data() {
     return {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1075.

<!-- Include below a description of the changes proposed in the pull request -->
Adds loader for the enzymes table.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
The loader is shown when:
- a new table is being loaded
- filtering is done
- sorting is done
- next/previous page is clicked
The download button is disabled when the table is loading

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![2022-08-17-153812_781x344_scrot](https://user-images.githubusercontent.com/1029190/185148393-f7f104a9-9230-4d9d-bcb9-56a9679d36e9.png)


**Testing**  
<!-- Please delete options that are not relevant -->
- To see better how the loader looks and behaves, you can add these lines
```
  const sleep = ms => new Promise(r => setTimeout(r, ms));
  await sleep(1000);
```
to `api/src/endpoints/gotEnzymes.js`, line 113
- Go to eg `gotenzymes/compound/C00003` and try reloading the page, sorting and filtering the columns, moving to another enzymes page etc.

**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [X] My code meets the Acceptance Criteria
- [X] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [X] I have performed a self-review of my own code and commented any hard-to-understand areas
- [X] Tests and lint/format validations are passing
- [X] My changes generate no new warnings
