### PR TITLE
fix: use stop instead of kill to gracefully shutdown containers

### DIFF
--- a/proj.sh
+++ b/proj.sh
@@ -33,7 +33,7 @@ function start-stack {
 }
 
 function stop-stack {
-  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-local.yml kill
+  docker compose --env-file $CHOSEN_ENV -f docker-compose.yml -f docker-compose-local.yml stop
 }
 
 function clean-stack {


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1131.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->

Use `docker compose stop` instead of `docker compose kill` when running `stop-stack`. This sends a graceful shutdown message `SIGTERM` instead of `SIGKILL`.

After applying this change, I restarted the stack several times without `neo4j` failing to start, whereas before it was failing almost every other time.

This is a quick little read along with an informative but heart-breaking comic that illustrates the differences: https://linuxhandbook.com/sigterm-vs-sigkill/


**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- A rebuild is needed due to new dependencies
- Instructions on how to test

After `source proj.sh`, restart (`stop-stack` followed by `start-stack`) a few times and verify that `neo4j` always starts without problems.

**Further comments**  
<!-- Specify questions or related information -->

Relevant docs:
- https://docs.docker.com/engine/reference/commandline/compose_down/
- https://docs.docker.com/engine/reference/commandline/compose_kill/

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
