### PR TITLE
feat: improve filtering matches

### DIFF
--- a/api/src/gotEnzymes/enzyme.js
+++ b/api/src/gotEnzymes/enzyme.js
@@ -19,11 +19,9 @@ const getFiltersQueries = filters => {
 
     if (value && value.length > 0) {
       if (field === 'ec_number') {
-        filtersQueries.push(
-          sql`array[${sql`${value.toString()}`}] <@ ${sql`string_to_array(ec_number, ';')`}`
-        );
+        filtersQueries.push(sql`ec_number ~~* ${`%${value.toString()}%`}`);
       } else {
-        filtersQueries.push(sql`${sql(field)} = ${value.toString()}`);
+        filtersQueries.push(sql`${sql(field)} like ${`%${value.toString()}%`}`);
       }
     }
   }

--- a/api/src/gotEnzymes/enzyme.js
+++ b/api/src/gotEnzymes/enzyme.js
@@ -19,9 +19,11 @@ const getFiltersQueries = filters => {
 
     if (value && value.length > 0) {
       if (field === 'ec_number') {
-        filtersQueries.push(sql`ec_number ~~* ${`%${value.toString()}%`}`);
+        filtersQueries.push(sql`ec_number ilike ${`%${value.toString()}%`}`);
       } else {
-        filtersQueries.push(sql`${sql(field)} like ${`%${value.toString()}%`}`);
+        filtersQueries.push(
+          sql`${sql(field)} ilike ${`%${value.toString()}%`}`
+        );
       }
     }
   }

--- a/project-words.txt
+++ b/project-words.txt
@@ -77,6 +77,7 @@ Hotjar
 Hotjar's
 hoverable
 Hyltander
+ilike
 inchi
 Intawat
 jaccard


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1112 and was created by @e0 and @inghylt 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Using `ILIKE` to allow users to filter the enzymes table using partial and case insensitive matches 

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
- Visit https://dev.metabolicatlas.org/gotenzymes and play around with different filtering in the enzymes table. Note that on dev the results are cached so don't use the same filter search every time.

**Further comments**  
<!-- Specify questions or related information -->
Please only focus on the response time of applying filters.The response time for gotEnzymes enzymes table is slower than before in general, but it should be possible to separate the queries between populating the entire enzymes table vs applying filters. That will be implemented if the filtering response time is acceptable.

The  filter response time could perhaps be improved by creating index using gist (that would also enable us to try out fuzzy searching as used [here](https://github.com/MetabolicAtlas/MetabolicAtlas/blob/3decdd333e070889890869a3c8162caaaafdda7e/api/src/gotEnzymes/search.js#L5)) but it's not really feasible since it is awfully time consuming. We tried running `create index on enzymes using gist (organism);` and waited for more than an hour and it didn't finish. Image running it for gene, reaction, compound, ec and domain as well, redeploying would take forever.

@e0 noted that if we use filtering with "select with search" (example [here](https://vue-multiselect.js.org/#sub-select-with-search)) where the searchable drop down options are the unique results for each column, we could have the same high performant whole word match as before. That's one of the possible implementations of #1056. If you think the filter performance of this PR it too slow, which makes sense, maybe we should close this issue and work on #1056 directly? Or should we go ahead with the current implementation and ask the researches if they think it is good enough?

Another idea might be to use `ILIKE` only on some columns, but that might result in confusing UX

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
