### PR TITLE
fix: reapply colors after node has been clicked

### DIFF
--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -597,6 +597,7 @@ export default {
       const [id, type] = this.getElementIdAndType(element);
       this.clickedElmId = id;
       this.clickedElm = { id, type, n: element.n };
+      this.applyColors();
     },
     getElementIdAndType(element) {
       let type = 'metabolite';

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -536,10 +536,13 @@ export default {
       // map appears "flat".
       this.controller.setCamera({ x: 0, y: 0, z: lz });
     },
-    async applyColors() {
+    async applyColors({ deselect } = { deselect: false }) {
       if (this.controller) {
         const colors = {};
-        this.network.nodes.forEach(node => {
+        const nodes = deselect
+          ? this.network.nodes.filter(n => n.id === this.clickedElmId)
+          : this.network.nodes;
+        nodes.forEach(node => {
           let color = colorToRGBArray(this.defaultMetaboliteColor);
 
           // TODO: use this when implementing compartment and subsystem highlight
@@ -571,7 +574,7 @@ export default {
               color = colorToRGBArray(this.defaultMetaboliteColor);
             }
           }
-          if (node.id === this.clickedElmId) {
+          if (node.id === this.clickedElmId && !deselect) {
             colors[node.id] = colorToRGBArray(NODE_SELECT_COLOR);
           } else {
             colors[node.id] = color;
@@ -594,10 +597,10 @@ export default {
       this.$store.dispatch('interactionPartners/setCoords', payload);
     },
     async selectElement(element) {
+      await this.applyColors({ deselect: true });
       const [id, type] = this.getElementIdAndType(element);
       this.clickedElmId = id;
       this.clickedElm = { id, type, n: element.n };
-      this.applyColors();
     },
     getElementIdAndType(element) {
       let type = 'metabolite';

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -298,6 +298,7 @@ export default {
     },
     async toggleGenes() {
       await this.controller.toggleNodeType('e');
+      this.applyColors();
     },
     toggleLabels() {
       this.controller.toggleLabels();

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -189,6 +189,7 @@ export default {
         this.$emit('updatePanelSelectionData', selectionData);
         this.$emit('endSelection', true);
         this.$store.dispatch('maps/setLoadingElement', false);
+        this.applyColors();
       } catch {
         this.$emit('updatePanelSelectionData', selectionData);
         selectionData.error = true;

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -183,13 +183,13 @@ export default {
           type,
           id,
         };
+        await this.applyColors({ deselect: true });
         await this.$store.dispatch('maps/getSelectedElement', payload);
         const data = this.selectedElement;
         selectionData.data = data;
         this.$emit('updatePanelSelectionData', selectionData);
         this.$emit('endSelection', true);
         this.$store.dispatch('maps/setLoadingElement', false);
-        this.applyColors();
       } catch {
         this.$emit('updatePanelSelectionData', selectionData);
         selectionData.error = true;
@@ -197,10 +197,13 @@ export default {
         this.$store.dispatch('maps/setLoadingElement', false);
       }
     },
-    async applyColors() {
+    async applyColors({ deselect } = { deselect: false }) {
       const colors = {};
       const centerId = this.queryParams.sel;
-      this.network.nodes.forEach(node => {
+      const nodes = deselect
+        ? this.network.nodes.filter(n => n.id === this.selectedElementId)
+        : this.network.nodes;
+      nodes.forEach(node => {
         let color = colorToRGBArray(this.defaultMetaboliteColor);
 
         if (node.g === 'r') {
@@ -240,7 +243,7 @@ export default {
             color = colorToRGBArray(this.defaultMetaboliteColor);
           }
         }
-        if (node.id === centerId) {
+        if (node.id === centerId && !deselect) {
           color = colorToRGBArray('#ff0000');
         }
         colors[node.id] = color;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1221

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Colors are reapplied after a node has been clicked

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
Please visit both 3D network viewer and IP partner. Try out networks of different sizes and with multiple simultaneous overlays.

**Further comments**  
<!-- Specify questions or related information -->
There is some lag, but IMO (and @e0:s :D) it is not a problem. The lag only annoys me a bit when applying reaction overlay on  Cytosol and Extracellular, i,e, massive networks, but since those are really too big to be of any value for researchers anyway I think it is acceptable. 

Note that there is no lag even on large networks such as `/explore/Human-GEM/interaction-partners/MAM03343c?expandedIds=MAM02039c`

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
