### PR TITLE
feat: use class or id selectors in for scoped css

### DIFF
--- a/frontend/src/components/IdInModels.vue
+++ b/frontend/src/components/IdInModels.vue
@@ -17,7 +17,7 @@
         </template>
         <template v-else> not used by any of the integrated models. </template>
       </p>
-      <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
+      <ul class="models-list is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
         <li v-for="(components, model) in compGroupedByModel" :key="model" class="my-1">
           {{ model }} {{ components[0].version }}
           <ul class="is-flex-direction-column is-align-items-flex-start mb-4 ml-5">
@@ -110,10 +110,10 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-ul {
+.models-list {
   list-style: disc outside none;
 }
-ul ul {
+.models-list ul {
   list-style: circle outside none;
 }
 </style>

--- a/frontend/src/components/Loader.vue
+++ b/frontend/src/components/Loader.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="container is-fullhd is-centered has-text-centered">
     <a class="button is-primary is-inverted is-outlined is-large is-loading"></a>
-    <p class="is-size-5">{{ message }}</p>
+    <p class="loader-message is-size-5">{{ message }}</p>
   </div>
 </template>
 
@@ -15,7 +15,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-p {
+.loader-message {
   line-height: 3em;
 }
 </style>

--- a/frontend/src/components/NotFound.vue
+++ b/frontend/src/components/NotFound.vue
@@ -6,11 +6,11 @@
       <template v-if="type">
         <p class="title is-size-5">
           <span class="is-capitalized">{{ type }}</span>
-          <code>{{ componentId }}</code>
+          <code class="code">{{ componentId }}</code>
           not found
           <template v-if="type !== 'model'">
             in
-            <code>{{ model.short_name }}</code>
+            <code class="code">{{ model.short_name }}</code>
           </template>
         </p>
         <p v-if="type === 'model'">{{ messages.modelNotFound }}</p>
@@ -71,7 +71,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-code {
+.code {
   font-size: 1em;
   padding-top: 0px;
   padding-bottom: 0px;

--- a/frontend/src/components/explorer/mapViewer/MissingReactionModal.vue
+++ b/frontend/src/components/explorer/mapViewer/MissingReactionModal.vue
@@ -144,5 +144,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped></style>

--- a/frontend/src/components/shared/ComparisonMatrix.vue
+++ b/frontend/src/components/shared/ComparisonMatrix.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-if="mergedComparisons" class="table-container">
-    <table class="table">
+    <table class="table comparison-matrix">
       <thead>
         <tr>
           <th class="has-nowrap px-3 py-3"></th>
@@ -189,7 +189,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-table {
+.comparison-matrix {
   caption-side: bottom;
 
   caption {

--- a/frontend/src/components/shared/RangeFilter.vue
+++ b/frontend/src/components/shared/RangeFilter.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="is-flex">
+  <div class="range-filter is-flex">
     <input
       v-debounce:300ms="minChange"
       :class="{ 'input is-danger': !validMin }"
@@ -80,7 +80,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
-div {
+.range-filter {
   width: 125px;
 }
 </style>

--- a/frontend/src/layouts/AboutLayout.vue
+++ b/frontend/src/layouts/AboutLayout.vue
@@ -35,5 +35,3 @@ export default {
   },
 };
 </script>
-
-<style lang="scss" scoped></style>


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #917.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Make sure `class` or `id` is used for scoped styling.
- Remove unused `style` blocks.

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
Please test the following pages and verify that things look the same as before. The new selectors can be found from the PR changes.
- `/identifier/KEGG/C00222`, file: `frontend/src/components/IdInModels.vue`
- `/gotenzymes/reaction/R01677`
  - file: `frontend/src/components/Loader.vue` (note that it could be difficult to see the loader message if the page loads too fast)
  - file: `frontend/src/components/shared/RangeFilter.vue`
- `/explore/Human-GEM/gem-browser/metabolite/123`, file: `frontend/src/components/NotFound.vue`
- `/gems/comparison?models=FruitflyGem-1.2.0&models=HumanGem-1.11.0`, file: `frontend/src/components/shared/ComparisonMatrix.vue`

**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
