### PR TITLE
fix: consistent about links

### DIFF
--- a/frontend/src/components/about/Elixir.vue
+++ b/frontend/src/components/about/Elixir.vue
@@ -79,6 +79,9 @@ export default {
       ],
     };
   },
+  mounted() {
+    setTimeout(() => document.getElementById('title-ELIXIR').scrollIntoView(), 50);
+  },
 };
 </script>
 

--- a/frontend/src/components/about/Elixir.vue
+++ b/frontend/src/components/about/Elixir.vue
@@ -79,6 +79,7 @@ export default {
       ],
     };
   },
+  // Implemented since this section does not have a subsection anchor to use in MetabolicAtlas/frontend/src/content/about.js
   mounted() {
     setTimeout(() => document.getElementById('title-ELIXIR').scrollIntoView(), 50);
   },

--- a/frontend/src/components/about/News.vue
+++ b/frontend/src/components/about/News.vue
@@ -47,5 +47,8 @@ export default {
       news,
     };
   },
+  mounted() {
+    document.getElementById('title-News').scrollIntoView();
+  },
 };
 </script>

--- a/frontend/src/components/about/News.vue
+++ b/frontend/src/components/about/News.vue
@@ -47,6 +47,7 @@ export default {
       news,
     };
   },
+  // Implemented since this section does not have a subsection anchor to use in MetabolicAtlas/frontend/src/content/about.js
   mounted() {
     document.getElementById('title-News').scrollIntoView();
   },

--- a/frontend/src/layouts/AboutLayout.vue
+++ b/frontend/src/layouts/AboutLayout.vue
@@ -5,7 +5,7 @@
       <div class="columns is-variable is-8 pt-5">
         <TableOfContents :links="tocLinks" />
         <div class="column content has-text-justified">
-          <h3 v-if="title" class="title is-3 mt-0">{{ title }}</h3>
+          <h3 v-if="title" :id="'title-' + title" class="title is-3 mt-0">{{ title }}</h3>
           <div :class="{ 'content-container': !fullContentWidth }">
             <slot name="contents" />
           </div>


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1068.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Scroll to the section title when there are no subsections. Fix added for both News and ELIXIR section since the bug was present for both of them

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
Instructions on how to test
- Click eg "Contact us" from the "Table of Content"
- Compare to clicking "News" 
- Click eg "Contact us" from the "Table of Content"
- Compare to clicking "ELIXIR" 
 
Do this on normal and a mobile device


**Further comments**  
<!-- Specify questions or related information -->
I have noticed when visiting Elixir for the first time the scrolling does not always end up right at the title. For News that does not occur, so I think the problem might have something to do with the logos. The `setTimeout` was added to fix it, works well in Chrome, but in Firefox I can still recreate the problem. Best way to recreate it is to visit `http://localhost/about/elixir` until you notice that the title is not at the top. But since the original problems are fixed and ELIXIR is still functional, I think this is acceptable. Do you guys agree?

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
