### PR TITLE
fix: blinking SVG map when switching between 2D and 3D

### DIFF
--- a/frontend/src/components/explorer/mapViewer/MapLoader.vue
+++ b/frontend/src/components/explorer/mapViewer/MapLoader.vue
@@ -1,6 +1,6 @@
 <template>
   <div v-show="loading" class="map-loader loading">
-    <a class="button is-loading"></a>
+    <a class="button is-warning is-loading"></a>
   </div>
 </template>
 
@@ -17,11 +17,11 @@ export default {
 };
 </script>
 
-<style lang="scss">
+<style lang="scss" scoped>
 .map-loader {
   z-index: 10;
   position: absolute;
-  background: black;
+  background: white;
   top: 0;
   left: 0;
   width: 100%;
@@ -34,7 +34,7 @@ export default {
     font-weight: 1000;
     display: table-cell;
     vertical-align: middle;
-    background: black;
+    background: white;
     border: 0;
   }
 }

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -114,8 +114,10 @@ export default {
     }),
   },
   watch: {
-    async mapData() {
-      await this.init();
+    async mapData(newM, oldM) {
+      if (newM.id !== oldM.id) {
+        await this.init();
+      }
     },
     componentClassName() {
       this.setupHoverEventHandlers();


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1242 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Fixed the problem that the SVG map blinks when switching back from the 3D map viewer 

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
Open the Map Viewer, switch between 2D and 3D and see if the SVG map blinks
Try a few examples

**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] My changes generate no new warnings
