### PR TITLE
fix: clear loader after network is rendered

### DIFF
--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -116,8 +116,8 @@ export default {
         id: this.currentMap.id,
       };
       await this.$store.dispatch('maps/get3DMapNetwork', payload);
-      this.$store.dispatch('maps/setLoading', false);
       await this.applyColorsAndRenderNetwork({});
+      this.$store.dispatch('maps/setLoading', false);
       // controller.filterBy({group: 'm'});
       // controller.filterBy({id: [1, 2, 3, 4]});
       // Subscribe to node selection events

--- a/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
+++ b/frontend/src/components/explorer/mapViewer/ThreeDviewer.vue
@@ -86,8 +86,10 @@ export default {
     }),
   },
   watch: {
-    async currentMap() {
-      await this.loadNetwork();
+    async currentMap(newM, oldM) {
+      if (newM.id !== oldM.id) {
+        await this.loadNetwork();
+      }
     },
     dataOverlayPanelVisible() {
       // this is needed by the 3D viewer to update its size


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1239.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Clear loader after network is rendered.

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
1. Visit `/explore/Human-GEM/map-viewer/cytosol?dim=3d`.
2. Verify that the network viewer shows immediately after the loader clears, without a delay showing an empty canvas.

**Further comments**  
<!-- Specify questions or related information -->
I couldn't really notice the delay even before this fix on my machine, tested on Safari, Firefox, and Chrome. The fix I included should work in theory but I haven't fully confirmed it. Please let me know if this solves it for you.

**Definition of Done checklist**  
- [ ] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
