### PR TITLE
fix: update swagger description

### DIFF
--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -386,7 +386,7 @@ paths:
       description:
         'This query retrieves a list of all compartments and subsystems that are
         available on Metabolic Atlas for a specified GEM. This includes identifiers
-        for the SVG maps.'
+        for the SVG maps. **Note that the response is large and might cause the browser to hang.**'
       operationId: 'mapListing'
       produces:
         - 'application/json'
@@ -395,7 +395,7 @@ paths:
           in: 'query'
           required: true
           type: 'string'
-          description: 'the model name, e.g. **HumanGem**'
+          description: 'the model name, e.g. **YeastGem**'
       responses:
         '200':
           description: 'Successful query'
@@ -419,7 +419,9 @@ paths:
         - name: 'componentTypes'
           in: 'query'
           type: 'object'
-          description: 'optional list of component types to return, by default all are returned, e.g. **{"gene":true, "compartmentalizedMetabolite": true}**'
+          default: { 'gene': true }
+          required: true
+          description: 'list of component types to return, e.g. **{"gene":true, "compartmentalizedMetabolite": true}**'
       produces:
         - 'application/json'
       responses:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -419,7 +419,7 @@ paths:
         - name: 'componentTypes'
           in: 'query'
           type: 'object'
-          default: { 'gene': true }
+          default: {"gene":true, "compartmentalizedMetabolite": true}
           required: true
           description: 'list of component types to return, e.g. **{"gene":true, "compartmentalizedMetabolite": true}**'
       produces:

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -419,7 +419,7 @@ paths:
         - name: 'componentTypes'
           in: 'query'
           type: 'object'
-          default: {"gene":true, "compartmentalizedMetabolite": true}
+          default: { 'gene': true, 'compartmentalizedMetabolite': true }
           required: true
           description: 'list of component types to return, e.g. **{"gene":true, "compartmentalizedMetabolite": true}**'
       produces:


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1073 .

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
For 1:
The problem is not only that the server response is a bit slow, but also that the browser gets unhappy with the amount of response data loaded to swagger. I did the following updates:
- changed the example value to Yeast-GEM which is slightly smaller than Human-Gem
- added a warning to the description

For 2:
- added a default, since swagger otherwise insisted to use `{}`as the standard value (not accepted by the api).
- removed the text saying that the value is optional

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

![2022-10-17-162153_1183x463_scrot](https://user-images.githubusercontent.com/1029190/196202339-5666c350-c4b1-475d-932e-81ddd47df3fa.png)
![2022-10-17-162204_1185x797_scrot](https://user-images.githubusercontent.com/1029190/196202335-7f0498bb-0bb7-4c94-994c-c7d53db6a743.png)

**Testing**  
<!-- Please delete options that are not relevant -->
1:
- Visit `/api/v2/#/Miscellaneous/mapListing`
- Read through the instructions and examples 
- Note the slowness of the page when the request has finished. For example, try to edit the `model` field. For me, there's a lot of lagging when typing.

2:
- Visit `/api/v2/#/Miscellaneous/randomComponentInfo`
- Read through the instructions and examples
- Make sure no unexpected error is returned when trying out the request

**Further comments**
Are there other ways to avoid that the browser hangs when having loaded the `listings`?

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria (but part 1 is still slow)
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] My changes generate no new warnings
