### PR TITLE
style: limit table and content widths

### DIFF
--- a/frontend/src/components/explorer/interactionPartners/ReactionTable.vue
+++ b/frontend/src/components/explorer/interactionPartners/ReactionTable.vue
@@ -267,6 +267,20 @@ export default {
     opacity: 0.3;
   }
 
+  table {
+    table-layout: fixed;
+
+    .tag,
+    .tag-text {
+      max-width: 100%;
+    }
+
+    .td-content,
+    .tag-text {
+      overflow: hidden;
+    }
+  }
+
   sup {
     vertical-align: bottom;
     font-size: 0.7em;
@@ -321,15 +335,6 @@ export default {
 
         .td-content {
           text-align: right;
-        }
-
-        .tag,
-        .tag-text {
-          max-width: 100%;
-        }
-
-        .tag-text {
-          overflow: hidden;
         }
       }
     }


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1253.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other (minor UI change)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Prevent table from being wider than the screen
- Prevent table cell content from overflowing

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="1554" alt="image" src="https://user-images.githubusercontent.com/423498/207315118-4bd22aa0-099a-4903-9e30-003b25fc29b4.png">
<img width="823" alt="image" src="https://user-images.githubusercontent.com/423498/207315603-4e5bdd25-8e65-4c04-8a43-ff7239e02e72.png">
<img width="435" alt="image" src="https://user-images.githubusercontent.com/423498/207315663-7a048e2e-bec9-497c-98be-cbc7d52f65ec.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
1. Visit `/explore/Human-GEM/interaction-partners/MAM01285c`.
2. Scroll down to the reactions table and verify that the width does not exceed the screen and that the table and its contents look good. Please try on different screen widths as well.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
