### PR TITLE
fix: missing related reactions

### DIFF
--- a/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
+++ b/frontend/src/components/explorer/gemBrowser/ReactionTable.vue
@@ -211,6 +211,15 @@ export default {
       this.$store.dispatch('reactions/clearRelatedReactions');
       this.errorMessage = '';
       try {
+        if (!this.model || this.model.short_name !== this.$route.params.model) {
+          const modelSelectionSuccessful = await this.$store.dispatch(
+            'models/selectModel',
+            this.$route.params.model
+          );
+          if (!modelSelectionSuccessful) {
+            this.modelNotFound = true;
+          }
+        }
         const payload = {
           model: this.model,
           id: this.sourceName,


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1256.
<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)

 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Make sure the model is updated before sending api query (before this fix, FruitFly would be used).



**Testing**  
<!-- Please delete options that are not relevant -->
- Instructions on how to test (stolen from issue)

1. Go to genes page on GEM browser e.g. ENSG00000068120
2. Click an Ensemble protein, e.g. ENSP00000467687
3. Click the component ENSG00000068120 for Human-GEM 
4. Verify that the reaction table contains 4 reactions
5. Refresh the page, note that 4 reactions are still shown


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
