### PR TITLE
fix: use the value of the param

### DIFF
--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -80,6 +80,12 @@ paths:
           required: true
           type: 'string'
           description: 'the model name, e.g. **HumanGem**'
+        - name: 'full'
+          in: 'query'
+          required: false
+          type: 'string'
+          description: 'if left out, or set to false, only get the number of metabolites, genes, reactions contained by the given compartment.'
+          default: true
       responses:
         '200':
           description: 'Successful query'


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #914.

The param `full` in `/compartmets/{id}`, will be false when set to a falsy value or when left out.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Updated the handling of the parameter
- Updated the swagger docs

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Take a look at the updated swagger description
- Test that:
  - `api/v2/compartments/golgi_apparatus?model=HumanGem&full=true` give full results
  - `api/v2/compartments/golgi_apparatus?model=HumanGem&full` give full results
  - `api/v2/compartments/golgi_apparatus?model=HumanGem` give short results
  - `api/v2/compartments/golgi_apparatus?model=HumanGem&full=false` give short results


**Further comments**  
<!-- Specify questions or related information -->
See [slack thread](https://nbisweden.slack.com/archives/C01D13EKUV7/p1663840452835189?thread_ts=1663838914.788989&cid=C01D13EKUV7) for a discussion of how the parameter should behave.

**Definition of Done checklist**  
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
