### PR TITLE
fix: move content sorting from frontend to api for relevant endpoints

### DIFF
--- a/api/src/endpoints/dataOverlay.js
+++ b/api/src/endpoints/dataOverlay.js
@@ -32,7 +32,7 @@ routes.get('/:model/:dataType/:filename/data-sets', async (req, res) => {
     const dataSourceFile = await getDataSourceFile(model, dataType, filename);
     const [, ...dataSets] = dataSourceFile.split(/\r?\n/)[0].split('\t');
 
-    res.json(dataSets);
+    res.json(dataSets.sort((a, b) => a.localeCompare(b)));
   } catch (e) {
     console.error(e.message);
     res.sendStatus(404);

--- a/api/src/endpoints/repository.js
+++ b/api/src/endpoints/repository.js
@@ -28,14 +28,18 @@ const addCountToModel = async model => {
 
 routes.get('/integrated_models', async (req, res) => {
   try {
-    const models = integratedGemsRepoJson.map(model => ({
-      ...model,
-      apiName: model.short_name
-        .split('-')
-        .map(s => s[0] + s.slice(1).toLowerCase())
-        .join(''),
-      apiVersion: model.version.split('.').join('_'),
-    }));
+    const models = integratedGemsRepoJson
+      .map(model => ({
+        ...model,
+        apiName: model.short_name
+          .split('-')
+          .map(s => s[0] + s.slice(1).toLowerCase())
+          .join(''),
+        apiVersion: model.version.split('.').join('_'),
+      }))
+      .sort((a, b) =>
+        a.short_name.toLowerCase() < b.short_name.toLowerCase() ? -1 : 1
+      );
 
     const modelsWithCount = await Promise.all(
       models.map(m => addCountToModel(m))
@@ -65,7 +69,7 @@ routes.get('/integrated_models/:name', async (req, res) => {
 
 routes.get('/models', async (req, res) => {
   try {
-    res.json(gemsRepoJson);
+    res.json(gemsRepoJson.sort((a, b) => a.id - b.id));
   } catch (e) {
     res.status(400).send(e.message);
   }

--- a/api/src/neo4j/queries/relatedMetabolites.js
+++ b/api/src/neo4j/queries/relatedMetabolites.js
@@ -15,7 +15,8 @@ RETURN {
     id: c.id, 
     .*
   }
-} as metabolites`;
+} as metabolites
+ORDER BY metabolites.id`;
 
   return queryListResult(statement);
 };

--- a/api/test/dataOverlay.test.js
+++ b/api/test/dataOverlay.test.js
@@ -8,4 +8,14 @@ describe('data overlay', () => {
     expect(Object.values(data).length).toBeGreaterThan(0);
     expect(Object.values(data)[0].length).toBeGreaterThan(0);
   });
+
+  test('should return an ordered list of data set names', async () => {
+    const res = await fetch(
+      `${API_BASE}/data-overlay/Human-GEM/reaction/HPA_single-cell_reactions.tsv/data-sets`
+    );
+
+    const data = await res.json();
+    const sortedData = [...data].sort((a, b) => a.localeCompare(b));
+    expect(data).toEqual(sortedData);
+  });
 });

--- a/api/test/metabolites.test.js
+++ b/api/test/metabolites.test.js
@@ -49,4 +49,14 @@ describe('metabolites', () => {
     ]);
     expect(compResult.length).toBeLessThanOrEqual(allResult.length);
   });
+
+  test('should return an ordered list of related metabolites', async () => {
+    const res = await fetch(
+      `${API_BASE}/metabolites/MAM02319e/related-metabolites?model=ZebrafishGem&version=${ZEBRAFISH_GEM_VERSION}`
+    );
+
+    const relatedMetabolites = (await res.json()).map(m => m.id);
+    const orderedMetabolites = ['MAM02319c', 'MAM02319m'];
+    expect(relatedMetabolites).toEqual(orderedMetabolites);
+  });
 });

--- a/api/test/repository.test.js
+++ b/api/test/repository.test.js
@@ -1,0 +1,21 @@
+import fetch from 'node-fetch';
+
+describe('repository', () => {
+  test('should return an ordered list of integrated models', async () => {
+    const res = await fetch(`${API_BASE}/repository/integrated_models`);
+
+    const models = await res.json();
+    const sortedModels = [...models].sort((a, b) =>
+      a.short_name.toLowerCase() < b.short_name.toLowerCase() ? -1 : 1
+    );
+    expect(models).toEqual(sortedModels);
+  });
+
+  test('should return an ordered list of models', async () => {
+    const res = await fetch(`${API_BASE}/repository/models`);
+
+    const models = await res.json();
+    const sortedModels = [...models].sort((a, b) => a.id - b.id);
+    expect(models).toEqual(sortedModels);
+  });
+});

--- a/frontend/src/store/modules/gems.js
+++ b/frontend/src/store/modules/gems.js
@@ -40,10 +40,7 @@ const actions = {
       return strippedGem;
     });
 
-    commit(
-      'setGems',
-      formattedGems.sort((a, b) => a.id - b.id)
-    );
+    commit('setGems', formattedGems);
   },
   getGemData({ commit, state }, id) {
     const gem = state.gems.find(g => g.id === id);

--- a/frontend/src/store/modules/models.js
+++ b/frontend/src/store/modules/models.js
@@ -31,10 +31,7 @@ const actions = {
   async getModels({ commit, state }) {
     if (state.modelList.length === 0) {
       const models = await modelsApi.fetchModels();
-      commit(
-        'setModelList',
-        models.sort((a, b) => (a.short_name.toLowerCase() < b.short_name.toLowerCase() ? -1 : 1))
-      );
+      commit('setModelList', models);
     }
   },
   /* eslint-disable no-shadow */


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #609

**Type of change**  
- [x] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
- Move sorting from frontend to backend
- Frontend views no longer sorts entries
- The following api entrypoints have been updated
  - '/data-overlay/:model/:dataType/:filename/data-sets': sort names
  - '/metabolites/:id/related-metabolites': sort by id
  - '/repository/models': sort according to frontend method
  - '/repository/integrated_models': sort according to frontend method

**Testing**  
- Make sure tests seem sane
- Make sure tests succeed `ma-exec api yarn test test/metabolites.test.js test/dataOverlay.test.js test/repository.test.js`
- Verify that navigating to metabolites from http://localhost/explore/Zebrafish-GEM/gem-browser works as expected
- Verifying that selecting overlay works http://localhost/explore/Human-GEM/map-viewer/


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
