### PR TITLE
fix: remove unused css selectors

### DIFF
--- a/frontend/src/components/Home.vue
+++ b/frontend/src/components/Home.vue
@@ -309,11 +309,5 @@ export default {
   .card {
     max-width: 500px;
   }
-  .stripe:nth-child(2n) {
-    background: whitesmoke;
-    .columns {
-      flex-direction: row-reverse;
-    }
-  }
 }
 </style>

--- a/frontend/src/components/explorer/MapViewer.vue
+++ b/frontend/src/components/explorer/MapViewer.vue
@@ -439,9 +439,6 @@ export default {
     .om-3 {
       order: 3;
     }
-    .om-4 {
-      order: 4;
-    }
   }
 }
 

--- a/frontend/src/components/explorer/interactionPartners/ContextMenu.vue
+++ b/frontend/src/components/explorer/interactionPartners/ContextMenu.vue
@@ -31,9 +31,7 @@ export default {
 </script>
 
 <style lang="scss">
-#contextMenuGraph,
-#contextMenuExport,
-#contextMenuExpression {
+#contextMenuGraph {
   position: absolute;
   z-index: 20;
 


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes https://github.com/MetabolicAtlas/private-issues/issues/37 and relates to #1304 and #1313.

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Other: Removal of unused code
 
**List of changes made**  
<!-- Specify what changes have been made and why -->
Removed CSS selectors that are not used.

**Testing**  
<!-- Please delete options that are not relevant -->
Check that the first page, Map Viewer and Interaction Partners pages work like expected.

**Further comments**  
<!-- Specify questions or related information -->
The CSS selectors that are listed in #37 as unused have been tested to find out if this was the case. It turned out that some of them were actually used (see comments in #37).

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
