### PR TITLE
fix: move neo4j imports to untouched container directory

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -38,7 +38,7 @@ services:
       - NEO4J_apoc_import_file_use__neo4j__config=true
     volumes:
       - ./neo4j/plugins:/plugins
-      - ./neo4j/import:/var/lib/neo4j/import
+      - ./neo4j/import:/opt/neo4j-import
     ports:
       - "127.0.0.1:${PORT_NEO4J_1:-7474}:7474"
       - "127.0.0.1:${PORT_NEO4J_2:-7687}:7687"

--- a/proj.sh
+++ b/proj.sh
@@ -190,7 +190,7 @@ import-db () (
       --username "$NEO4J_USERNAME" \
       --password "$NEO4J_PASSWORD" \
       --format plain \
-      --file import/import.cypher
+      --file /opt/neo4j-import/import.cypher
 )
 
 deactivate () {


### PR DESCRIPTION
fix: move neo4j imports to untouched container directory and update import-db

**Related issue(s) and PR(s)**  
This PR closes #1303

It moves the data import files for neo4j from `/var/lib/neo4j/import` to `/opt/neo4j-import` in order to prevent the container from changing the permissions when running.

**Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- Updates `docker-compose-local.yml` to use `/opt/neo4j-import` for imports
- Updates `proj.sh` to use the new import directory


**Testing**  
- Reset your `neo4j/import` directory
- Follow setup instructions
- Run `start-stack`
- Run `import-db`
- Expect the database to imported properly


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
