### PR TITLE
fix: nginx setup for deployment with ssl

### DIFF
--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -15,7 +15,6 @@ services:
       - CERTBOT_EMAIL=${CERTBOT_EMAIL}
       - SERVER_NAME=${SERVER_NAME}
       - IP_FILTER=${IP_FILTER}
-      - ENVSUBST_VARS=SERVER_NAME IP_FILTER
     volumes:
       - letsencrypt:/etc/letsencrypt
     restart: unless-stopped

--- a/nginx/prod.Dockerfile
+++ b/nginx/prod.Dockerfile
@@ -7,6 +7,7 @@ WORKDIR /project
 COPY frontend .
 RUN yarn && yarn build
 
-FROM staticfloat/nginx-certbot
-COPY nginx/prod.nginx.conf /etc/nginx/user.conf.d/nginx.conf
+FROM jonasal/nginx-certbot:3.2.0-nginx1.23.1-alpine
+COPY nginx/redirector.conf /etc/nginx/conf.d/redirector.conf
+COPY nginx/prod.nginx.conf /etc/nginx/templates/default.conf.template
 COPY --from=frontend /project/dist /content

--- a/nginx/redirector.conf
+++ b/nginx/redirector.conf
@@ -1,0 +1,23 @@
+# Copied from 
+# https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/src/nginx_conf.d/redirector.conf
+# and disabling IPv6
+
+server {
+    # Listen on plain old HTTP and catch all requests so they can be redirected
+    # to HTTPS instead.
+    listen 80 default_server reuseport;
+    # listen [::]:80 default_server reuseport;
+
+    # Pass this particular URL off to the certbot server so it can properly
+    # respond to the Let's Encrypt ACME challenges for the HTTPS certificates.
+    location '/.well-known/acme-challenge' {
+        default_type "text/plain";
+        proxy_pass http://localhost:81;
+    }
+
+    # Everything else gets shunted over to HTTPS for each user defined
+    # server to handle.
+    location / {
+        return 301 https://$http_host$request_uri;
+    }
+}


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1157 and relates to https://github.com/MetabolicAtlas/private-issues/issues/38.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

**List of changes made**  
<!-- Specify what changes have been made and why -->
The production Dockerfile was updated, and an Nginx configuration was added to disable IPv6 (see comments below for full story).

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test: deploy the stack as usual to either `dev` or `prod3`

**Further comments**  
<!-- Specify questions or related information -->
This was also researched by @MalinAhlberg and @inghylt.

In the end, there were multiple problems, mainly stemming from using Let's Encrypt certificates though a custom Docker image. This is marked for removal in https://github.com/MetabolicAtlas/private-issues/issues/38 . However, the FTP server still requires the certificates, so this functionality can only be removed with the removal of the FTP server.

The certificates can be obtained from the current container, but port has to be manually changes from `1337` to `80`. Opening the port up in Docker compose did not help, and neither did the VM's iptables configuration.

After obtaining the certificates manually, these are stored in a permanent volume, so normally the problem should have gone away. However, the container kept restarting because of a new problem having to do with how the `nginx` service was restarted https://github.com/staticfloat/docker-nginx-certbot-old/blob/5d2eef666c639fcaadc237492a46c4371d392cb1/src/scripts/entrypoint.sh#L41

This also pointed out that the image we were using was old, so the next step was to switch to a new one https://hub.docker.com/r/jonasal/nginx-certbot . As described in the [README](https://github.com/JonasAlfredsson/docker-nginx-certbot#acknowledgments-and-thanks), this image is fork of the fork from the same original author. So, it made sense to switch back to it.

This new image however also enables IPv6, which had to be disabled by fetching the original file, commenting out the IPv6 line which is not supported by our VM, and overwriting the original one in the container. Moreover, this new image drops support of templating the way it was previously done, so a new approach was taken using the native Nginx templating https://github.com/JonasAlfredsson/docker-nginx-certbot/blob/master/docs/good_to_know.md#help-migrating-from-staticfloats-image .

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] My changes generate no new warnings
