### PR TITLE
fix: black background in 2D MapViewer fullscreen on Chrome

### DIFF
--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -603,6 +603,15 @@ export default {
   &:fullscreen {
     background: white;
   }
+  &:-webkit-full-screen {
+    background: white;
+  }
+  &:-moz-full-screen {
+    background: white;
+  }
+  &:-ms-fullscreen {
+    background: white;
+  }
 }
 
 .met,

--- a/frontend/src/components/explorer/mapViewer/Svgmap.vue
+++ b/frontend/src/components/explorer/mapViewer/Svgmap.vue
@@ -131,16 +131,6 @@ export default {
   },
   async mounted() {
     await this.init();
-
-    window.addEventListener('fullscreenchange', () => {
-      // toggle class for svgbox
-      const svgbox = document.querySelector('.svgbox');
-      if (document.fullscreenElement) {
-        svgbox.classList.add('fullscreen');
-      } else {
-        svgbox.classList.remove('fullscreen');
-      }
-    });
   },
   methods: {
     async init() {
@@ -610,6 +600,9 @@ export default {
   @media screen and (max-width: $tablet) {
     height: $viewer-height;
   }
+  &:fullscreen {
+    background: white;
+  }
 }
 
 .met,
@@ -634,9 +627,6 @@ export default {
   position: relative;
   width: 100%;
   height: 100%;
-  &.fullscreen {
-    background: white;
-  }
 
   #svg-wrapper {
     position: relative;


### PR DESCRIPTION
**Related issue(s) and PR(s)**  
This PR closes #1370 (and is related to PR #1367).

**Type of change**  
<!-- Please delete options that are not relevant -->
- [x] Bug fix (non-breaking change which fixes an issue)
 
**List of changes made**  
- Apply the white background to `.viewer-container` (the actual fullscreen element) via the `:fullscreen` pseudo-class plus `-webkit-`/`-moz-`/`-ms-` prefixed variants for browsers in our browserslist, instead of toggling a `.fullscreen` class on the `.svgbox` child.
- Remove the now-unneeded `fullscreenchange` listener.

**Testing**  
- Open the 2D MapViewer in Chrome, enter fullscreen, confirm the background is white. Repeat in Firefox to confirm no regression.

**Further comments**  
Chrome's user-agent stylesheet sets a black background on the fullscreen element itself (`:-webkit-full-screen { background: black }`), so `.viewer-container` rendered black. Firefox doesn't set that UA default. The previous rule applied white to `.svgbox` (a child), which didn't always cover the full fullscreen area due to flow layout around the absolutely-positioned overlays — so Chrome's black bled through (?). The fix moves the background rule to the actual fullscreen element.

**Definition of Done checklist**  
- [x] My code meets the Acceptance Criteria
- [x] My code follows the [NBIS style guidelines](https://github.com/NBISweden/development-guidelines)
- [x] I have performed a self-review of my own code and commented any hard-to-understand areas
- [x] Tests and lint/format validations are passing
- [x] My changes generate no new warnings
