### PR TITLE
fix: reset docker context after deploy

### DIFF
--- a/proj.sh
+++ b/proj.sh
@@ -49,6 +49,7 @@ function ma-exec {
 }
 
 function deploy-stack {
+  trap-context-reset
   CHOSEN_ENV="env-${1:-$LOCALENV}.env"
   generate-data
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
@@ -60,6 +61,15 @@ function deploy-stack {
 function import-db {
   generate-data --reset-db
   docker exec -it neo4j bash -c "cypher-shell -u ${NEO4J_USERNAME} -p ${NEO4J_PASSWORD} --format plain --file import/import.cypher"
+}
+
+function trap-context-reset {
+  if [ "$ZSH_VERSION" ]
+  then
+    trap 'unset DOCKER_CONTEXT' INT TERM     # zsh specific
+  else
+    trap 'unset DOCKER_CONTEXT' RETURN     # POSIX
+  fi
 }
 
 echo -e "Available commands:

--- a/proj.sh
+++ b/proj.sh
@@ -54,6 +54,7 @@ function deploy-stack {
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml --project-name metabolicatlas up --detach --build --force-recreate --remove-orphans --renew-anon-volumes
   docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-remote.yml exec -d pg psql -U postgres -c "alter user postgres with password '${POSTGRES_PASSWORD}';"
   CHOSEN_ENV=$METATLAS_DEFAULT_ENV
+  export DOCKER_CONTEXT=default
 }
 
 function import-db {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #852.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Reset docker context after deploying by: `export DOCKER_CONTEXT=default`

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
1. Deploy to dev server: `deploy-stack dev`.
2. Verify that the docker context is reset to `default` after deployment: `docker context show`.
3. Verify that commands such as `stop-stack` no longer affects the dev server.

**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
