### PR TITLE
Feature: Navigate to new route when expanding IP node to get browser history correct

### DIFF
--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -361,7 +361,6 @@ export default {
       }
     },
     navigateToExpansion() {
-
       function createExpandedQuery(query, newId) {
         const expandedQuery = { ...query };
         if (query.expandedIds && !query.expandedIds?.includes(newId)) {

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -296,7 +296,7 @@ export default {
       const viewerHeight = this.$refs.viewer3d.clientHeight;
       this.$refs.viewer3d.style.height = `${viewerHeight}px`;
     },
-    handleWindowResize(event) {
+    handleWindowResize() {
       clearTimeout(this.resizeTimer);
 
       this.resizeTimer = setTimeout(async () => {

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -361,10 +361,8 @@ export default {
       }
     },
     navigateToExpansion() {
-      console.log('Navigate to expansion');
 
       function createExpandedQuery(query, newId) {
-        console.log(query);
         const expandedQuery = { ...query };
         if (query.expandedIds && !query.expandedIds?.includes(newId)) {
           expandedQuery.expandedIds = [...query.expandedIds.split(','), newId].join(',');

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -374,7 +374,7 @@ export default {
         console.log(query);
         const expandedQuery = { ...query };
         if (query.expandedIds && !query.expandedIds?.includes(newId)) {
-          expandedQuery.expandedIds = [...query.expandedIds.split(","), newId].join(",");
+          expandedQuery.expandedIds = [...query.expandedIds.split(','), newId].join(',');
         } else {
           expandedQuery.expandedIds = newId;
         }

--- a/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
+++ b/frontend/src/components/explorer/interactionPartners/DetailsPage.vue
@@ -300,13 +300,6 @@ export default {
       clearTimeout(this.resizeTimer);
 
       this.resizeTimer = setTimeout(async () => {
-        // handleQueryParamsWatch emits a window resize event with cancelable
-        // set to true (default is false). This is to prevent handleQueryParamsWatch
-        // from triggering the height fix.
-        if (event.cancelable) {
-          return;
-        }
-
         // This temporarily disables the effect of `setFixedViewerHeight`
         this.$refs.viewer3d.style.height = '100%';
         await this.applyColorsAndRenderNetwork();


### PR DESCRIPTION

**Related issue(s) and PR(s)**  
This PR closes #1168 

<!-- Include below a description of the changes proposed in the pull request -->
Changed the order of things when expanding interaction partner nodes. Instead of loading the data into the store first and trying to get routes correct later, navigate to new route first and load expansions from query params. 

**Type of change**  
- [x] New feature (non-breaking change which adds functionality)
 
**List of changes made**  
<!-- Specify what changes have been made and why -->

- Context action (_Expand Interaction Partners_) click navigates to new route instead of loading expansions
- On new params expansions are reset and reloaded (just as if following a deep link to this expansion state) 

Note that this could possibly affect performance as expansions are reloaded even if already present in store, but compared to production the same requests seem to be made so it seems this behavior is not changed. 

**Screenshot of the fix**  
<!-- Attach screenshot if relevant -->

**Testing**  
<!-- Please delete options that are not relevant -->
1. Go to http://localhost/explore/Human-GEM/interaction-partners
2. Right click a node and click _Expand Interaction Partners_
3. Repeat step 2
4. Go back in browser 
5. Each back step should take you to the previous expansion state.

Also test that interaction partner seem work as on https://metabolicatlas.org/explore/Human-GEM/interaction-partners in other respects. 


**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
