### PR TITLE
fix: Add `url` to `identifier` responses for MA ids

### DIFF
--- a/api/src/neo4j/queries/idInModels.js
+++ b/api/src/neo4j/queries/idInModels.js
@@ -46,6 +46,7 @@ RETURN { identifier: properties(r), components: COLLECT(DISTINCT({component: r, 
     if (dbName === 'MetabolicAtlas') {
       identifier.dbName = dbName;
       identifier.externalId = identifier.id;
+      identifier.url = `https://identifiers.org/metatlas:${identifier.id}`;
     }
 
     return { components, identifier };

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -612,7 +612,7 @@ paths:
           in: 'path'
           required: true
           type: 'string'
-          description: 'the external ID, e.g. **ENSG00000120915** or **MAR02279** for *Protien Atlas* and *MetabolicAtlas* respectively'
+          description: 'the external ID, e.g. **ENSG00000120915** or **MAR02279** for *Protein Atlas* and *MetabolicAtlas* respectively'
       responses:
         '200':
           description: 'Successful query'

--- a/api/src/swagger/config.yaml
+++ b/api/src/swagger/config.yaml
@@ -607,12 +607,12 @@ paths:
           in: 'path'
           required: true
           type: 'string'
-          description: 'the name of the database, e.g. **Protein Atlas**'
+          description: 'the name of the database, e.g. **Protein Atlas** or **MetabolicAtlas**'
         - name: 'externalId'
           in: 'path'
           required: true
           type: 'string'
-          description: 'the external ID, e.g. **ENSG00000120915**'
+          description: 'the external ID, e.g. **ENSG00000120915** or **MAR02279** for *Protien Atlas* and *MetabolicAtlas* respectively'
       responses:
         '200':
           description: 'Successful query'

--- a/api/test/identifier.test.js
+++ b/api/test/identifier.test.js
@@ -10,4 +10,26 @@ describe('identifier', () => {
 
     expect(models).toEqual(sortedModels);
   });
+  test('a response identifier must include id, dbName, externalId and url', async () => {
+    const exampleItems = [
+      'BiGG/PPNCL3',
+      'MetabolicAtlas/MAR02279',
+      'Protein%20Atlas/ENSG00000120915',
+    ];
+    const responses = await Promise.all(
+      exampleItems.map(item =>
+        fetch(`${API_BASE}/identifier/${item}`).then(r => r.json())
+      )
+    );
+    for (const res of responses) {
+      expect(res.identifier).toEqual(
+        expect.objectContaining({
+          id: expect.any(String),
+          dbName: expect.any(String),
+          externalId: expect.any(String),
+          url: expect.stringContaining('https://'),
+        })
+      );
+    }
+  });
 });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1331

It adds an identifier `url` to responses for `MetabolicAtlas` database items.

**Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- Add `url` to responses with `dbName === 'MetabolicAtlas'`

**Example**
***command***
```sh
curl http://localhost/api/v2/identifier/MetabolicAtlas/MAR02279 | jq
```
***output***
```json
{
  "components": [
    {
      "id": "MAR02279",
      "model": "Fruitfly-GEM",
      "componentType": "Reaction",
      "version": "1.2.0"
    },
    {
      "id": "MAR02279",
      "model": "Human-GEM",
      "componentType": "Reaction",
      "version": "1.12.0"
    },
    {
      "id": "MAR02279",
      "model": "Mouse-GEM",
      "componentType": "Reaction",
      "version": "1.3.0"
    },
    {
      "id": "MAR02279",
      "model": "Rat-GEM",
      "componentType": "Reaction",
      "version": "1.3.0"
    },
    {
      "id": "MAR02279",
      "model": "Worm-GEM",
      "componentType": "Reaction",
      "version": "1.3.0"
    },
    {
      "id": "MAR02279",
      "model": "Zebrafish-GEM",
      "componentType": "Reaction",
      "version": "1.2.0"
    }
  ],
  "identifier": {
    "id": "MAR02279",
    "dbName": "MetabolicAtlas",
    "externalId": "MAR02279",
    "url": "https://identifiers.org/metatlas:MAR02279"
  }
}
```

**Testing**  
- Use command `ma-exec api npx jest test/identifier.test.js`
- Verify that the test looks sane

- Or `curl http://localhost/api/v2/identifier/MetabolicAtlas/MAR02279 | jq`
- Verify that `.identifier.url` exists and works

**Further comments**  
My expectation is that this should be enough to solve this task. As far as I could tell only the items relating to externalDbs included `url` in their data so this should not conflict with any table data. However I am open to the possibility that it could make sense to first check for an existing `url` on the object before applying the generated on.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
