### PR TITLE
fix: random components fails to load on Interaction Partners page

### DIFF
--- a/api/test/randomComponents.test.js
+++ b/api/test/randomComponents.test.js
@@ -24,4 +24,22 @@ describe('random components', () => {
       await expectBadReqeustMaliciousCharacter(res);
     },
   );
+
+  test('should return 400 if componentTypes is not a JSON-encoded string', async () => {
+    const res = await fetch(
+      `${API_BASE}/random-components?model=HumanGem&componentTypes=${encodeURIComponent('[object Object]')}`,
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test('returns 200 when componentTypes is a JSON-stringified object', async () => {
+    const componentTypes = JSON.stringify({
+      gene: true,
+      compartmentalizedMetabolite: true,
+    });
+    const res = await fetch(
+      `${API_BASE}/random-components?model=HumanGem&version=${HUMAN_GEM_VERSION}&componentTypes=${encodeURIComponent(componentTypes)}`,
+    );
+    expect(res.status).toBe(200);
+  });
 });

--- a/frontend/src/api/randomComponents.js
+++ b/frontend/src/api/randomComponents.js
@@ -4,7 +4,7 @@ const fetchRandomComponents = async ({ model, version, componentTypes }) => {
   const params = { model, version };
 
   if (componentTypes) {
-    params.componentTypes = componentTypes;
+    params.componentTypes = JSON.stringify(componentTypes);
   }
 
   const { data } = await axios.get('/random-components', { params });


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1439.

**Type of change**  
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- `frontend/src/api/randomComponents.js`: serialize `componentTypes` with `JSON.stringify` before passing it to axios. The backend at `api/src/endpoints/neo4j.js` calls `JSON.parse(componentTypes)` and expects a JSON-encoded string. Since the axios v1 bump (commit `77fba57d`), axios' default parameter serializer stringifies nested objects via `toString()`, producing the literal string `"[object Object]"`, which the backend then fails to parse. Pre-stringifying restores the contract the backend expects.
- `api/test/randomComponents.test.js`: added two integration tests for the `/random-components` endpoint — one asserting that a non-JSON `componentTypes` (e.g. the literal `[object Object]` string axios v1 was producing) returns 400, and one asserting that a properly `JSON.stringify`'d `componentTypes` returns 200. The first test is the regression test for this fix.

**Testing**  
- Manual test:
  1. Start the stack (`source proj.sh && start-stack`).
  2. Navigate to `http://localhost/explore/Human-GEM/interaction-partners`.
  3. The "random components of Human-GEM" button should resolve and the four tiles (two genes, two metabolites) should populate. Clicking the button again fetches a new random set.
- Running the new automated tests: the Jest suite is currently not runnable as-is because `node-fetch` v3 is ESM-only and there's no Babel/Jest transform configured for it (a pre-existing issue on `main`, not introduced by this PR; tracked in the "Jest test suite is broken" issue). To run the tests locally with the stack up, comment out the line `import fetch from 'node-fetch';` at the top of `api/test/randomComponents.test.js` (Node 18+ provides `fetch` globally), then run `source proj.sh && ma-exec api npx jest randomComponents`. Both new tests should pass.

**Further comments**  
The same axios-v1 serialization shift could affect other call sites that pass non-primitive values as axios `params`. A repo-wide audit of `params.<key> = <object>` is worth doing as a follow-up.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [ ] Tests and lint/format validations are passing — the Jest suite is currently unrunnable on `main` (tracked in the "Jest test suite is broken" issue), new tests pass after the one-line workaround
- [x] My changes generate no new warnings