### PR TITLE
fix: inconsistent related reactions number

### DIFF
--- a/api/src/neo4j/queries/relatedReactions.js
+++ b/api/src/neo4j/queries/relatedReactions.js
@@ -63,7 +63,15 @@ MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${
       throw new Error(`Unrecognized node type: ${nodeType}`);
   }
 
-  statement += `WITH collect (r) as reaction`;
+  if (limit) {
+    statement += `
+WITH collect (DISTINCT r)[..${limit}] as reaction
+`;
+  } else {
+    statement += `
+WITH collect (DISTINCT r) as reaction
+`;
+  }
 
   statement += `
 CALL apoc.cypher.mapParallel2("
@@ -101,10 +109,6 @@ RETURN apoc.map.mergeList(apoc.coll.flatten(apoc.map.values(apoc.map.groupByMult
 )) as reactions
 ORDER BY reactions.id
 `;
-
-  if (limit) {
-    statement += `LIMIT ${limit}`;
-  }
 
   return queryListResult(statement);
 };

--- a/api/src/neo4j/queries/relatedReactions.js
+++ b/api/src/neo4j/queries/relatedReactions.js
@@ -63,15 +63,7 @@ MATCH (:Compartment${m} {id: '${id}'})-[${v}]-(:CompartmentalizedMetabolite)-[${
       throw new Error(`Unrecognized node type: ${nodeType}`);
   }
 
-  if (limit) {
-    statement += `
-WITH collect (r)[..${limit}] as reaction
-`;
-  } else {
-    statement += `
-WITH collect (r) as reaction
-`;
-  }
+  statement += `WITH collect (r) as reaction`;
 
   statement += `
 CALL apoc.cypher.mapParallel2("
@@ -109,6 +101,10 @@ RETURN apoc.map.mergeList(apoc.coll.flatten(apoc.map.values(apoc.map.groupByMult
 )) as reactions
 ORDER BY reactions.id
 `;
+
+  if (limit) {
+    statement += `LIMIT ${limit}`;
+  }
 
   return queryListResult(statement);
 };

--- a/api/test/metabolites.test.js
+++ b/api/test/metabolites.test.js
@@ -43,10 +43,10 @@ describe('metabolites', () => {
       ),
     ]);
 
-    const [compRelust, allResult] = await Promise.all([
+    const [compResult, allResult] = await Promise.all([
       compartmentalized.json(),
       allCompartments.json(),
     ]);
-    expect(compRelust.length).toBeLessThanOrEqual(allResult.length);
+    expect(compResult.length).toBeLessThanOrEqual(allResult.length);
   });
 });

--- a/api/test/metabolites.test.js
+++ b/api/test/metabolites.test.js
@@ -32,4 +32,21 @@ describe('metabolites', () => {
     const data = await res.json();
     expect(data.length).toBe(2);
   });
+
+  test('a compartmentalized metabolite should have <= related reactions than the corresponding metabolite', async () => {
+    const [compartmentalized, allCompartments] = await Promise.all([
+      fetch(
+        `${API_BASE}/metabolites/MAM02040c/related-reactions?model=HumanGem&version=${HUMAN_GEM_VERSION}&isForAllCompartments=false&limit=1000`
+      ),
+      fetch(
+        `${API_BASE}/metabolites/MAM02040c/related-reactions?model=HumanGem&version=${HUMAN_GEM_VERSION}&isForAllCompartments=true&limit=1000`
+      ),
+    ]);
+
+    const [compRelust, allResult] = await Promise.all([
+      compartmentalized.json(),
+      allCompartments.json(),
+    ]);
+    expect(compRelust.length).toBeLessThanOrEqual(allResult.length);
+  });
 });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1262 . Many thanks to @inghylt for helping out with this!

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Select distinct reactions before applying limit


**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test
Go to `explore/Human-GEM/gem-browser/metabolite/MAM02040c` and check that the number of related reactions are >1000 even when switching to "See reactions for all compartments".

Please also check that the numbers for other metabolite's related reactions are the same as before.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
