### PR TITLE
fix: jest test suite is broken

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -21,7 +21,6 @@
     "neo4j-driver": "^5.28.1",
     "ngraph.forcelayout": "^3.3.1",
     "ngraph.graph": "^20.0.1",
-    "node-fetch": "3.3.2",
     "postgres": "^3.4.7",
     "sanitize-filename": "^1.6.3",
     "sharp": "^0.33.5",

--- a/api/test/compare.test.js
+++ b/api/test/compare.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { MALICIOUS_CHARACTERS } from '../src/malicious-characters';
 import { expectBadReqeustMaliciousCharacter } from './util';
 

--- a/api/test/compartments.test.js
+++ b/api/test/compartments.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   expectEmptyResponse,

--- a/api/test/crossReference.test.js
+++ b/api/test/crossReference.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 
 describe('cross reference', () => {
   test('should return more than one component', async () => {

--- a/api/test/crossReference.test.js
+++ b/api/test/crossReference.test.js
@@ -1,4 +1,3 @@
-
 describe('cross reference', () => {
   test('should return more than one component', async () => {
     const res = await fetch(`${API_BASE}/identifier/HMR%202.0/HMR_1157`);

--- a/api/test/dataOverlay.test.js
+++ b/api/test/dataOverlay.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 
 describe('data overlay', () => {
   test('should return at least one data type, that includes at least one data source', async () => {

--- a/api/test/dataOverlay.test.js
+++ b/api/test/dataOverlay.test.js
@@ -1,4 +1,3 @@
-
 describe('data overlay', () => {
   test('should return at least one data type, that includes at least one data source', async () => {
     const res = await fetch(`${API_BASE}/data-overlay/Human-GEM`);

--- a/api/test/gemComparison.test.js
+++ b/api/test/gemComparison.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 
 describe('GEM comparison', () => {
   test('the comparison should have reactions data', async () => {

--- a/api/test/gemComparison.test.js
+++ b/api/test/gemComparison.test.js
@@ -1,4 +1,3 @@
-
 describe('GEM comparison', () => {
   test('the comparison should have reactions data', async () => {
     const res = await fetch(

--- a/api/test/genes.test.js
+++ b/api/test/genes.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   expectEmptyResponse,

--- a/api/test/gotEnzymes.test.js
+++ b/api/test/gotEnzymes.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 
 describe('gotEnzymes', () => {
   describe('search', () => {

--- a/api/test/gotEnzymes.test.js
+++ b/api/test/gotEnzymes.test.js
@@ -1,4 +1,3 @@
-
 describe('gotEnzymes', () => {
   describe('search', () => {
     it.each(['aspmetasp', 'dioxat', 'glnasngln', 'vacuole', 'zurr'])(

--- a/api/test/hpa.test.js
+++ b/api/test/hpa.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { MALICIOUS_CHARACTERS } from '../src/malicious-characters';
 import {
   expectBadReqeustMaliciousCharacter,

--- a/api/test/identifier.test.js
+++ b/api/test/identifier.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   maliciousCharactersExceptPathSeparators,

--- a/api/test/integratedModels.test.js
+++ b/api/test/integratedModels.test.js
@@ -1,4 +1,3 @@
-
 // This constant should be updated whenever new data (new versions
 // of existing models, or new models) is added to the project.
 const CORRECT_DATA = {

--- a/api/test/integratedModels.test.js
+++ b/api/test/integratedModels.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 
 // This constant should be updated whenever new data (new versions
 // of existing models, or new models) is added to the project.

--- a/api/test/interactionPartners.test.js
+++ b/api/test/interactionPartners.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { MALICIOUS_CHARACTERS } from '../src/malicious-characters';
 import {
   expectBadReqeustMaliciousCharacter,

--- a/api/test/maps.test.js
+++ b/api/test/maps.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { expectBadReqeustMaliciousCharacter } from './util';
 import { MALICIOUS_CHARACTERS } from '../src/malicious-characters';
 

--- a/api/test/metabolites.test.js
+++ b/api/test/metabolites.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   expectEmptyResponse,

--- a/api/test/randomComponents.test.js
+++ b/api/test/randomComponents.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   expectSuccessfulResponse,

--- a/api/test/reactions.test.js
+++ b/api/test/reactions.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   expectEmptyResponse,

--- a/api/test/repository.test.js
+++ b/api/test/repository.test.js
@@ -1,4 +1,3 @@
-
 describe('repository', () => {
   describe('GET all integrated models', () => {
     test('should return an ordered list of integrated models', async () => {

--- a/api/test/repository.test.js
+++ b/api/test/repository.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 
 describe('repository', () => {
   describe('GET all integrated models', () => {

--- a/api/test/search.test.js
+++ b/api/test/search.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { MALICIOUS_CHARACTERS } from '../src/malicious-characters';
 import { expectBadReqeustMaliciousCharacter } from './util';
 

--- a/api/test/subsystems.test.js
+++ b/api/test/subsystems.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import {
   expectBadReqeustMaliciousCharacter,
   expectEmptyResponse,

--- a/api/test/svgThumbnail.test.js
+++ b/api/test/svgThumbnail.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import fs from 'fs';
 
 describe('SVG thumbnail', () => {

--- a/api/test/threeDNetwork.test.js
+++ b/api/test/threeDNetwork.test.js
@@ -1,4 +1,3 @@
-import fetch from 'node-fetch';
 import { MALICIOUS_CHARACTERS } from '../src/malicious-characters';
 import { expectBadReqeustMaliciousCharacter } from './util';
 

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -3429,11 +3429,6 @@ cssesc@^3.0.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-3.0.0.tgz#37741919903b868565e1c09ea747445cd18983ee"
   integrity sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==
 
-data-uri-to-buffer@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz#d8feb2b2881e6a4f58c2e08acfd0e2834e26222e"
-  integrity sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==
-
 data-view-buffer@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/data-view-buffer/-/data-view-buffer-1.0.1.tgz#8ea6326efec17a2e42620696e671d7d5a8bc66b2"
@@ -4116,14 +4111,6 @@ fdir@^6.4.0:
   resolved "https://registry.yarnpkg.com/fdir/-/fdir-6.4.0.tgz#8e80ab4b18a2ac24beebf9d20d71e1bc2627dbae"
   integrity sha512-3oB133prH1o4j/L5lLW7uOCF1PlD+/It2L0eL/iAqWMB91RBbqTewABqxhj0ibBd90EEmWZq7ntIWzVaWcXTGQ==
 
-fetch-blob@^3.1.2, fetch-blob@^3.1.4:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/fetch-blob/-/fetch-blob-3.2.0.tgz#f09b8d4bbd45adc6f0c20b7e787e793e309dcce9"
-  integrity sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==
-  dependencies:
-    node-domexception "^1.0.0"
-    web-streams-polyfill "^3.0.3"
-
 file-entry-cache@^8.0.0:
   version "8.0.0"
   resolved "https://registry.yarnpkg.com/file-entry-cache/-/file-entry-cache-8.0.0.tgz#7787bddcf1131bffb92636c69457bbc0edd6d81f"
@@ -4230,13 +4217,6 @@ for-each@^0.3.3:
   integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
   dependencies:
     is-callable "^1.1.3"
-
-formdata-polyfill@^4.0.10:
-  version "4.0.10"
-  resolved "https://registry.yarnpkg.com/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz#24807c31c9d402e002ab3d8c720144ceb8848423"
-  integrity sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==
-  dependencies:
-    fetch-blob "^3.1.2"
 
 forwarded@0.2.0:
   version "0.2.0"
@@ -5607,20 +5587,6 @@ ngraph.random@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/ngraph.random/-/ngraph.random-1.1.0.tgz#5345c4bb63865c85d98ee6f13eab1395d8545a90"
   integrity sha512-h25UdUN/g8U7y29TzQtRm/GvGr70lK37yQPvPKXXuVfs7gCm82WipYFZcksQfeKumtOemAzBIcT7lzzyK/edLw==
-
-node-domexception@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/node-domexception/-/node-domexception-1.0.0.tgz#6888db46a1f71c0b76b3f7555016b63fe64766e5"
-  integrity sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==
-
-node-fetch@3.3.2:
-  version "3.3.2"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-3.3.2.tgz#d1e889bacdf733b4ff3b2b243eb7a12866a0b78b"
-  integrity sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==
-  dependencies:
-    data-uri-to-buffer "^4.0.0"
-    fetch-blob "^3.1.4"
-    formdata-polyfill "^4.0.10"
 
 node-int64@^0.4.0:
   version "0.4.0"
@@ -7009,11 +6975,6 @@ watchpack@^2.4.1:
   dependencies:
     glob-to-regexp "^0.4.1"
     graceful-fs "^4.1.2"
-
-web-streams-polyfill@^3.0.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz#2073b91a2fdb1fbfbd401e7de0ac9f8214cecb4b"
-  integrity sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==
 
 webpack-cli@^5.1.4:
   version "5.1.4"


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1440.

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- `api/package.json` and `api/yarn.lock`: removed `node-fetch` from the dependency list. The dependency was bumped to v3 (ESM-only) but no Babel/Jest transform was configured for it, which meant Jest could not load any test file — every test file errored at import time with `SyntaxError: Cannot use import statement outside a module`. The api container runs Node 22 (`node:22-alpine` per `api/Dockerfile`), which provides `fetch` natively, so the dependency is no longer needed.
- `api/test/*.test.js` (20 files): removed `import fetch from 'node-fetch';` from each test file. The tests now use the global `fetch`. No other test logic changed.

**Testing**  
- Instructions on how to test:
  1. Start the stack (`source proj.sh && start-stack`).
  2. Run the suite: `ma-exec api yarn test`.
  3. Before this PR: every test file fails at load time with `SyntaxError: Cannot use import statement outside a module` originating from `node_modules/node-fetch/src/index.js`. Zero tests run.
  4. After this PR: all 22 test suites load and execute. 820 of 845 tests pass.
- The remaining 25 failing assertions across 10 suites are unrelated to the loader fix — they are hardcoded expected counts and IDs that have drifted from the current Human-GEM data (e.g. `expected 400 received 324` for a compartment's metabolite count, `expected reaction id MAR03896 received MAR03894` in search results). These were previously hidden because the suite couldn't load.

**Further comments**  
The CI workflows under `.github/workflows/` do not currently run `yarn test` for the api. Adding a job that does so would prevent silent breakage of the test loader (or of the data-drift failures noted above) from happening again. Worth tracking as a follow-up?

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing — the suite now runs (820/845 pass); the 25 remaining failures are pre-existing data-drift issues independent of this fix
- [x] My changes generate no new warnings

