### PR TITLE
refactor: rewrite jQuery stuff in plain JavaScript

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,6 @@
     "bulma-timeline": "^3.0.5",
     "eslint-config-prettier": "^8.5.0",
     "file-saver": "^2.0.2",
-    "jquery": "3.6.0",
     "nprogress": "0.2.0",
     "vue": "^3.2.0",
     "@ckpack/vue-color": "1.2.0",

--- a/frontend/src/components/SearchTable.vue
+++ b/frontend/src/components/SearchTable.vue
@@ -315,7 +315,6 @@
 
 <script>
 import { mapGetters, mapState } from 'vuex';
-import $ from 'jquery';
 import 'vue-good-table-next/dist/vue-good-table-next.css';
 import { VueGoodTable } from 'vue-good-table-next';
 import Loader from '@/components/Loader.vue';
@@ -633,7 +632,7 @@ export default {
     next();
   },
   updated() {
-    $('#search').focus();
+    document.getElementById('search').focus();
   },
   methods: {
     fillFilterFields() {

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -3294,11 +3294,6 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
-jquery@3.6.0:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1156.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Rewrite jQuery instances using plain JavaScript in:
  - `frontend/src/components/SearchTable.vue`
  - `frontend/src/components/explorer/mapViewer/Svgmap.vue`
- Remove jQuery from the project (`frontend`)


**Testing**  
<!-- Please delete options that are not relevant -->
- A rebuild is needed due to new dependencies
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
1. Visit a 2D map page, for example `/explore/Human-GEM/map-viewer/golgi_apparatus?dim=2d`.
2. Verify that the map works as before. Please try different interactions such as using data overlay, mouse hovering and clicking, toggles, search etc.
3. Visit a global search page, for example `/search?term=mitoc`.
4. Verify that the search works as before.

**Further comments**  
<!-- Specify questions or related information -->
This change shaves another `~12.6 %` off the bundle size (`frontend/stats.html`), going from `2.22 MB` to `1.94 MB`.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
