### PR TITLE
Chore: improve gotenzymes deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ update-gotenzymes
 For remote servers, the init script is configured to run automatically if the database has not been initialized. To reconstruct the database, delete the mounted volume for the database on the remote server (located at `/var/lib/docker-volumes/pg/postgres-data`) and deploy again.
 
 ## Description of helper commands
-**Note that the following commands should be run in a bash shell**
+**Note that the following commands should be run in a bash shell** (the current shell can be replaced using: `exec bash`)
 - To bootstrap the project: `build-stack`
 - To run the project: `start-stack`
 - To stop the project: `stop-stack`

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Finally, start the Docker containers with
 start-stack
 ```
 
-Given successful deployment, the frontend should be accessible at: `http://localhost/`. If you encounter any problems try looking at the logs `logs api` / `logs frontend`.
+Given successful deployment, the frontend should be accessible at: `http://localhost/`. It may take a while before the GotEnzymes database is ready if it has not been built before. If you encounter any problems try looking at the logs `logs api` / `logs frontend`.
 
 To deploy the stack to a remote server, create another `ENV` file, e.g. `env-dev.env`, and modify it accordingly:
 
@@ -92,7 +92,7 @@ deploy-stack dev
 To reconstruct the database for GotEnzymes on the local (development) machine. Run the following. This should take ~10 minutes.
 
 ```bash
- ma-exec pg psql -f scripts/init.sql -U postgres
+update-gotenzymes
 ```
 
 For remote servers, the init script is configured to run automatically if the database has not been initialized. To reconstruct the database, delete the mounted volume for the database on the remote server (located at `/var/lib/docker-volumes/pg/postgres-data`) and deploy again.
@@ -112,7 +112,9 @@ For remote servers, the init script is configured to run automatically if the da
 
 - To clean the project (delete containers and volumes): `clean-stack`
 - To display real-time logs: `logs [container-name: frontend/api/nginx/neo4j/ftp]`
-- To deploy the project: `deploy-stack`
+- To deploy the project to the remote server: `deploy-stack` `<CONTEXT>`
+- To update the GotEnzymes database: `update-gotenzymes [CONTEXT]`
+  - If `CONTEXT` is not provided, the local GotEnzymes database will be reconstructed.
 - To (re-)import the Neo4j database: `import-db`
 
 ### A note to Unix/Linux users

--- a/README.md
+++ b/README.md
@@ -89,13 +89,17 @@ deploy-stack dev
 
 ### GotEnzymes
 
-To reconstruct the database for GotEnzymes on the local (development) machine. Run the following. This should take ~10 minutes.
+To reconstruct the database for GotEnzymes on the local (development) machine. Run the following command. This should take ~10 minutes.
+>For Mac M1 users, please select `VirtioFS` for file sharing in Docker configuration in order to speed up the postgresql database building process.
 
 ```bash
 update-gotenzymes
 ```
 
-For remote servers, the init script is configured to run automatically if the database has not been initialized. To reconstruct the database, delete the mounted volume for the database on the remote server (located at `/var/lib/docker-volumes/pg/postgres-data`) and deploy again.
+For remote servers, run the following command
+```bash
+update-gotenzymes <CONTEXT>
+```
 
 ## Description of helper commands
 **Note that the following commands should be run in a bash shell** (the current shell can be replaced using: `exec bash`)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ update-gotenzymes
 For remote servers, the init script is configured to run automatically if the database has not been initialized. To reconstruct the database, delete the mounted volume for the database on the remote server (located at `/var/lib/docker-volumes/pg/postgres-data`) and deploy again.
 
 ## Description of helper commands
-
+**Note that the following commands should be run in a bash shell**
 - To bootstrap the project: `build-stack`
 - To run the project: `start-stack`
 - To stop the project: `stop-stack`

--- a/README.md
+++ b/README.md
@@ -92,12 +92,12 @@ deploy-stack dev
 To reconstruct the database for GotEnzymes on the local (development) machine, run the following (it should take ~10 minutes). The [source data for GotEnzymes is on Zenodo](https://doi.org/10.5281/zenodo.15814635). After downloading, please unzip it in the `pg/input_data` directory.
 
 ```bash
-update-gotenzymes
+import-pg-db
 ```
 
 For remote servers, run the following command
 ```bash
-update-gotenzymes <CONTEXT>
+import-pg-db <CONTEXT>
 ```
 
 ## Description of helper commands
@@ -116,9 +116,9 @@ update-gotenzymes <CONTEXT>
 - To clean the project (delete containers and volumes): `clean-stack`
 - To display real-time logs: `logs [container-name: frontend/api/nginx/neo4j/ftp]`
 - To deploy the project to the remote server: `deploy-stack` `<CONTEXT>`
-- To update the GotEnzymes database: `update-gotenzymes [CONTEXT]`
+- To update the GotEnzymes database: `import-pg-db [CONTEXT]`
   - If `CONTEXT` is not provided, the local GotEnzymes database will be reconstructed.
-- To (re-)import the Neo4j database: `import-db`
+- To (re-)import the Neo4j database: `import-neo4j-db`
 
 ### A note to Unix/Linux users
 

--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -60,9 +60,12 @@ services:
       - FTP_IP=127.0.0.1
       - FLAGS=-Y 0 -d -d
   pg:
-    image: postgres:14.3-alpine
+    build:
+      context: pg
+    command: postgres -c stats_temp_directory=/tmp
     volumes:
       - ./pg/scripts:/scripts
+      - ./pg/postgres-data:/var/lib/postgresql/data
       - ./pg/input_data:/input_data
     ports:
       - "127.0.0.1:5432:5432"

--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -65,6 +65,7 @@ services:
     command: postgres -c stats_temp_directory=/tmp
     volumes:
       - /var/lib/docker-volumes/pg/postgres-data:/var/lib/postgresql/data
+      - /var/lib/docker-volumes/pg/input_data:/input_data
     deploy:
       resources:
         reservations:

--- a/pg/.dockerignore
+++ b/pg/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+*.zip
+input_data
+postgres-data

--- a/pg/Dockerfile
+++ b/pg/Dockerfile
@@ -1,4 +1,3 @@
 FROM postgres:14.3-alpine
 
-COPY input_data /input_data/
 COPY scripts/init.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1087 

Since the strategies are quite different from the draft PR #1275, a new branch and PR is created. 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] improvement of the deployment
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Given the condition that the GotEnzymes input_data will not be changed frequently in the future, the following changes have been made to avoid frequent data transferring and rebuilding of the GotEnzymes database. 

1. `input_data` is not copied to the container but mounted at  `/var/lib/docker-volumes/pg/input_data/` for the remote server, by doing so, the size of the image `pg` is reduced from 3.04 GB to 216 MB. `input_data` is uploaded to the remote server by `rsync` and do not need to be transferred through docker at every deployment. 
2. For local deployment, the GotEnzymes database is mounted `pg/postgres-data`. The container `pg` is based on the same image `pg` as for the remote deployment. By doing so, the GotEnzymes database will be built only at the first `start-stack` but will not run if it already exists 
3. A command `update-gotenzymes` is added to update the GotEnzymes database either locally or remotely 
    - `update-gotenzymes` for updating the database locally 
    - `update-gotenzymes REMOTE-CONTEXT` for updating the database remotely 
    
   For Mac M1 user, please select `VirtioFS` for file sharing to speed up postgresql database building process.
    
4. `docker system prune --all` is run at each `deploy-stack` to avoid out of disk space problem.

In addition, some verification is added to the helper script, e.g. `deploy-stack` will return the usage of `context` is not provided. The README is also updated accordingly.

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
`source proj.sh` before running the test
For locally deployment, also need to rebuild the pg. 
Test also starting from a clean docker setup. 


**Further comments**  
<!-- Specify questions or related information -->
1. The time of `update-gotenzymes` is normally when running on the remote server with Ubuntu 20.04

```
time -p update-gotenzymes dev2: real 1183.84 user 0.36 sys 0.23
time -p update-gotenzymes dev: real 629.97 user 0.30 sys 0.16  
```

However, on my local machine with Mac M1, it takes 3 hours to build the database at first run of `start-stack`. It seems postgres is using 1-2% of CPU when running the building procedure in the background. I don't know if it happens only to my laptop. Nevertheless, it needs to be done only once. 

2. Regarding the deployment speed, it takes about half the time when there is a clean stack locally. However, when you have deployed to the remote server once, the old setup is sometimes faster. It seems the 3GB pg image is not transferred at all when cache exist. 

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
