### PR TITLE
feat: add toggle states for gene and label buttons

### DIFF
--- a/frontend/src/components/explorer/mapViewer/MapControls.vue
+++ b/frontend/src/components/explorer/mapViewer/MapControls.vue
@@ -23,10 +23,10 @@
     <span
       v-if="toggleSubsystems"
       class="button p-2"
-      title="Show/Hide subsystem"
-      @click="toggleSubsystems()"
+      :title="`${showLabels ? 'Hide' : 'Show'} subsystems`"
+      @click="handleToggleSubsystems()"
     >
-      <i class="fa fa-eye-slash">&thinsp;S</i>
+      <i class="fa" :class="[showSubsystems ? 'fa-eye-slash' : 'fa-eye']">&thinsp;S</i>
     </span>
     <span
       v-if="toggleBackgroundColor"
@@ -99,6 +99,7 @@ export default {
     return {
       showGenes: true,
       showLabels: true,
+      showSubsystems: true,
     };
   },
   computed: {
@@ -122,6 +123,10 @@ export default {
     handleToggleLabels() {
       this.showLabels = !this.showLabels;
       this.toggleLabels();
+    },
+    handleToggleSubsystems() {
+      this.showSubsystems = !this.showSubsystems;
+      this.toggleSubsystems();
     },
     handleToggleFullScreen() {
       if (this.isFullscreenDisabled) {

--- a/frontend/src/components/explorer/mapViewer/MapControls.vue
+++ b/frontend/src/components/explorer/mapViewer/MapControls.vue
@@ -4,11 +4,21 @@
     <span class="button" title="Zoom out" @click="zoomOut()">
       <i class="fa fa-search-minus"></i>
     </span>
-    <span v-if="toggleGenes" class="button p-2" title="Show/Hide genes" @click="toggleGenes()">
-      <i class="fa fa-eye-slash">&thinsp;G</i>
+    <span
+      v-if="toggleGenes"
+      class="button p-2"
+      :title="`${showGenes ? 'Hide' : 'Show'} genes`"
+      @click="handleToggleGenes()"
+    >
+      <i class="fa" :class="[showGenes ? 'fa-eye-slash' : 'fa-eye']">&thinsp;G</i>
     </span>
-    <span v-if="toggleLabels" class="button p-2" title="Show/Hide labels" @click="toggleLabels()">
-      <i class="fa fa-eye-slash">&thinsp;L</i>
+    <span
+      v-if="toggleLabels"
+      class="button p-2"
+      :title="`${showLabels ? 'Hide' : 'Show'} labels`"
+      @click="handleToggleLabels()"
+    >
+      <i class="fa" :class="[showLabels ? 'fa-eye-slash' : 'fa-eye']">&thinsp;L</i>
     </span>
     <span
       v-if="toggleSubsystems"
@@ -85,6 +95,12 @@ export default {
       type: Boolean,
     },
   },
+  data() {
+    return {
+      showGenes: true,
+      showLabels: true,
+    };
+  },
   computed: {
     isFullscreenDisabled() {
       if (
@@ -99,6 +115,14 @@ export default {
     },
   },
   methods: {
+    handleToggleGenes() {
+      this.showGenes = !this.showGenes;
+      this.toggleGenes();
+    },
+    handleToggleLabels() {
+      this.showLabels = !this.showLabels;
+      this.toggleLabels();
+    },
     handleToggleFullScreen() {
       if (this.isFullscreenDisabled) {
         return;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1107.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Change button appearance (`fa-eye` or `fa-eye-slash`) depending on the toggle state.
- Change tooltip message (e.g. 'Show labels' or 'Hide labels') depending on the toggle state.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="607" alt="image" src="https://user-images.githubusercontent.com/423498/204505582-a49b26fd-9778-46ad-b3c4-a7b707b9c561.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test

1. Visit an interaction partners page, for example: `/explore/Human-GEM/interaction-partners/ENSG00000158578`.
2. Verify that the label toggle button works and that the state (button appearance and tooltip/hover message) changes after clicking on it.
3. Visit a 2d map viewer page, for example: `/explore/Human-GEM/map-viewer/acylglycerides_metabolism?dim=2d`.
4. Verify that the gene and subsystem toggle buttons work and that the states (button appearance and tooltip/hover message) change after clicking on it.
5. Visit a 3d map viewer page, for example: `/explore/Human-GEM/map-viewer/acylglycerides_metabolism?dim=3d`.
6. Verify that the gene and label toggle buttons work and that the states (button appearance and tooltip/hover message) change after clicking on it.

**Further comments**  
<!-- Specify questions or related information -->
In the 3d map viewer page, the node colors get set to white after toggling the genes button. This bug is not introduced with this PR. It may be related to #1221 and if not a new issue should be created for it.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
