### PR TITLE
Fix: search limit inconsistency

### DIFF
--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -242,7 +242,9 @@ LIMIT 50
         metaboliteIds: groupedByComponents['Metabolite'] || [],
         model,
         version: v,
-        limit,
+        limit:
+          (groupedByComponents['CompartmentalizedMetabolite'] || []).length +
+          (groupedByComponents['Metabolite'] || []).length,
       }),
       fetchGenes({
         ids: groupedByComponents['Gene'],

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -45,12 +45,12 @@ WITH apoc.map.mergeList(apoc.coll.flatten(
 )) as metabolites, mid
 RETURN metabolites {mid: mid, .*}
 `;
-
   if (limit) {
     statement += `
 LIMIT ${limit}
 `;
   }
+
   return queryListResult(statement);
 };
 
@@ -225,9 +225,7 @@ LIMIT ${limit}
         metaboliteIds: groupedByComponents['Metabolite'] || [],
         model,
         version: v,
-        limit:
-          (groupedByComponents['CompartmentalizedMetabolite'] || []).length +
-          (groupedByComponents['Metabolite'] || []).length,
+        limit,
       }),
       fetchGenes({ ids: groupedByComponents['Gene'], model, version: v }),
       fetchReactions({
@@ -257,24 +255,42 @@ LIMIT ${limit}
     compartments,
   };
 
-  const resWithScore = {};
+  let resWithScore = [];
   for (const [component, result] of Object.entries(resObj)) {
     if (result) {
-      resWithScore[component] = result.map(obj => ({
-        ...obj,
-        score: getScore(obj, uniqueIds),
-      }));
-    } else {
-      resWithScore[component] = [];
+      resWithScore = resWithScore.concat(
+        result.map(obj => ({
+          ...obj,
+          score: getScore(obj, uniqueIds),
+          component,
+        }))
+      );
+    }
+  }
+  // sort all results by score in descending order
+  resWithScore.sort((a, b) => b.score - a.score);
+
+  // take only <= limit number of results and group them by components
+  const resWithScoreGroupedByComponent = resWithScore
+    .slice(0, limit)
+    .reduce(function (r, a) {
+      r[a.component] = r[a.component] || [];
+      r[a.component].push(a);
+      return r;
+    }, Object.create(null));
+
+  for (const component of Object.keys(resObj)) {
+    if (!(component in resWithScoreGroupedByComponent)) {
+      resWithScoreGroupedByComponent[component] = [];
     }
   }
 
   return {
-    metabolite: resWithScore.metabolites,
-    gene: resWithScore.genes,
-    reaction: resWithScore.reactions,
-    subsystem: resWithScore.subsystems,
-    compartment: resWithScore.compartments,
+    metabolite: resWithScoreGroupedByComponent.metabolites,
+    gene: resWithScoreGroupedByComponent.genes,
+    reaction: resWithScoreGroupedByComponent.reactions,
+    subsystem: resWithScoreGroupedByComponent.subsystems,
+    compartment: resWithScoreGroupedByComponent.compartments,
   };
 };
 

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -25,8 +25,10 @@ WITH DISTINCT(
                 THEN { id: node.id, labels: labelList, score: score }
 		ELSE { id: parentNode.id, labels: LABELS(parentNode), score: score }
 	END
-) as r 
-WHERE any(r IN r.labels WHERE r="${model}")
+) as r
+WHERE
+	any(r IN r.labels WHERE r="${model}")
+	AND any(r IN r.labels WHERE r="${component}")
 RETURN r
 `;
 

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -88,7 +88,7 @@ RETURN metabolites {mid: mid, .*}
 `;
   // limit is applied for CompartmentalizedMetabolite again since the number of
   // IDs for Metabolite and CompartmentalizedMetabolite together may exceed the
-  // at the first step when fethcing unique IDs
+  // at the first step when fetching unique IDs
   if (limit) {
     statement += `
 LIMIT ${limit}

--- a/api/src/neo4j/queries/search/modelSearch.js
+++ b/api/src/neo4j/queries/search/modelSearch.js
@@ -225,7 +225,9 @@ LIMIT ${limit}
         metaboliteIds: groupedByComponents['Metabolite'] || [],
         model,
         version: v,
-        limit,
+        limit:
+          (groupedByComponents['CompartmentalizedMetabolite'] || []).length +
+          (groupedByComponents['Metabolite'] || []).length,
       }),
       fetchGenes({ ids: groupedByComponents['Gene'], model, version: v }),
       fetchReactions({

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -6,7 +6,7 @@ describe('gem search', () => {
     await driver.close();
   });
 
-  test('gem search should have max 10 results per type', async () => {
+  test('gem search should have max 10 results per component type', async () => {
     const data = await search({
       searchTerm: 'Retinol+metabolism',
       model: 'HumanGem',

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -6,18 +6,23 @@ describe('gem search', () => {
     await driver.close();
   });
 
-  test('gem search should have max 50 results per component type', async () => {
+  test('gem search should have max 50 results', async () => {
     const data = await search({
-      searchTerm: 'H2O',
+      searchTerm: 'Retinol+metabolism',
       model: 'HumanGem',
       version: HUMAN_GEM_VERSION,
     });
 
     expect(Object.keys(data)).toContain('Human-GEM');
+    let length = 0;
+    for (const component of Object.keys(data['Human-GEM'])) {
+      if (component !== 'name') {
+        length += data['Human-GEM'][component].length;
+      }
+    }
 
-    const { metabolite } = data['Human-GEM'];
-    expect(metabolite.length).toBeGreaterThan(0);
-    expect(metabolite.length).toBeLessThanOrEqual(50);
+    expect(length).toBeGreaterThan(0);
+    expect(length).toBeLessThanOrEqual(50);
   });
 
   test('gem search should receive sensible ranking scores', async () => {

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -6,7 +6,7 @@ describe('gem search', () => {
     await driver.close();
   });
 
-  test('gem search should have max 10 results per component type', async () => {
+  test('gem search should have max 10 results per type', async () => {
     const data = await search({
       searchTerm: 'Retinol+metabolism',
       model: 'HumanGem',

--- a/api/test/searchGem.test.js
+++ b/api/test/searchGem.test.js
@@ -6,7 +6,7 @@ describe('gem search', () => {
     await driver.close();
   });
 
-  test('gem search should have max 50 results', async () => {
+  test('gem search should have max 10 results per type', async () => {
     const data = await search({
       searchTerm: 'Retinol+metabolism',
       model: 'HumanGem',
@@ -14,15 +14,13 @@ describe('gem search', () => {
     });
 
     expect(Object.keys(data)).toContain('Human-GEM');
-    let length = 0;
-    for (const component of Object.keys(data['Human-GEM'])) {
-      if (component !== 'name') {
-        length += data['Human-GEM'][component].length;
-      }
+    for (const component of Object.keys(data['Human-GEM']).filter(
+      c => c != 'name'
+    )) {
+      const { length } = data['Human-GEM'][component];
+      expect(length).toBeGreaterThanOrEqual(0);
+      expect(length).toBeLessThanOrEqual(10);
     }
-
-    expect(length).toBeGreaterThan(0);
-    expect(length).toBeLessThanOrEqual(50);
   });
 
   test('gem search should receive sensible ranking scores', async () => {

--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -528,9 +528,9 @@
           <p>
             The
             <i>Quick search</i>
-            is restricted to the selected GEM on the left side of searching bar and limited to 50
-            results, however, a maximum of 10 rows per type are shown. Alternatively, one can click
-            on the banner under the search input field to run a
+            is restricted to the selected GEM on the left side of searching bar and limited to 10
+            results per component type. Alternatively, one can click on the banner under the search
+            input field to run a
             <i>Global Search</i>, where the term is searched among all the integrated models'
             components and is unrestricted. To learn more about the search term possibilities, go to
             the

--- a/frontend/src/components/Documentation.vue
+++ b/frontend/src/components/Documentation.vue
@@ -529,8 +529,8 @@
             The
             <i>Quick search</i>
             is restricted to the selected GEM on the left side of searching bar and limited to 50
-            results per component type. Alternatively, one can click on the banner under the search
-            input field to run a
+            results, however, a maximum of 10 rows per type are shown. Alternatively, one can click
+            on the banner under the search input field to run a
             <i>Global Search</i>, where the term is searched among all the integrated models'
             components and is unrestricted. To learn more about the search term possibilities, go to
             the

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -49,7 +49,7 @@
         class="notification is-large is-unselectable has-text-centered is-clickable py-1 mb-1"
         @mousedown="globalSearch()"
       >
-        Limited to 50 results (max 10 per type). Click here to search all integrated GEMs
+        Limited to 10 rows per type. Click here to search all integrated GEMs
       </div>
       <div v-show="!showLoader" v-if="searchResults.length !== 0" class="resList">
         <template v-for="type in componentTypeOrder">

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -49,7 +49,7 @@
         class="notification is-large is-unselectable has-text-centered is-clickable py-1 mb-1"
         @mousedown="globalSearch()"
       >
-        Limited to 10 rows per type. Click here to search all integrated GEMs
+        Limited to 10 results per type. Click here to search all integrated GEMs
       </div>
       <div v-show="!showLoader" v-if="searchResults.length !== 0" class="resList">
         <template v-for="type in componentTypeOrder">

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -49,7 +49,7 @@
         class="notification is-large is-unselectable has-text-centered is-clickable py-1 mb-1"
         @mousedown="globalSearch()"
       >
-        Limited to 10 results per type. Click here to search all integrated GEMs
+        Limited to 50 results. Click here to search all integrated GEMs
       </div>
       <div v-show="!showLoader" v-if="searchResults.length !== 0" class="resList">
         <template v-for="type in componentTypeOrder">

--- a/frontend/src/components/explorer/gemBrowser/GemSearch.vue
+++ b/frontend/src/components/explorer/gemBrowser/GemSearch.vue
@@ -49,7 +49,7 @@
         class="notification is-large is-unselectable has-text-centered is-clickable py-1 mb-1"
         @mousedown="globalSearch()"
       >
-        Limited to 50 results. Click here to search all integrated GEMs
+        Limited to 50 results (max 10 per type). Click here to search all integrated GEMs
       </div>
       <div v-show="!showLoader" v-if="searchResults.length !== 0" class="resList">
         <template v-for="type in componentTypeOrder">

--- a/frontend/src/store/modules/search.js
+++ b/frontend/src/store/modules/search.js
@@ -76,9 +76,7 @@ const getters = {
           }
           return {
             topScore: v.topScore,
-            results: v.results
-              .sort((a, b) => sortResultsScore(a, b, state.searchTermString))
-              .slice(0, 10),
+            results: v.results.sort((a, b) => sortResultsScore(a, b, state.searchTermString)),
           };
         })(),
       ])

--- a/frontend/src/store/modules/search.js
+++ b/frontend/src/store/modules/search.js
@@ -76,7 +76,9 @@ const getters = {
           }
           return {
             topScore: v.topScore,
-            results: v.results.sort((a, b) => sortResultsScore(a, b, state.searchTermString)),
+            results: v.results
+              .sort((a, b) => sortResultsScore(a, b, state.searchTermString))
+              .slice(0, 10),
           };
         })(),
       ])

--- a/frontend/src/store/modules/search.js
+++ b/frontend/src/store/modules/search.js
@@ -76,9 +76,7 @@ const getters = {
           }
           return {
             topScore: v.topScore,
-            results: v.results
-              .sort((a, b) => sortResultsScore(a, b, state.searchTermString))
-              .slice(0, 10),
+            results: v.results.sort((a, b) => sortResultsScore(a, b, state.searchTermString)),
           };
         })(),
       ])
@@ -101,7 +99,7 @@ const actions = {
       version: model.apiVersion,
       searchTerm: state.searchTermString,
       model: model.apiName,
-      limit: 50,
+      limit: 10,
       a: { model, metabolitesAndGenesOnly },
     };
     const results = await searchApi.search(payload);


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #968 and #848 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
1. The results of GemSearch are sorted by score and <= limit number of top ranked results are returned. This makes sure that the parameter `limit` is more meaningful. 
2. The notification message in GemSearch is changed to `Limited to 50 results (max 10 per type)` to reflect that the limit is for all components, but when showing on the frontend, at maximum 10 per type are shown.
3. The test for GemSearch is updated to reflect that the limit is for all components.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->

**Further comments**  
<!-- Specify questions or related information -->
The results of GemSearch are sometimes different compared to before since some of the low scoring hits exceeding limit 50 are excluded. 

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
