### PR TITLE
fix: do not include empty results for global search

### DIFF
--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -373,10 +373,17 @@ LIMIT ${limit}
   const resWithScore = {};
   for (const [component, result] of Object.entries(resObj)) {
     if (result) {
-      resWithScore[component] = result.map(obj => ({
-        ...obj,
-        score: getScore(obj, uniqueIds),
-      }));
+      resWithScore[component] = [];
+
+      for (const node of result) {
+        if (Object.keys(node).length === 0) {
+          continue;
+        }
+        resWithScore[component].push({
+          ...node,
+          score: getScore(node, uniqueIds),
+        });
+      }
     } else {
       resWithScore[component] = [];
     }

--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -373,17 +373,15 @@ LIMIT ${limit}
   const resWithScore = {};
   for (const [component, result] of Object.entries(resObj)) {
     if (result) {
-      resWithScore[component] = [];
-
-      for (const node of result) {
-        if (Object.keys(node).length === 0) {
-          continue;
+      resWithScore[component] = result.reduce((list, node) => {
+        if (Object.keys(node).length) {
+          list.push({
+            ...node,
+            score: getScore(node, uniqueIds),
+          });
         }
-        resWithScore[component].push({
-          ...node,
-          score: getScore(node, uniqueIds),
-        });
-      }
+        return list;
+      }, []);
     } else {
       resWithScore[component] = [];
     }

--- a/api/src/neo4j/queries/search/globalSearch.js
+++ b/api/src/neo4j/queries/search/globalSearch.js
@@ -74,15 +74,12 @@ const fetchGenes = async ({ ids, model, version }) => {
     return null;
   }
 
+  // The following unions need to have the gs.name line last or
+  // else the results can randomly drop subsystems or compartments
   const statement = `
 WITH ${JSON.stringify(ids)} as gids
 UNWIND gids as gid
 CALL apoc.cypher.run("
-  MATCH (gs:GeneState)-[${version}]-(:Gene:${model} {id: $gid})
-  RETURN { id: $gid, name: gs.name } as data
-  
-  UNION
-  
   MATCH (:Gene:${model} {id: $gid})-[${version}]-(r:Reaction)
   WITH DISTINCT r
   MATCH (r)-[${version}]-(s:Subsystem)
@@ -97,6 +94,11 @@ CALL apoc.cypher.run("
   MATCH (cm)-[${version}]-(c:Compartment)-[${version}]-(cs:CompartmentState)
   USING JOIN on c
   RETURN { id: $gid, compartment: COLLECT(DISTINCT({ id: c.id, name: cs.name })) } as data
+  
+  UNION
+
+  MATCH (gs:GeneState)-[${version}]-(:Gene:${model} {id: $gid})
+  RETURN { id: $gid, name: gs.name } as data
 ", {gid:gid}) yield value
 RETURN apoc.map.mergeList(apoc.coll.flatten(
 	apoc.map.values(apoc.map.groupByMulti(COLLECT(value.data), "id"), [value.data.id])

--- a/api/test/searchGlobal.test.js
+++ b/api/test/searchGlobal.test.js
@@ -66,4 +66,14 @@ describe('search', () => {
 
     expect(cytosolRetinols.length).toEqual(1);
   });
+
+  test('search should not include results with score 0', async () => {
+    const data = await search({
+      searchTerm: 'Herc1',
+    });
+
+    const { metabolite } = data['Human-GEM'];
+    const emptyMetabolites = metabolite.filter(m => m.score === 0);
+    expect(emptyMetabolites.length).toEqual(0);
+  });
 });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1282.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Prevent empty (`{ score: 0 }`) results from being returned.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->
<img width="1390" alt="image" src="https://user-images.githubusercontent.com/423498/208707191-1a752368-d9ab-465d-8b42-3e92be3d1ffe.png">


**Testing**  
<!-- Please delete options that are not relevant -->
- Relative urls that can be reused both for production and local testing
- Instructions on how to test
1. Visit `/search?term=Herc1`.
2. Click the `Metabolites` tab and scroll to the bottom.
3. Verify that there are **no** empty rows being rendered.
4. Click the Genes tab and make sure that there are no rows with empty values for Subsystem or Compartment.
5. Please repeat the above steps for some other search terms.

**Further comments**  
<!-- Specify questions or related information -->
There is a weird behavior with the cypher query in `fetchGenes` that could randomly drop subsystems or compartments. It seems that when the sub-queries are reordered to have the `gs.name` query last, then this problem goes away. See screenshots below.

Before:
<img width="975" alt="image" src="https://user-images.githubusercontent.com/423498/208893802-83a41b88-61ce-4306-9dce-a5e98cef2cc8.png">

After:
![image](https://user-images.githubusercontent.com/423498/208893852-1f015c7d-2ec9-4ec2-939c-7907055a142e.png)


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
