### PR TITLE
Fix: chemical formatting

### DIFF
--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -5,8 +5,8 @@ const chemicalFormula = (formula, charge) => {
   if (
     /-\w/g.test(formula) ||
     /,\w/g.test(formula) ||
-    /\btrans|cis|am|apoa|g\d+/g.test(formula.toLowerCase()) ||
-    /\b[^o]\d+\b/g.test(formula.toLowerCase()) ||
+    /\b(trans|cis|am|apoa|g)\d+/g.test(formula.toLowerCase()) ||
+    /\b[^o]\d+(alpha|beta)*\b/g.test(formula.toLowerCase()) ||
     formula.toLowerCase() === formula
   ) {
     // avoid bad formatting of metabolite names

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -26,11 +26,8 @@ const chemicalFormula = (formula, charge) => {
 };
 
 const chemicalEquation = formula => {
-  let equation = formula.replace('<=>', '⇔');
-  equation = equation.replace('=>', '⇒');
-  equation = equation.replaceAll(/(\S)\+/g, '$1<sup>+</sup>');
-  equation = equation.replaceAll(/(\S)-\s/g, '$1<sup>-</sup> ');
-  equation = equation.replaceAll(/([A-Za-z])(\d+)/g, '$1<sub>$2</sub>');
+  let equation = formula.split(' ').map(x => chemicalFormula(x, null)).join(' ');
+  equation = equation.replace('<=>', '⇔').replace('=>', '⇒').replace('<=', '⇐');
   return equation;
 };
 

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -2,7 +2,7 @@ const chemicalFormula = (formula, charge) => {
   if (formula === null || formula === undefined) {
     return '';
   }
-  if (/-\w/g.test(formula)) {
+  if (/-\w/g.test(formula) || /,\w/g.test(formula) || /\btrans|cis|am|apoa|g\d+/g.test(formula.toLowerCase()) || /\b[^o]\d+\b/g.test(formula.toLowerCase()) ||formula.toLowerCase() === formula) {
     // avoid bad formatting of metabolite names
     return formula;
   }

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -2,7 +2,13 @@ const chemicalFormula = (formula, charge) => {
   if (formula === null || formula === undefined) {
     return '';
   }
-  if (/-\w/g.test(formula) || /,\w/g.test(formula) || /\btrans|cis|am|apoa|g\d+/g.test(formula.toLowerCase()) || /\b[^o]\d+\b/g.test(formula.toLowerCase()) ||formula.toLowerCase() === formula) {
+  if (
+    /-\w/g.test(formula) ||
+    /,\w/g.test(formula) ||
+    /\btrans|cis|am|apoa|g\d+/g.test(formula.toLowerCase()) ||
+    /\b[^o]\d+\b/g.test(formula.toLowerCase()) ||
+    formula.toLowerCase() === formula
+  ) {
     // avoid bad formatting of metabolite names
     return formula;
   }

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -12,15 +12,23 @@ const chemicalFormula = (formula, charge) => {
     // avoid bad formatting of metabolite names
     return formula;
   }
-  let form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
+  let form;
   if (charge) {
+    form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
     form = `${form}<sup>${Math.abs(charge) !== 1 ? Math.abs(charge) : ''}${
       charge > 0 ? '+' : '-'
     }</sup>`;
   } else {
     // if no explicit charge is provided, check if the form includes one
     // useful for showing eg NADP+ rather than the formal charge NADP3-
-    form = form.replace(/([-+])$/, '<sup>$1</sup>');
+    if (/\b(Ca|Fe|Cu|Mg)\d\+/.test(formula)) {
+      // for cations with multiple charges, format both the charge number
+      // and charge sign as superscript
+      form = formula.replace(/([0-9]\+)/g, '<sup>$1</sup>');
+    } else {
+      form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
+      form = form.replace(/([-+])$/, '<sup>$1</sup>');
+    }
   }
   return form;
 };

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -5,7 +5,7 @@ const chemicalFormula = (formula, charge) => {
   if (
     /-\w/g.test(formula) ||
     /,\w/g.test(formula) ||
-    /\b(trans|cis|am|apoa|g)\d+/g.test(formula.toLowerCase()) ||
+    /\b(trans|cis|am|apoa|g|gm|gd)\d+(alpha|beta)*/g.test(formula.toLowerCase()) ||
     /\b[^o]\d+(alpha|beta)*\b/g.test(formula.toLowerCase()) ||
     formula.toLowerCase() === formula
   ) {

--- a/frontend/src/helpers/chemical-formatters.js
+++ b/frontend/src/helpers/chemical-formatters.js
@@ -18,17 +18,15 @@ const chemicalFormula = (formula, charge) => {
     form = `${form}<sup>${Math.abs(charge) !== 1 ? Math.abs(charge) : ''}${
       charge > 0 ? '+' : '-'
     }</sup>`;
+  } else if (/\b(Ca|Fe|Cu|Mg)\d\+/.test(formula)) {
+    // for cations with multiple charges, format both the charge number
+    // and charge sign as superscript
+    form = formula.replace(/([0-9]\+)/g, '<sup>$1</sup>');
   } else {
     // if no explicit charge is provided, check if the form includes one
     // useful for showing eg NADP+ rather than the formal charge NADP3-
-    if (/\b(Ca|Fe|Cu|Mg)\d\+/.test(formula)) {
-      // for cations with multiple charges, format both the charge number
-      // and charge sign as superscript
-      form = formula.replace(/([0-9]\+)/g, '<sup>$1</sup>');
-    } else {
-      form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
-      form = form.replace(/([-+])$/, '<sup>$1</sup>');
-    }
+    form = formula.replace(/([0-9])/g, '<sub>$1</sub>');
+    form = form.replace(/([-+])$/, '<sup>$1</sup>');
   }
   return form;
 };

--- a/project-words.txt
+++ b/project-words.txt
@@ -1,6 +1,7 @@
 Agren
 Albornoz
 Altmetric
+apoa
 apoc
 arrowless
 Avlant


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1140 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
This PR fixes incorrect formatting of equations as described at https://github.com/MetabolicAtlas/MetabolicAtlas/issues/1140#issuecomment-1319249412, that is
1. incorrectly formatted number as subscript for metabolite names 
2. incorrectly formatted cations with multiple charges
The function `chemicalEquation` is now reusing the function `chemicalFormula` and thus it fixes also the problem for equations in GotEnzymes
 

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
You can check if the bad formatting in the following pages are fixed

https://metabolicatlas.org/explore/Human-GEM/gem-browser/metabolite/MAM01899r G10597
https://metabolicatlas.org/explore/Human-GEM/gem-browser/reaction/MAR04110 APoa1
https://metabolicatlas.org/explore/Fruitfly-GEM/gem-browser/metabolite/MAM03969m   Trans4Decenoyl
https://metabolicatlas.org/explore/Fruitfly-GEM/gem-browser/metabolite/MAM01782r emem2gacpail
https://metabolicatlas.org/explore/Fruitfly-GEM/gem-browser/metabolite/MAM02789c F2alpha
https://metabolicatlas.org/explore/Fruitfly-GEM/gem-browser/metabolite/MAM02009e GM1alpha
https://metabolicatlas.org/explore/Fruitfly-GEM/gem-browser/metabolite/MAM02776e   prostaglandin A1
https://metabolicatlas.org/explore/Human-GEM/gem-browser/reaction/MAR01529 Ca2+
https://metabolicatlas.org/explore/Human-GEM/gem-browser/reaction/MAR11407 Fe2+ Fe3+
https://metabolicatlas.org/gotenzymes/reaction/R12925 Cu2+ 


**Further comments**  
<!-- Specify questions or related information -->
For `prostaglandin A1`, although prostaglandin A<sub>1</sub> is also allowed, I have choosed the raw format so that it matches the format of name of the metabolite. see discussion at https://github.com/MetabolicAtlas/MetabolicAtlas/issues/1140#issuecomment-1319332162

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
