### PR TITLE
fix: correct error message for bad value for expanded ids

### DIFF
--- a/api/src/endpoints/neo4j.js
+++ b/api/src/endpoints/neo4j.js
@@ -62,6 +62,9 @@ const fetchWith = async (req, res, queryHandler) => {
     const result = await queryHandler(payload);
     res.json(result);
   } catch (e) {
+    if (e.message.startsWith('Invalid id')) {
+      return res.status(404).send(e.message);
+    }
     if (e.message === '404') {
       return res.sendStatus(404);
     }

--- a/api/src/neo4j/queries/interactionPartners.js
+++ b/api/src/neo4j/queries/interactionPartners.js
@@ -50,7 +50,14 @@ WITH apoc.map.mergeList(apoc.coll.flatten(
 )) as reaction, component
 RETURN { component: component, reactions: COLLECT(reaction)}
 `;
-  const result = await querySingleResult(statement);
+  let result;
+  try {
+    result = await querySingleResult(statement);
+  } catch (e) {
+    const error = new Error(`Invalid id: ${id}`);
+    throw error;
+  }
+
   let links = [];
   let nodes = [];
   let unique = new Set();

--- a/api/src/neo4j/queries/interactionPartners.js
+++ b/api/src/neo4j/queries/interactionPartners.js
@@ -133,13 +133,15 @@ const getInteractionPartnersExpansion = async ({
   let expandedNodes = {};
 
   const expandedNetworks = await Promise.all(
-    expanded.map(nodeId =>
-      getInteractionPartners({
-        id: nodeId,
-        model,
-        version,
-      })
-    )
+    expanded
+      .filter(n => n.trim())
+      .map(nodeId =>
+        getInteractionPartners({
+          id: nodeId,
+          model,
+          version,
+        })
+      )
   );
 
   for (let i = 0; i < expandedNetworks.length; i++) {

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -10,7 +10,7 @@
       <div v-else class="interaction-partners">
         <template v-if="componentNotFound">
           <div class="columns is-centered">
-            <notFound type="Interaction Partners" :component-id="mainNodeID"></notFound>
+            <notFound type="Interaction Partners" :component-id="componentNotFound"></notFound>
           </div>
         </template>
         <template v-if="loading">
@@ -382,7 +382,11 @@ export default {
       } catch (error) {
         switch (error.response.status) {
           case 404:
-            this.componentNotFound = true;
+            if (error.response.data.startsWith('Invalid id')) {
+              this.componentNotFound = error.response.data.split(':')[1] || this.mainNodeID;
+            } else {
+              this.componentNotFound = this.mainNodeID;
+            }
             break;
           default:
             this.errorMessage = messages.unknownError;

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -383,7 +383,7 @@ export default {
         switch (error.response.status) {
           case 404:
             if (error.response.data.startsWith('Invalid id')) {
-              this.componentNotFound = error.response.data.split(':')[1] || this.mainNodeID;
+              this.componentNotFound = error.response.data.split(/:(.*)/)[1] || this.mainNodeID;
             } else {
               this.componentNotFound = this.mainNodeID;
             }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes  #1174.

<!-- Include below a description of the changes proposed in the pull request -->
The api will return the failing node id when calling `/interaction-partners` and `interaction-partners-expansion`.
The frontend will show the failing node id.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Api will return an error message `Invalid id xxx` when provided with an incorrect value for interaction partners
Frontend will parse and show that id

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
![2022-12-02-084350_1435x295_scrot](https://user-images.githubusercontent.com/1029190/205241576-dc6bdc84-27e0-4dc9-852f-9ce7b8090c65.png)


**Testing**  
<!-- Please delete options that are not relevant -->
- Visit Interaction Partners, eg `explore/Human-GEM/interaction-partners/MAM03769e`, and make sure you can expand nodes as expected
- Visit Interaction Partners using a bad value for the main node, eg `explore/Human-GEM/interaction-partners/nonono` and make sure that the error message makes sense
- Try adding a bad value for the expanded node, make sure the error message makes sense, eg
  - `/explore/Human-GEM/interaction-partners/MAM03769e?expandedIds=crash`
  - `/explore/Human-GEM/interaction-partners/MAM03769e?expandedIds=MAM03768e,crash`
- Make a call to the api and make sure the output looks ok, eg `/api/v2/interaction-partners-expansion/MAM03769e?model=HumanGem&version=1_12_0&expanded[]=MAM03768e&expanded[]=crash`

**Further comments**  
<!-- Specify questions or related information -->
When providing multiple erroneous values for the expanded ids, one of them will be shown. Which one will depend on which query from the [`Promise.all`](https://github.com/MetabolicAtlas/MetabolicAtlas/blob/ac94d0293197f67ade534ee7fdc2cc45071ebed4/api/src/neo4j/queries/interactionPartners.js#L135) that will fail first.
If the main node id is invalid, that will always be reported as the failing id.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
