### PR TITLE
fix: expansion of interaction partners

### DIFF
--- a/api/src/endpoints/neo4j.js
+++ b/api/src/endpoints/neo4j.js
@@ -36,7 +36,8 @@ function validatePayload(payload) {
 
 function validateInput(value) {
   if (Array.isArray(value)) {
-    throw new Error('Arrays not expected as inputs');
+    value.forEach(validateInput);
+    return;
   }
   MALICIOUS_CHARACTERS.forEach(malicious_char => {
     if (value && value.includes(malicious_char)) {

--- a/api/test/interactionPartners.test.js
+++ b/api/test/interactionPartners.test.js
@@ -61,4 +61,35 @@ describe('interaction partners', () => {
       await expectBadReqeustMaliciousCharacter(res);
     },
   );
+
+  test('expansion accepts an expanded array without rejecting it as an array input', async () => {
+    const id = 'ENSG00000120697';
+    const params = new URLSearchParams({
+      model: 'HumanGem',
+      version: HUMAN_GEM_VERSION,
+    });
+    params.append('expanded[]', id);
+    params.append('expanded[]', id);
+    const res = await fetch(
+      `${API_BASE}/interaction-partners-expansion/${id}?${params.toString()}`,
+    );
+    const body = await res.text();
+    expect(body).not.toBe('Arrays not expected as inputs');
+  });
+
+  // eslint-disable-next-line jest/expect-expect
+  test.each(MALICIOUS_CHARACTERS)(
+    'expansion should return 400 if an expanded array element contains %p',
+    async character => {
+      const params = new URLSearchParams({
+        model: 'HumanGem',
+        version: HUMAN_GEM_VERSION,
+      });
+      params.append('expanded[]', character);
+      const res = await fetch(
+        `${API_BASE}/interaction-partners-expansion/ENSG00000120697?${params.toString()}`,
+      );
+      await expectBadReqeustMaliciousCharacter(res);
+    },
+  );
 });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1378.

**Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- `api/src/endpoints/neo4j.js`: `validateInput` now recurses into arrays instead of rejecting them outright. The `/interaction-partners-expansion/:id` endpoint legitimately receives `expanded` as an array of node ids — axios serializes the JS array as `expanded[]=…` and Express' `qs` parser turns it back into an array — but `validatePayload` was throwing `Arrays not expected as inputs` before the request could reach the query handler, so every expansion attempt returned 400. The malicious-character check still runs on each array element, so the safety rail is preserved.
- `api/test/interactionPartners.test.js`: added two integration tests for the expansion endpoint — one asserting that an array-valued `expanded` is no longer rejected as an array input, and one parameterised over `MALICIOUS_CHARACTERS` confirming that injection attempts inside an array element still return 400 with `Malicious char detected`.

**Testing**  
- Instructions on how to test:
  1. Start the stack (`source proj.sh && start-stack`).
  2. Navigate to a gene or metabolite in Interaction Partners, e.g. `/explore/Human-GEM/interaction-partners/ENSG00000120697`.
  3. Right-click a node to expand it. The graph should grow with the expansion's neighbours instead of breaking.
- Running the new automated tests: the Jest suite is currently not runnable as-is because `node-fetch` v3 is ESM-only and there's no Babel/Jest transform configured for it (a pre-existing issue on `main`, not introduced by this PR). To run the tests locally, comment out the line `import fetch from 'node-fetch';` at the top of `api/test/interactionPartners.test.js` (Node 18+ provides `fetch` globally), then run `source proj.sh && ma-exec api npx jest interactionPartners`

**Further comments**  
While investigating I noticed two adjacent issues that I've kept out of this PR to keep the diff minimal:
- The `componentTypes` query parameter on `/random-components` is broken because the frontend passes a JS object to axios, which axios v1 serializes via `toString()` to the literal string `"[object Object]"`, causing the backend's `JSON.parse` to throw. The "random components" landing of Interaction Partners hangs because of this. Worth tracking in a separate issue.
- Inside `getInteractionPartnersExpansion`, `expanded.filter(n => n.trim())` assumes `expanded` is always an array. Currently the frontend always sends an array via axios so this isn't reachable, but a more defensive normalisation would be safer.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing — see "Testing" note: the Jest suite is broken on `main` independently of this change; new tests pass after the one-line workaround
- [x] My changes generate no new warnings

