### PR TITLE
fix: move sorting from frontend to backend for external-db-endpoint

### DIFF
--- a/api/src/neo4j/queries/idInModels.js
+++ b/api/src/neo4j/queries/idInModels.js
@@ -26,20 +26,22 @@ RETURN { externalDb: properties(r), components: COLLECT(DISTINCT({component: r, 
   try {
     let { externalDb, components } = await querySingleResult(statement);
 
-    components = components.map(({ component, version }) => {
-      const { labels, properties } = component;
-      const model = labels
-        .find(l => l.indexOf('Gem') > -1)
-        .replace('Gem', '-GEM');
-      const componentType = labels.find(l => l.indexOf('Gem') === -1);
+    components = components
+      .map(({ component, version }) => {
+        const { labels, properties } = component;
+        const model = labels
+          .find(l => l.indexOf('Gem') > -1)
+          .replace('Gem', '-GEM');
+        const componentType = labels.find(l => l.indexOf('Gem') === -1);
 
-      return {
-        id: properties.id,
-        model,
-        componentType,
-        version: version.replace('V', '').replace(/_/g, '.'),
-      };
-    });
+        return {
+          id: properties.id,
+          model,
+          componentType,
+          version: version.replace('V', '').replace(/_/g, '.'),
+        };
+      })
+      .sort((a, b) => a.model.localeCompare(b.model));
 
     if (dbName === 'MetabolicAtlas') {
       externalDb.dbName = dbName;

--- a/api/test/externalDb.test.js
+++ b/api/test/externalDb.test.js
@@ -1,0 +1,13 @@
+import fetch from 'node-fetch';
+
+describe('externalDb', () => {
+  test('an external db should have components sorted by model name', async () => {
+    const res = await fetch(`${API_BASE}/external-db/BiGG/PPNCL3`).then(r =>
+      r.json()
+    );
+    const models = res.components.map(c => c.model);
+    const sortedModels = [...models].sort((a, b) => a.localeCompare(b));
+
+    expect(models).toEqual(sortedModels);
+  });
+});

--- a/frontend/src/components/IdInModels.vue
+++ b/frontend/src/components/IdInModels.vue
@@ -78,20 +78,12 @@ export default {
       externalDb: state => state.externalDb.externalDb,
     }),
     compGroupedByModel() {
-      const result = this.components.reduce((r, a) => {
+      return this.components.reduce((r, a) => {
         // eslint-disable-next-line
         r[a.model] = r[a.model] || [];
         r[a.model].push(a);
         return r;
       }, {});
-      const orderedRst = Object.keys(result)
-        .sort()
-        .reduce((obj, key) => {
-          // eslint-disable-next-line
-          obj[key] = result[key];
-          return obj;
-        }, {});
-      return orderedRst;
     },
     componentType() {
       return this.components.length > 0


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1309

**Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- Sort `components` result from `/external-db/:dbName/:externalId` api endpoint
- Remove sorting from frontend component for `/identifier/:dbName/:identifierId`

**Testing**  
- Checkout and build project
- Verify that the order is correct in the frontend
- Use any tool to verify that the backend returns the components in the correct order: `curl http://localhost/api/v2/external-db/BiGG/PPNCL3 | jq`
- Run test: `ma-exec api yarn test test/externalDB.test.js`

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
