### PR TITLE
Chore: Add dbms.lock.acquisition.timeout setting

### DIFF
--- a/docker-compose-local.yml
+++ b/docker-compose-local.yml
@@ -33,6 +33,8 @@ services:
 
   neo4j:
     environment:
+      - NEO4J_dbms_transaction_timeout=40s
+      - NEO4J_dbms_lock_acquisition_timeout=40s
       - NEO4J_apoc_export_file_enabled=true
       - NEO4J_apoc_import_file_enabled=true
       - NEO4J_apoc_import_file_use__neo4j__config=true

--- a/docker-compose-remote.yml
+++ b/docker-compose-remote.yml
@@ -33,6 +33,7 @@ services:
   neo4j:
     environment:
       - NEO4J_dbms_transaction_timeout=40s
+      - NEO4J_dbms_lock_acquisition_timeout=40s
       - NEO4J_dbms_memory_heap_initial__size=5G
       - NEO4J_dbms_memory_off__heap_max__size=8G
     restart: unless-stopped


### PR DESCRIPTION

**Related issue(s) and PR(s)**  
This PR closes #903 

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other Changed timeout setting
 
**List of changes made**  
<!-- Specify what changes have been made and why -->

- Set dbms.lock.acquisition.timeout to 40 s in both docker-compose-local.yaml and docker-compose-remote.yaml
- Set dbms.transaction.timeout to 40 s in docker-compose-local.yaml (was set in docker-compose-remote.yaml already) 

**Testing**  
<!-- Please delete options that are not relevant -->

1. Stop and rebuild stack 
2. Open local neo4j browser on http://localhost:7474/browser/
3. Log in with your credentials
4. Run 
```
CALL dbms.listConfig()
YIELD name, value
WHERE name IN ["dbms.transaction.timeout", "dbms.lock.acquisition.timeout"] 
RETURN name, value
```

Expected: Timeout is set to 40 s for both variables. 

Also quickly run application at http://localhost/ 

**Further comments**  

<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
