### PR TITLE
feat: reallocate prod vm resources

### DIFF
--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -20,21 +20,17 @@ services:
     restart: unless-stopped
     deploy:
       resources:
-        reservations:
-          memory: 0.5G
         limits:
-          memory: 1G
+          memory: 1.5G
 
   api:
     command: yarn start
     restart: unless-stopped
     deploy:
       resources:
-        reservations:
-          memory: 0.5G
         limits:
-          cpus: "0.30"
-          memory: 1G
+          cpus: "0.40"
+          memory: 1.5G
 
   neo4j:
     environment:
@@ -44,11 +40,9 @@ services:
     restart: unless-stopped
     deploy:
       resources:
-        reservations:
-          memory: 9G
         limits:
-          cpus: "0.95"
-          memory: 10G
+          cpus: "1.40"
+          memory: 13G
     ulimits:
       nofile:
         soft: 80000
@@ -81,8 +75,8 @@ services:
         reservations:
           memory: 3G
         limits:
-          cpus: "0.50"
-          memory: 3G
+          cpus: "0.70"
+          memory: 5G
 
 volumes:
   letsencrypt:


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1180.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [ ] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Increasing the limits set through Docker compose.

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test: check the new production server at https://metatlas-prod3.csbi.chalmers.se/

**Further comments**  
<!-- Specify questions or related information -->
The [`reservations`](https://docs.docker.com/compose/compose-file/deploy/#resources) were removed because for our deployment process they don't serve a purpose - the target VMs don't change that often, and when they do it's a resource increase.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria