### PR TITLE
Fix redirects for gem browser and map viewer

### DIFF
--- a/frontend/src/router.js
+++ b/frontend/src/router.js
@@ -99,13 +99,17 @@ const routes = [
   {
     path: '/explore/gem-browser/human1:pathMatch(.*)*',
     redirect: to => ({
-      path: `/explore/Human-GEM/gem-browser${to.params.pathMatch.join('/')}`,
+      path: `/explore/Human-GEM/gem-browser${
+        Array.isArray(to.params.pathMatch) ? to.params.pathMatch.join('/') : ''
+      }`,
     }),
   },
   {
-    path: '/explore/map-viewer/human1:pathMatch(.*)*',
+    path: '/explore/map-viewer/:sub(human1/compartment|human1/subsystem|human1)/:pathMatch(.*)*',
     redirect: to => ({
-      path: `/explore/Human-GEM/map-viewer${to.params.pathMatch.join('/')}`,
+      path: `/explore/Human-GEM/map-viewer/${
+        Array.isArray(to.params.pathMatch) ? to.params.pathMatch.join('/') : ''
+      }`,
     }),
   },
 


### PR DESCRIPTION
**Related issue(s) and PR(s)** 

This PR closes #1292.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
- Updated redirects for map-viewer so that users end up at right URL without component and subsystem keywords
- Update redirects for map-viewer and genome-browser so that users are redirected to the respective resources rather than ending up in an endless loading page

In short:

- Check for when only gem browser or map viewer is visited
- Make sure the compartment and subsystem keywords are dropped

**Testing**  
<!-- Please delete options that are not relevant -->
Navigate to:

- [/explore/map-viewer/human1/compartment/endoplasmic_reticulum?dim=2d](https://www.metabolicatlas.org/explore/map-viewer/human1/compartment/endoplasmic_reticulum?dim=2d).
- [/explore/map-viewer/human1/)
- [/explore/gem-browser/human1/)

