### PR TITLE
fix: reset page to 1 when sorting or filtering

### DIFF
--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -211,6 +211,7 @@ export default {
           ...this.serverPaginationOptions.pagination,
           column: field,
           isAscending: type === 'asc',
+          page: 1,
         },
       };
 
@@ -228,6 +229,10 @@ export default {
         filters: {
           ...this.serverPaginationOptions.filters,
           ...columnFilters,
+        },
+        pagination: {
+          ...this.serverPaginationOptions.pagination,
+          page: 1,
         },
       };
 

--- a/frontend/src/components/gotEnzymes/EnzymesTable.vue
+++ b/frontend/src/components/gotEnzymes/EnzymesTable.vue
@@ -136,18 +136,6 @@ export default {
           filterOptions: { customFilter: true },
         },
       ].filter(col => col.label !== this.componentType),
-      tablePaginationOptions: {
-        enabled: true,
-        mode: 'pages',
-        perPage: 50,
-        position: 'bottom',
-        setCurrentPage: 1,
-        nextLabel: 'next',
-        prevLabel: 'prev',
-        rowsPerPageLabel: 'Rows per page',
-        ofLabel: 'of',
-        perPageDropdownEnabled: false,
-      },
       serverPaginationOptions: {
         filters: {},
         pagination: {
@@ -164,6 +152,20 @@ export default {
       enzymes: state => state.gotEnzymes.enzymes,
       totalRows: state => state.gotEnzymes.totalEnzymes,
     }),
+    tablePaginationOptions() {
+      return {
+        enabled: !!this.enzymes.length,
+        mode: 'pages',
+        perPage: 50,
+        position: 'bottom',
+        setCurrentPage: 1,
+        nextLabel: 'next',
+        prevLabel: 'prev',
+        rowsPerPageLabel: 'Rows per page',
+        ofLabel: 'of',
+        perPageDropdownEnabled: false,
+      };
+    },
   },
   async beforeMount() {
     await this.setup();


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1269.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Always reset the page to `1` when sorting or filtering. Please read under **Further comments** for the reasoning behind this.

**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
1. Visit an enzymes details page, for example: `/gotenzymes/reaction/R01677`.
2. Go to the bottom of the page and change the page, for example to: `20`.
3. Sort by a column, for example: `Compound`.
4. Verify that the page number displayed in the frontend as well as the `page` parameter sent to the server are both `1`.
5. Filter by a column, for example: enter `C00387` under `Compound`.
6. Verify that the page number displayed in the frontend as well as the `page` parameter sent to the server are both `1`.

**Further comments**  
<!-- Specify questions or related information -->
We had some discussion on whether the page should be changed in the frontend or when sent to the server. Due to UX best practices, as well as library (`vue-good-table`) limitations, it makes the most sense to always set the page to `1` when sorting or filtering.

##### UX best practices
If the user is on page `10` out of `11` total pages:
- When sorting by a new column, in theory it is unlikely that the user has calculated the exact results they would like to see on page `10` with the new sort order prior to the table update. For more info, there is some really good discussion and advice from this page: https://ux.stackexchange.com/questions/129073/should-the-pagination-be-reset-when-changing-the-order
- When filtering, it is likely that the total pages decreases, for example to `5`. If the number of total pages are less than the current page number, it will create a buggy behavior where no rows are displayed and the pagination would be `10` out of `5`. This along with the same reasoning in the point above make it more sensible to reset the page to `1` when filtering.

##### Library limitations
The library that is used for tables and pagination across the website, `vue-good-table`, seems abandoned at this point. Following are some pain points spotted when working on this issue.

- **Can't override.** It seems like they have adopted the same UX best practices as above and [always reset](https://github.com/borisflesch/vue-good-table-next/blob/master/src/components/Table.vue#L1189-L1194) the page to `1` when sorting or filtering. The way this is implemented makes it difficult to override even if we would want to.
- **Displaying pagination at both top and bottom are broken.** I wanted to use the `both` option so that it is clearer to the user what the current page is. When testing, it turns out that the top and bottom pagination are not synced. There are several open issues for this in the original `vue-good-table` repo and it is something that has not been fixed/implemented [since 2018](https://github.com/xaksis/vue-good-table/issues/245#issuecomment-399150172).
- **Abandoned?**
  - The [original library](https://github.com/xaksis/vue-good-table) is not Vue 3 compatible. The [last release](https://www.npmjs.com/package/vue-good-table?activeTab=versions) was from > 1 year ago.
  - The [Vue 3 compatible one](https://github.com/borisflesch/vue-good-table-next), which is still marked as a work-in-progress, has many of the same problems as the original library. The [last release](https://www.npmjs.com/package/vue-good-table-next?activeTab=versions) was from > 7 months ago.
  - In the long term it is probably best to look for a replacement solution to `vue-good-table`. For now it is good to keep in mind of the status and limitations and try to find pragmatic solutions/work-arounds.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
