### PR TITLE
style: set stacking context for viewer containers

### DIFF
--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -660,6 +660,7 @@ export default {
   }
 
   #viewer-container {
+    z-index: 0;
     width: 100%;
     height: 100%;
     position: relative;
@@ -670,6 +671,7 @@ export default {
   }
 
   #viewer3d {
+    z-index: 0;
     width: 100%;
     height: 100%;
     min-height: 500px;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1226.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Set a `z-index` value for the network viewer containers to prevent ensure they do not interfere with the stacking context of the rest of the website. For more on stacking context (`z-index`) see: https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context#example

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="1505" alt="image" src="https://user-images.githubusercontent.com/423498/204296573-65b9eb5f-0574-46ba-bce6-6146d85c01bf.png">

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test (instructions stolen from @MalinAhlberg's issue description)

1. Visit `/explore/Human-GEM/interaction-partners/MAM02040r?expandedIds=&dataTypes=gene&dataSources=hpaRna.tsv&dataSets=None`.
2. Zoom in and out a bit on the map.
3. Click "Choose a file" (Load custom data).
4. Select and open a file.
5. Verify that the modal appears in front of the network viewer and all of the labels.

**Further comments**  
<!-- Specify questions or related information -->
To ensure that the labels are behind the the modal, it is enough to add the `z-index: 0;` for `#viewer-container`. An extra `z-index: 0;` is added for `#viewer3d` to make sure that the labels are also behind the "Export" dropdown.
<img width="171" alt="image" src="https://user-images.githubusercontent.com/423498/204298103-20eb6c06-7900-4ecf-96b0-8415d1189db0.png">


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
