### PR TITLE
fix: prevent duplicate metabolites in global search

### DIFF
--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -328,40 +328,35 @@ LIMIT ${limit}
     groupedByComponents[c].push(id);
   }
 
-  const [
-    metabolites,
-    genes,
-    reactions,
-    subsystems,
-    compartments,
-  ] = await Promise.all([
-    fetchCompartmentalizedMetabolites({
-      ids: groupedByComponents['CompartmentalizedMetabolite'] || [],
-      metaboliteIds: groupedByComponents['Metabolite'] || [],
-      model,
-      version: v,
-      limit,
-    }),
-    fetchGenes({ ids: groupedByComponents['Gene'], model, version: v }),
-    fetchReactions({
-      ids: groupedByComponents['Reaction'],
-      model,
-      version: v,
-      includeMetabolites: !!limit,
-    }),
-    fetchSubsystems({
-      ids: groupedByComponents['Subsystem'],
-      model,
-      version: v,
-      includeCounts: true,
-    }),
-    fetchCompartments({
-      ids: groupedByComponents['Compartment'],
-      model,
-      version: v,
-      includeCounts: true,
-    }),
-  ]);
+  const [metabolites, genes, reactions, subsystems, compartments] =
+    await Promise.all([
+      fetchCompartmentalizedMetabolites({
+        ids: groupedByComponents['CompartmentalizedMetabolite'] || [],
+        metaboliteIds: groupedByComponents['Metabolite'] || [],
+        model,
+        version: v,
+        limit,
+      }),
+      fetchGenes({ ids: groupedByComponents['Gene'], model, version: v }),
+      fetchReactions({
+        ids: groupedByComponents['Reaction'],
+        model,
+        version: v,
+        includeMetabolites: !!limit,
+      }),
+      fetchSubsystems({
+        ids: groupedByComponents['Subsystem'],
+        model,
+        version: v,
+        includeCounts: true,
+      }),
+      fetchCompartments({
+        ids: groupedByComponents['Compartment'],
+        model,
+        version: v,
+        includeCounts: true,
+      }),
+    ]);
 
   const resObj = {
     metabolites,

--- a/api/test/searchGlobal.test.js
+++ b/api/test/searchGlobal.test.js
@@ -53,4 +53,17 @@ describe('search', () => {
     expect(scoreSet.size).toEqual(1);
     expect(scoreSet.has(9.693942070007324)).toEqual(true);
   });
+
+  test('search should not return duplicate metabolites', async () => {
+    const data = await search({
+      searchTerm: 'retinol',
+    });
+
+    const { metabolite } = data['Human-GEM'];
+    const cytosolRetinols = metabolite.filter(
+      m => m.compartment.letterCode === 'c' && m.name === 'retinol'
+    );
+
+    expect(cytosolRetinols.length).toEqual(1);
+  });
 });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1148.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Prevent duplicate metabolites from being returned. This is done in a similar way to how model search was fixed.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

Before fix:
<img width="1436" alt="image" src="https://user-images.githubusercontent.com/423498/201695562-edf80806-45ed-4b78-a56e-275dae285775.png">

After fix:
<img width="1435" alt="image" src="https://user-images.githubusercontent.com/423498/201695622-2c1b6607-d07a-49f4-84ee-02a678cc131b.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test

1. Visit `/search?term=retinol`.
2. Select (as shown in the screenshots) `Human-GEM` under `Model`, enter `retinol` in `Name`, and select `Cytosol` under `Compartment`.
3. Verify that a total of 8 results are displayed, as opposed to 9 before the fix (prod or dev server), and there is only 1 instance of an exact match with the name `retinol`, as opposed to 2.

**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
