### PR TITLE
feat: add overlay status indicator panel

### DIFF
--- a/frontend/cypress/e2e/homepage.cy.js
+++ b/frontend/cypress/e2e/homepage.cy.js
@@ -37,4 +37,22 @@ context('Homepage', () => {
     })
   })
 
+  describe('DataOverlay', () => {
+    const targets = [
+      {
+        url: '/explore/Human-GEM/map-viewer/acyl_coa_hydrolysis?dim=2d&panel=1&sel=&search=&coords=-3034.36,-3215.63,0.25,0,0,500&dataTypes=gene&dataSources=hpaRna.tsv&dataSets=adipose%20tissue',
+        indicator: 'gene'
+      },
+      {
+        url: '/explore/Human-GEM/map-viewer/acyl_coa_hydrolysis?dim=2d&panel=1&sel=&search=&coords=-3034.36,-3215.63,0.25,0,0,500&dataTypes=reaction&dataSources=HPA_single-cell_reactions.tsv&dataSets=adipose%20tissue_adipocytes_11',
+        indicator: 'reaction'
+      }
+    ]
+    for (const {url, indicator} of targets) {
+      it(`It has the ${indicator} indicator`, () => {
+        cy.visit(url)
+        cy.get('.map-indicators .indicator-id').contains(indicator)
+      })
+    }
+  })
 })

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -96,6 +96,7 @@
             @un-select="unSelect"
             @update-panel-selection-data="updatePanelSelectionData"
           />
+          <IndicatorPanel class="map-indicators" :indicators="dataOverlayIndicators" />
           <ErrorPanel
             :message="loadMapErrorMessage"
             :hide-error-panel="(loadMapErrorMessage = '')"
@@ -160,6 +161,7 @@ import NotFound from '@/components/NotFound.vue';
 import SidebarDataPanels from '@/components/explorer/mapViewer/SidebarDataPanels.vue';
 import Svgmap from '@/components/explorer/mapViewer/Svgmap.vue';
 import ThreeDViewer from '@/components/explorer/mapViewer/ThreeDviewer.vue';
+import IndicatorPanel from '@/components/explorer/mapViewer/IndicatorPanel.vue';
 import { default as messages } from '@/content/messages';
 
 export default {
@@ -173,6 +175,7 @@ export default {
     Svgmap,
     ThreeDViewer,
     MissingReactionModal,
+    IndicatorPanel,
   },
   data() {
     return {
@@ -204,6 +207,7 @@ export default {
     ...mapGetters({
       mapQueryParams: 'maps/queryParams',
       dataOverlayQueryParams: 'dataOverlay/queryParams',
+      dataOverlayIndicators: 'dataOverlay/indicators',
     }),
     queryParams() {
       return { ...this.mapQueryParams, ...this.dataOverlayQueryParams };
@@ -470,5 +474,11 @@ export default {
   @media (max-width: $tablet) {
     display: none;
   }
+}
+
+.map-indicators {
+  position: absolute;
+  bottom: 1rem;
+  right: 1rem;
 }
 </style>

--- a/frontend/src/components/explorer/mapViewer/IndicatorPanel.vue
+++ b/frontend/src/components/explorer/mapViewer/IndicatorPanel.vue
@@ -1,0 +1,77 @@
+<template>
+  <div v-if="groupsWithItems.length > 0" class="indicator-panel overlay p-2">
+    <div v-for="group in groupsWithItems" :key="group.id" class="indicator-group">
+      <span class="indicator-group-name">{{ group.name }}</span>
+      <ul class="indicator-list p-0 m-0">
+        <li v-for="item in group.items" :key="item.id" class="indicator">
+          <span class="indicator-id">{{ item.id }}</span>
+          <span v-if="item.status !== undefined" class="indicator-separator">:&nbsp;</span>
+          <span v-if="item.status !== undefined" class="indicator-status">{{ item.status }}</span>
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'IndicatorPanel',
+  props: {
+    indicators: {
+      type: Array,
+      required: true,
+    },
+    groups: {
+      type: Array,
+      required: false,
+    },
+    showEmptyGroups: {
+      type: Boolean,
+      required: false,
+    },
+  },
+  computed: {
+    groupsWithItems() {
+      const groupedItems = this.indicators.reduce((acc, indicator) => {
+        const { groupId } = indicator;
+        const items = acc[groupId] || [];
+        items.push(indicator);
+        acc[groupId] = items;
+        return acc;
+      }, {});
+
+      const groups = this.groups
+        ? this.groups.filter(group => group.id in groupedItems)
+        : Object.keys(groupedItems).map(id => ({ id, name: id }));
+
+      return groups.map(({ id, name }) => ({
+        id,
+        name,
+        items: groupedItems[id],
+      }));
+    },
+  },
+};
+</script>
+
+<style lang="scss">
+.indicator-panel {
+  color: #fff;
+}
+
+.indicator-group-name {
+  font-weight: bold;
+}
+
+.indicator {
+  padding: 0 0.5rem;
+}
+
+.indicator > .indicator-id {
+  text-transform: capitalize;
+}
+
+.indicator > .indicator-status {
+  text-transform: capitalize;
+}
+</style>

--- a/frontend/src/store/modules/dataOverlay.js
+++ b/frontend/src/store/modules/dataOverlay.js
@@ -62,6 +62,14 @@ const getters = {
     });
     return componentTypes;
   },
+  indicators: (state, results) =>
+    results.componentTypes
+      .map(type => ({
+        groupId: 'Overlays',
+        id: type,
+        status: 'On',
+      }))
+      .sort((a, b) => a.id.localeCompare(b.id)),
 };
 
 const actions = {
@@ -202,7 +210,7 @@ const actions = {
         });
       } else {
         await commit('removeDataType', currentDataSourceIndex);
-        await commit('setDataSet', { currentDataSourceIndex, dataSet: 'None' });
+        await commit('setDataSet', { index: currentDataSourceIndex, dataSet: 'None' });
       }
     }
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #975

Adds a panel indicating the overlay data status

**Type of change**  
- [x] New feature (non-breaking change which adds functionality)

**List of changes made**  
- Add an indicators getter to dataOverlay
- Add an indicator panel component
- Add indicator panel to mapviewer

**Screenshot of the fix**  
![Screen Shot 2023-04-13 at 18 00 11](https://user-images.githubusercontent.com/124560665/231818156-cc62b9c2-7874-4133-ae48-df26cc2336aa.png)

**Testing**  
- Go to: http://localhost/explore/Human-GEM/map-viewer/acylglycerides_metabolism?dim=2d&panel=0&sel=&search=&coords=-1973.35,-3529.21,0.18,0,0,500&dataTypes=gene,reaction&dataSources=hpaRna.tsv,HPA_single-cell_reactions.tsv&dataSets=adrenal%20gland,adipose%20tissue_fibroblasts_0
- Look for the panel in the lower right corner
- Change the overlays and verify that it is updated


**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
