### PR TITLE
Fix/make sure integrated model data is loaded

### DIFF
--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -346,6 +346,7 @@ export default {
     try {
       this.showLoader = true;
       await this.$store.dispatch('gems/getGems');
+      await this.$store.dispatch('models/getModels');
       this.columns[0].filterOptions.filterDropdownItems = this.setFilterOptions;
       this.columns[3].filterOptions.filterDropdownItems = this.systemFilterOptions;
       this.columns[4].filterOptions.filterDropdownItems = this.conditionFilterOptions;
@@ -379,13 +380,11 @@ export default {
       this.showModelId = '';
       this.selectedModel = {};
       if (urlId) {
-        Object.values(this.integratedModels).forEach(anIntegratedModel => {
-          if (urlId === anIntegratedModel.short_name) {
-            this.selectedModel = anIntegratedModel;
-            this.showModelId = this.selectedModel.short_name;
-          }
-        });
-        if (!this.showModelId) {
+        const integratedModel = this.integratedModels.find(im => urlId === im.short_name);
+        if (integratedModel) {
+          this.selectedModel = integratedModel;
+          this.showModelId = this.selectedModel.short_name;
+        } else {
           const urlIdExists = this.$store.dispatch('gems/getGemData', urlId);
           if (urlIdExists) {
             this.selectedModel = this.gem;

--- a/frontend/src/components/Repository.vue
+++ b/frontend/src/components/Repository.vue
@@ -396,7 +396,7 @@ export default {
       }
     },
     selectModel(id) {
-      this.$router.push({ params: { model_id: id } });
+      this.$router.push({ params: { model_id: id || '' } });
     },
   },
 };


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR tries to fix issues with the route `https://metabolicatlas.org/gems/repository/<gem-or-model-id>`. 

The issues were as follows:
- When going to a page using any `<gem-or-model-id>` it would be impossible to close the modal: ex. https://metabolicatlas.org/gems/repository/Fruitfly-GEM
- When going to a page using any `<gem-or-model-id>` the data would fail to load properly in local development builds: ex. http://localhost/gems/repository/Fruitfly-GEM -> `TypeError: can't access property "short_name", $data.selectedModel is null`

<!-- Include below a description of the changes proposed in the pull request -->

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- Preload integrated models to make sure they are available when fetching model/gem via id
- Use an empty string in the route when setting model id to null in order to properly navigate

**Testing**  
- Go to: https://metabolicatlas.org/gems/repository
- Click any gem
- Click the close button on the modal an expect it to close and take you back to https://metabolicatlas.org/gems/repository
- In develop: go to: http://localhost/gems/repository/Fruitfly-GEM
- Expect the relevant modal to open without errors in the console

**Further comments**  
<!-- Specify questions or related information -->

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
