### PR TITLE
fix: gotenzymes show errors

### DIFF
--- a/frontend/src/components/gotEnzymes/DetailsPage.vue
+++ b/frontend/src/components/gotEnzymes/DetailsPage.vue
@@ -1,7 +1,25 @@
 <template>
   <div class="section extended-section">
     <div class="container is-fullhd">
-      <div>
+      <div v-if="notFound" class="columns is-centered">
+        <div
+          class="column has-text-centered is-three-fifths-desktop is-three-quarters-tablet is-fullwidth-mobile"
+        >
+          <div class="box has-background-light content">
+            <p class="title is-size-5">
+              <span class="is-capitalized">{{ componentType }}</span>
+              <code class="code">{{ componentId }}</code>
+              not found.
+            </p>
+            <p>
+              <span class="is-block">
+                Probably there is a typo in the {{ type }} identifier in the URL.
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+      <div v-else>
         <h3 class="title is-3">{{ componentType }} {{ componentId }}</h3>
         <loader v-if="showLoaderMessage" :message="showLoaderMessage" class="columns" />
         <template v-else-if="!notFound">

--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -1,5 +1,6 @@
 <template>
   <div id="enzymes-table">
+    <ErrorPanel :message="errorMessage" :hide-error-panel="hideErrorMessage" />
     <div class="field columns">
       <div class="column"></div>
       <div class="column is-narrow">
@@ -69,6 +70,8 @@ import { VueGoodTable } from 'vue-good-table-next';
 import Loader from '@/components/Loader.vue';
 import ExportTSV from '@/components/shared/ExportTSV.vue';
 import RangeFilter from '@/components/shared/RangeFilter.vue';
+import ErrorPanel from '@/components/shared/ErrorPanel.vue';
+import { default as messages } from '@/content/messages';
 
 export default {
   name: 'EnzymesTable',
@@ -77,6 +80,7 @@ export default {
     ExportTSV,
     RangeFilter,
     Loader,
+    ErrorPanel,
   },
   props: {
     initialFilter: { type: Object, default: () => {} },
@@ -85,6 +89,7 @@ export default {
   },
   data() {
     return {
+      errorMessage: '',
       linkableFields: ['compound', 'domain', 'ec_number', 'gene', 'organism', 'reaction_id'],
       showEnzymesLoader: true,
       columns: [
@@ -174,7 +179,11 @@ export default {
         },
       };
 
-      await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      try {
+        await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      } catch {
+        this.errorMessage = messages.unknownError;
+      }
       this.showEnzymesLoader = false;
     },
     async onPageChange({ currentPage }) {
@@ -187,7 +196,11 @@ export default {
         },
       };
 
-      await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      try {
+        await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      } catch {
+        this.errorMessage = messages.unknownError;
+      }
       this.showEnzymesLoader = false;
     },
     async onSortChange([{ field, type }]) {
@@ -201,7 +214,11 @@ export default {
         },
       };
 
-      await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      try {
+        await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      } catch {
+        this.errorMessage = messages.unknownError;
+      }
       this.showEnzymesLoader = false;
     },
     async onColumnFilter({ columnFilters }) {
@@ -214,7 +231,11 @@ export default {
         },
       };
 
-      await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      try {
+        await this.$store.dispatch('gotEnzymes/getEnzymes', this.serverPaginationOptions);
+      } catch {
+        this.errorMessage = messages.unknownError;
+      }
       this.showEnzymesLoader = false;
     },
     formatToTSV() {
@@ -229,6 +250,9 @@ export default {
         })
         .join('\n');
       return tsvContent;
+    },
+    hideErrorMessage() {
+      this.errorMessage = '';
     },
     async handleRangeFilterUpdate({ field, remove, ...payload }) {
       // payload can look like { min: 0, max: 1 }

--- a/frontend/src/components/gotEnzymes/Landing.vue
+++ b/frontend/src/components/gotEnzymes/Landing.vue
@@ -6,6 +6,7 @@
         <p class="is-size-5">We've got the enzymes you need</p>
       </div>
     </section>
+    <ErrorPanel :message="errorMessage" :hide-error-panel="hideErrorMessage" />
     <div class="section container is-fullhd">
       <div class="columns is-centered pt-6">
         <div
@@ -182,6 +183,7 @@ import TableOfContents from '@/components/shared/TableOfContents.vue';
 import { default as messages } from '@/content/messages';
 import Citation from '@/components/about/Citation.vue';
 import { getImageUrl } from '@/helpers/utils';
+import ErrorPanel from '@/components/shared/ErrorPanel.vue';
 
 export default {
   name: 'EnzymeLanding',
@@ -189,9 +191,11 @@ export default {
     SearchHighlighter,
     TableOfContents,
     Citation,
+    ErrorPanel,
   },
   data() {
     return {
+      errorMessage: '',
       searchTerm: '',
       searching: false,
       tocLinks: [
@@ -249,13 +253,20 @@ export default {
     async search() {
       this.$store.dispatch('gotEnzymes/resetSearch');
 
-      await this.$store.dispatch('gotEnzymes/search', this.searchTerm);
+      try {
+        await this.$store.dispatch('gotEnzymes/search', this.searchTerm);
+      } catch {
+        this.errorMessage = messages.unknownError;
+      }
 
       this.searching = false;
     },
     async handleInputUpdate() {
       this.searching = true;
       await this.search();
+    },
+    hideErrorMessage() {
+      this.errorMessage = '';
     },
   },
 };


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1241 
<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Errors are reported when:
1. searching fails on Landing page: "unkown error"-message box popping up
2. getting a component (trying to load a Details page) fails: "Uknown component" shown at the top of the page
3. sorting, filtering or loading enzymes table fails: "unknown error"-message box popping up

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
Examples of scenarios above:
1.
![2022-12-09-093146_723x571_scrot](https://user-images.githubusercontent.com/1029190/206659300-c33c7d48-4780-4a30-9e24-a3628852a415.png)

2.
![2022-12-09-093156_816x261_scrot](https://user-images.githubusercontent.com/1029190/206659317-d59a4ff8-d48f-4140-936a-2ddb500ecb58.png)

3.
![2022-12-09-093208_823x820_scrot](https://user-images.githubusercontent.com/1029190/206659333-8819dce2-7644-454a-8fb4-31e70728c2cd.png)


**Testing**  
<!-- Please delete options that are not relevant -->
To test this, you can use commit c9e0d24d21f27eb0f53f2d3e372c897c7516af42 which makes the different queries to the gotenzymes api fail randomly. Then visit `/gotenzymes` and try searching, loading component pages, and interacting with the enzymes table. Make sure that:
- no errors are reported unless there are failed api calls
- all failing api calls are reported to the user


**Further comments**  
<!-- Specify questions or related information -->
One could go for a more complex parsing of the api errors, but I do not think the user would benefit from this at this stage.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
