### PR TITLE
fix: reapply colors after node has been clicked

### DIFF
--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -597,6 +597,7 @@ export default {
       const [id, type] = this.getElementIdAndType(element);
       this.clickedElmId = id;
       this.clickedElm = { id, type, n: element.n };
+      this.applyColors();
     },
     getElementIdAndType(element) {
       let type = 'metabolite';

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -189,6 +189,7 @@ export default {
         this.$emit('updatePanelSelectionData', selectionData);
         this.$emit('endSelection', true);
         this.$store.dispatch('maps/setLoadingElement', false);
+        this.applyColors();
       } catch {
         this.$emit('updatePanelSelectionData', selectionData);
         selectionData.error = true;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1221

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Colors are reapplied after a node has been clicked

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
Please visit both 3D network viewer and IP partner. Try out networks of different sizes and with multiple simultaneous overlays.

**Further comments**  
<!-- Specify questions or related information -->
There is some lag, but IMO (and @e0:s :D) it is not a problem. The lag only annoys me a bit when applying reaction overlay on  Cytosol and Extracellular, i,e, massive networks, but since those are really too big to be of any value for researchers anyway I think it is acceptable. 

Note that there is no lag even on large networks such as `/explore/Human-GEM/interaction-partners/MAM03343c?expandedIds=MAM02039c`

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
